### PR TITLE
Add revision numbers to rebar dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,14 +12,14 @@
             {parse_transform, lager_transform}]}.
 
 {deps, [
-        {lager, ".*", {git, "git://github.com/basho/lager.git"}},
+        {lager, ".*", {git, "git://github.com/basho/lager.git", "81eaef0ce98fdbf64ab95665e3bc2ec4b24c7dac"}},
         {recon, ".*", {git, "git://github.com/ferd/recon.git", {tag, "2.2.1"}}},
-        {folsom, ".*", {git, "git://github.com/folsom-project/folsom.git"}},
-        {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git"}},
-        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git"}},
-        {dns, ".*", {git, "git://github.com/aetrion/dns_erlang.git"}},
-        {parse_xfrm_utils, ".*", {git, "git://github.com/sargun/parse_xfrm_utils.git"}},
-        {proper, ".*", {git, "https://github.com/manopapad/proper.git"}},
+        {folsom, ".*", {git, "git://github.com/folsom-project/folsom.git", {tag, "0.8.5"}}},
+        {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", "d378f996182daa6251ad5438cee4d3f6eb7ea50f"}},
+        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", "5acdc7e4f2f78e75d4e2900cc953049677e605c2"}},
+        {dns, ".*", {git, "git://github.com/aetrion/dns_erlang.git", "27c84be07561f8f3c00b9ffacd0b4f2d8003cd86"}},
+        {parse_xfrm_utils, ".*", {git, "git://github.com/sargun/parse_xfrm_utils.git", "409f727d81683dd397aafc3afd583d403e271baf"}},
+        {proper, ".*", {git, "https://github.com/manopapad/proper.git", "a112a2d64b2b1bfbea780e139980711dfe99b431"}},
         {iso8601, ".*", {git, "https://github.com/erlsci/iso8601.git", {tag, "1.2.2"}}}
 ]}.
 


### PR DESCRIPTION
Specifing dependencies withour revision number or tag is unsafe, as a change in them can suddenly brak this app and any other app using erl-dns as its dependency. This pull request fills rebar.config with current revision for each dependency.