### PR TITLE
Support parsing CDS0/CDNSKEY0 records

### DIFF
--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1212,10 +1212,10 @@
                 "type": "CDNSKEY",
                 "ttl": 120,
                 "data": {
-                    "flags": 256,
+                    "flags": 257,
                     "protocol": 3,
                     "alg": 8,
-                    "public_key": "MFswDQYJKoZIhvcNAQEBBQADSgAwRwJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jTCaEwnpE74YHCLegKAAn+efeZrT/EBBrzlacCAgIB",
+                    "public_key": "MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USChEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+CfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAE=",
                     "key_tag": 0
                 }
             },

--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1164,6 +1164,38 @@
     },
 
     {
+        "name": "example-dnssec0.com",
+        "records": [
+            {
+                "name": "example-dnssec0.com",
+                "type": "SOA",
+                "data": {
+                    "mname": "ns1.example-dnssec0.com",
+                    "rname": "ahu.example-dnssec0.com",
+                    "serial": 2000081501,
+                    "refresh": 28800,
+                    "retry": 7200,
+                    "expire": 604800,
+                    "minimum": 86400
+                },
+                "ttl": 100000
+            },
+            {
+                "name": "example-dnssec0.com",
+                "type": "CDS",
+                "ttl": 120,
+                "data": {
+                    "alg": 0,
+                    "digest": "0",
+                    "digest_type": 0,
+                    "keytag": 0
+                }
+            }
+        ],
+        "keys":[{"ksk":"-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USCh\nEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+C\nfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAEC\ngYEAlpYTHWYrcd0HQXO3F9lPqwwfHUt7VBaSEUYrk3N3ZYCWvmV1qyKbB/kb1SBs\n4GfW1vP966HXCffnX92LDXYxi7It3TJaKmo8aF/leN7w8WLNJXUayEoQKUfKLprj\nN14Jx/tgMu7I/BOoHId8b7e57pBKtDiSF6WWn3K7tNPbfmkCQQDST41m62mC4MAa\nDsUdyM0Vg/tjduGqnygryCDEXDabdg95a3wMk0SQCQzZFHGNYnsXcffTqGs/y+5w\nQWxyOGSNAkEAzHFkDJla30NiiKvhu7dY+0+dGrfMA7pNUh+LGdXe5QFdjwwxqPbF\n7NMGXKMdB8agSCxGZC3bxdvYNF9LULzhEwJABpDYNSoQx+UMvaEN5XTpLmCHuS1r\nsmhfKZPcDx8Z7mAYda3wZEuHQq+cf6i5XhOO9P5QKpKeslHLAMHa7NaNgQJBAI03\nGGacYLwui32fbzb8BYRg82Kga/OW6btY+O6hNs6iSR2gBlQ9j3Tgrzo+N4R/NQSl\nc05wGO2RnBUwlu0XUckCQHfHsWHVrrADTpalbv+FTDyWd0ouHXBmDecVZh3e7/ue\ncdMoblzeasvgp8CjFa9U+uDozY+aL6TNIpG++nn4lNw=\n-----END RSA PRIVATE KEY-----\n","ksk_keytag":37440,"ksk_alg":8,"zsk":"-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jT\nCaEwnpE74YHCLegKAAn+efeZrT/EBBrzlacCAgIBAkBh9VGFW2SJk1I9SBQaDIA9\nchdrrx+PHibSyozwT4eAPmd6OFoLausc7ls6v9evPeb+Yj3g0JXvTGp6BgNhFqLR\nAiEA1+ievAEBVM6IlOmpiTwlaWe/HV6MokBBq1G/tvJS0M8CIQDPm/DUsoTEv/Jj\n6O3U9hNcPLbvKMMGld2wbf7nrQmzqQIhAJrhwTaFdjnXhmfUB9a33vRIbSaIsLxA\nDyuM+03XP+YhAiEAmJIJz7WX9uPkCIy8wO655Hh4dt4UkBFRE98OqkHIwGkCIFFv\nN8rJojI+oEiJyNjEjWZD4qoUMUp3+YBl0htAJUE2\n-----END RSA PRIVATE KEY-----\n","zsk_keytag":49016,"zsk_alg":8,"inception":"2016-11-14T11:36:58.851612Z","until":"2017-02-12T11:36:58.849384Z"}]
+    },
+
+    {
         "name": "example-dnssec.com",
         "records": [
             {

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -218,6 +218,8 @@ encode_data({dns_rrdata_naptr, Order, Preference, Flags, Services, Regexp, Repla
   erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
 encode_data({dns_rrdata_ds, Keytag, Alg, DigestType, Digest}) ->
   erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+encode_data({dns_rrdata_cds, 0, 0, 0, <<0>>}) ->
+  erlang:iolist_to_binary("0 0 0 0");
 encode_data({dns_rrdata_cds, Keytag, Alg, DigestType, Digest}) ->
   erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_dnskey, Flags, Protocol, Alg, Key, KeyTag}) ->

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -472,7 +472,7 @@ json_record_to_erlang(Data) ->
   {}.
 
 % For supporting CDS0 record format where Digest is "0"
-hex_to_bin(<<"0">>) -> <<"0">>;
+hex_to_bin(<<"0">>) -> <<0>>;
 hex_to_bin(Bin) when is_binary(Bin) ->
   Fun = fun(A, B) ->
             case io_lib:fread("~16u", [A, B]) of
@@ -578,7 +578,7 @@ json_record_cds0_to_erlang_test() ->
                                   keytag = 0,
                                   digest_type = 0,
                                   alg = 0,
-                                  digest = <<"0">>
+                                  digest = <<0>>
                                 },
                        ttl = 3600},
                json_record_to_erlang([Name, <<"CDS">>, 3600, [
@@ -629,7 +629,7 @@ json_record_cdnskey0_to_erlang_test() ->
 
 hex_to_bin_test() ->
   ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
-  ?assertEqual(<<"0">>, hex_to_bin(<<"0">>)),
+  ?assertEqual(<<0>>, hex_to_bin(<<"0">>)),
   ?assertEqual(<<255, 0, 255>>, hex_to_bin(<<"FF00FF">>)).
 
 

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -482,6 +482,8 @@ hex_to_bin(Bin) when is_binary(Bin) ->
         end,
   << <<(Fun(A,B))>> || <<A, B>> <= Bin >>.
 
+% For supporting CDNSKEY0 record format where Digest is "0"
+base64_to_bin(<<"0">>) -> <<"0">>;
 base64_to_bin(Bin) when is_binary(Bin) ->
   base64:decode(Bin).
 
@@ -586,6 +588,45 @@ json_record_cds0_to_erlang_test() ->
                                                               {<<"digest">>, <<"0">>}
                                                              ], undefined])).
 
