### PR TITLE
Example zone for CDS0 and CDNSKEY0

### DIFF
--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1160,7 +1160,63 @@
                     "ip": "192.168.5.1"
                 }
             }
+        ]
+    },
+
+    {
+        "name": "example-dnssec0.com",
+        "records": [
+            {
+                "name": "example-dnssec0.com",
+                "type": "SOA",
+                "data": {
+                    "mname": "ns1.example-dnssec0.com",
+                    "rname": "ahu.example-dnssec0.com",
+                    "serial": 2000081501,
+                    "refresh": 28800,
+                    "retry": 7200,
+                    "expire": 604800,
+                    "minimum": 86400
+                },
+                "ttl": 100000
+            },
+            {
+                "name": "example-dnssec0.com",
+                "type": "CDS",
+                "ttl": 120,
+                "data": {
+                    "alg": 0,
+                    "digest": "00",
+                    "digest_type": 0,
+                    "keytag": 0
+                }
+            },
+            {
+                "name": "example-dnssec0.com",
+                "type": "CDNSKEY",
+                "ttl": 120,
+                "data": {
+                    "flags": 0,
+                    "protocol": 3,
+                    "alg": 0,
+                    "public_key": "MA==",
+                    "key_tag": 0
+                }
+            },
+            {
+                "name": "example-dnssec0.com",
+                "type": "DNSKEY",
+                "ttl": 120,
+                "data": {
+                    "flags": 257,
+                    "protocol": 3,
+                    "alg": 8,
+                    "public_key": "MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USChEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+CfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAE=",
+                    "key_tag": 0
+                }
+            }
         ],
+        "keys":[{"ksk":"-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USCh\nEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+C\nfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAEC\ngYEAlpYTHWYrcd0HQXO3F9lPqwwfHUt7VBaSEUYrk3N3ZYCWvmV1qyKbB/kb1SBs\n4GfW1vP966HXCffnX92LDXYxi7It3TJaKmo8aF/leN7w8WLNJXUayEoQKUfKLprj\nN14Jx/tgMu7I/BOoHId8b7e57pBKtDiSF6WWn3K7tNPbfmkCQQDST41m62mC4MAa\nDsUdyM0Vg/tjduGqnygryCDEXDabdg95a3wMk0SQCQzZFHGNYnsXcffTqGs/y+5w\nQWxyOGSNAkEAzHFkDJla30NiiKvhu7dY+0+dGrfMA7pNUh+LGdXe5QFdjwwxqPbF\n7NMGXKMdB8agSCxGZC3bxdvYNF9LULzhEwJABpDYNSoQx+UMvaEN5XTpLmCHuS1r\nsmhfKZPcDx8Z7mAYda3wZEuHQq+cf6i5XhOO9P5QKpKeslHLAMHa7NaNgQJBAI03\nGGacYLwui32fbzb8BYRg82Kga/OW6btY+O6hNs6iSR2gBlQ9j3Tgrzo+N4R/NQSl\nc05wGO2RnBUwlu0XUckCQHfHsWHVrrADTpalbv+FTDyWd0ouHXBmDecVZh3e7/ue\ncdMoblzeasvgp8CjFa9U+uDozY+aL6TNIpG++nn4lNw=\n-----END RSA PRIVATE KEY-----\n","ksk_keytag":37440,"ksk_alg":8,"zsk":"-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jT\nCaEwnpE74YHCLegKAAn+efeZrT/EBBrzlacCAgIBAkBh9VGFW2SJk1I9SBQaDIA9\nchdrrx+PHibSyozwT4eAPmd6OFoLausc7ls6v9evPeb+Yj3g0JXvTGp6BgNhFqLR\nAiEA1+ievAEBVM6IlOmpiTwlaWe/HV6MokBBq1G/tvJS0M8CIQDPm/DUsoTEv/Jj\n6O3U9hNcPLbvKMMGld2wbf7nrQmzqQIhAJrhwTaFdjnXhmfUB9a33vRIbSaIsLxA\nDyuM+03XP+YhAiEAmJIJz7WX9uPkCIy8wO655Hh4dt4UkBFRE98OqkHIwGkCIFFv\nN8rJojI+oEiJyNjEjWZD4qoUMUp3+YBl0htAJUE2\n-----END RSA PRIVATE KEY-----\n","zsk_keytag":49016,"zsk_alg":8,"inception":"2016-11-14T11:36:58.851612Z","until":"2017-02-12T11:36:58.849384Z"}]
     },
 
     {

--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1199,7 +1199,7 @@
                     "flags": 0,
                     "protocol": 3,
                     "alg": 0,
-                    "public_key": "MA==",
+                    "public_key": "AA==",
                     "key_tag": 0
                 }
             },


### PR DESCRIPTION
CDS0 and CDNSKEY0 are special forms of the CDS/CDNSKEY records that specify that DNSSEC is turned off. According to the RFC, they are
```
CDS 0 0 0 0
CDNSKEY 0 3 0 0
```

This adds these zones to the test.zones.json file to have examples for querying:
`dig -p 8053 @localhost example-dnssec0.com -t cds`
`dig -p 8053 @localhost example-dnssec0.com -t cdnskey`

Important to note that CDS digest is hex-encoded ("00") and CDNSKEY public key is base64 encoded ("AA==").