+json_record_cdnskey_to_erlang_test() ->
+  Name = <<"example-dnssec.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_CDNSKEY,
+                       data = #dns_rrdata_cdnskey{
+                                 flags = 257,
+                                 key_tag = 37440,
+                                 protocol = 3,
+                                 alg = 8,
+                                 public_key = [19950023884812141327069378526778424537821842682002326291664262861042243956868777019282790007759923364993897500365841, 322952729755131673734701209779560665954996175375376404453022988413912494776066645912342444415690645262643588770289772100982887500120087051315598339205817329813622689564541984611947665709742982003245799028497525519171546189867352183906279970741859214126016198414430241793]
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"CDNSKEY">>, 3600, [
+                                                                  {<<"flags">>, 257},
+                                                                  {<<"key_tag">>, 0},
+                                                                  {<<"protocol">>, 3},
+                                                                  {<<"alg">>, 8},
+                                                                  {<<"public_key">>, <<"MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USChEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+CfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAE=">>}
+                                                                 ], undefined])).
+json_record_cdnskey0_to_erlang_test() ->
+  Name = <<"example-dnssec.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_CDNSKEY,
+                       data = #dns_rrdata_cdnskey{
+                                 flags = 0,
+                                 key_tag = 13056,
+                                 protocol = 3,
+                                 alg = 0,
+                                 public_key = <<"0">>
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"CDNSKEY">>, 3600, [
+                                                                  {<<"flags">>, 0},
+                                                                  {<<"key_tag">>, 0},
+                                                                  {<<"protocol">>, 3},
+                                                                  {<<"alg">>, 0},
+                                                                  {<<"public_key">>, <<"0">>}
+                                                                 ], undefined])).
+
 hex_to_bin_test() ->
   ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
   ?assertEqual(<<"0">>, hex_to_bin(<<"0">>)),
@@ -594,6 +635,7 @@ hex_to_bin_test() ->
 
 base64_to_bin_test() ->
   ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
+  ?assertEqual(<<"0">>, base64_to_bin(<<"0">>)),
   ?assertEqual(<<3,1,0,1,191,165,76,56,217,9,250,187,15,147,125,112,215,
                  117,186,13,244,192,186,219,9,112,125,153,82,73,64,105,
                  80,64,122,98,28,121,76,104,177,134,177,93,191,143,159,


### PR DESCRIPTION
This adds support for parsing the digest and public_key values for CDS0/CDNSKEY0.

It also clarifies/adds tests around parsing CDS and CDNSKEY.