### PR TITLE
Properly handle zonecuts

### DIFF
--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -56,6 +56,14 @@
                     "exchange": "smtp-servers.example.com",
                     "preference": 10
                 }
+            },
+            {
+                "name": "cnamerecord.zonecut.withzonecut.com",
+                "type": "CNAME",
+                "ttl": 120,
+                "data": {
+                    "dname": "somewhere.else.net"
+                }
             }
         ]
     },

--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -50,10 +50,11 @@
             },
             {
                 "name": "child.zonecut.withzonecut.com",
-                "type": "A",
+                "type": "MX",
                 "ttl": 120,
                 "data": {
-                    "ip": "192.168.1.1"
+                    "exchange": "smtp-servers.example.com",
+                    "preference": 10
                 }
             }
         ]

--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1,5 +1,64 @@
 [
     {
+        "name": "withzonecut.com",
+        "records": [
+            {
+                "name": "withzonecut.com",
+                "type": "SOA",
+                "data": {
+                    "mname": "ns1.example.com",
+                    "rname": "ahu.example.com",
+                    "serial": 2000081501,
+                    "refresh": 28800,
+                    "retry": 7200,
+                    "expire": 604800,
+                    "minimum": 86400
+                },
+                "ttl": 100000
+            },
+            {
+                "name": "withzonecut.com",
+                "type": "NS",
+                "ttl": 120,
+                "data": {
+                    "dname": "ns1.example.com"
+                }
+            },
+            {
+                "name": "withzonecut.com",
+                "type": "NS",
+                "ttl": 120,
+                "data": {
+                    "dname": "ns2.example.com"
+                }
+            },
+            {
+                "name": "zonecut.withzonecut.com",
+                "type": "NS",
+                "ttl": 120,
+                "data": {
+                    "dname": "ns1.cutwithzonecut.com"
+                }
+            },
+            {
+                "name": "zonecut.withzonecut.com",
+                "type": "NS",
+                "ttl": 120,
+                "data": {
+                    "dname": "ns2.cutwithzonecut.com"
+                }
+            },
+            {
+                "name": "child.zonecut.withzonecut.com",
+                "type": "A",
+                "ttl": 120,
+                "data": {
+                    "ip": "192.168.1.1"
+                }
+            }
+        ]
+    },
+    {
         "name": "example.com",
         "records": [
             {

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -76,7 +76,12 @@ resolve(Message, _Qname, _Qtype, {error, not_authoritative}, _Host, _CnameChain)
 %% An SOA was found, thus we are authoritative and have the zone.
 %% Step 3: Match records
 resolve(Message, Qname, Qtype, Zone, Host, CnameChain) ->
-  resolve(Message, Qname, Qtype, get_records_by_name(Zone, Qname), Host, CnameChain, Zone).
+  case detect_zonecut(Zone, Qname) of
+    {zonecut, Records} ->
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Records};
+    no_zonecut ->
+      resolve(Message, Qname, Qtype, get_records_by_name(Zone, Qname), Host, CnameChain, Zone)
+  end.
 
 %% There were no exact matches on name, so move to the best-match resolution.
 resolve(Message, Qname, Qtype, _MatchedRecords = [], Host, CnameChain, Zone) ->
@@ -85,7 +90,6 @@ resolve(Message, Qname, Qtype, _MatchedRecords = [], Host, CnameChain, Zone) ->
 %% There was at least one exact match on name.
 resolve(Message, Qname, Qtype, MatchedRecords, Host, CnameChain, Zone) ->
   exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone).
-
 
 
 %% Determine if there is a CNAME anywhere in the records with the given Qname.
@@ -496,6 +500,42 @@ check_dnssec(Message, Host, Question) ->
     false ->
       ok
   end.
+
+zone_authority_name([Record | _]) ->
+  Record#dns_rr.name.
+
+detect_zonecut(Zone, Qname) when is_binary(Qname) ->
+  detect_zonecut(Zone, dns:dname_to_labels(Qname));
+
+detect_zonecut(_Zone, []) ->
+  no_zonecut;
+
+detect_zonecut(_Zone, [_Label]) ->
+  no_zonecut;
+
+detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
+  Qname = dns:labels_to_dname(Labels),
+  Records = get_records_by_name(Zone, Qname),
+  case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
+  true ->
+      no_zonecut;
+  false ->
+      case is_zonecut(Records) of
+        true ->
+          {zonecut, Records};
+        false ->
+          detect_zonecut(Zone, ParentLabels)
+      end
+  end.
+
+is_zonecut([]) ->
+  false;
+is_zonecut([Record | Records]) ->
+  case Record#dns_rr.type of
+   ?DNS_TYPE_NS  -> true;
+   _ -> is_zonecut(Records)
+  end.
+
 
 %% returns the record lookup delegation mdule for a zone.
 get_delegate(#zone{name = Name}) ->

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -81,18 +81,14 @@ resolve(Message, Qname, Qtype, Zone, Host, CnameChain) ->
     [] ->
       Result;
     Records ->
-      case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers) of
-        [] ->
-          Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Records, answers = []};
-        CnameAnswers ->
-          FilteredCnameAnswers = lists:filter(fun(RR) ->
-                        case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
-                          [] -> false;
-                          _ -> true
-                        end
-                      end, CnameAnswers),
-          Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Records, answers = FilteredCnameAnswers}
-      end
+      CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
+      FilteredCnameAnswers = lists:filter(fun(RR) ->
+                                              case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
+                                                [] -> false;
+                                                _ -> true
+                                              end
+                                          end, CnameAnswers),
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Records, answers = FilteredCnameAnswers}
   end.
 
 %% There were no exact matches on name, so move to the best-match resolution.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -516,12 +516,11 @@ detect_zonecut(_Zone, [_Label]) ->
 
 detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
   Qname = dns:labels_to_dname(Labels),
-  Records = get_records_by_name(Zone, Qname),
   case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
   true ->
       [];
   false ->
-      case lists:filter(erldns_records:match_type(?DNS_TYPE_NS), Records) of
+      case lists:filter(erldns_records:match_type(?DNS_TYPE_NS), get_records_by_name(Zone, Qname)) of
         [] ->
           detect_zonecut(Zone, ParentLabels);
         ZonecutNSRecords ->

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -81,7 +81,8 @@ resolve(Message, Qname, Qtype, Zone, Host, CnameChain) ->
     [] ->
       Result;
     Records ->
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, answers = [], authority = Records}
+      Answers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Records, answers = Answers}
   end.
 
 %% There were no exact matches on name, so move to the best-match resolution.


### PR DESCRIPTION
When responding to a question for a record under a [zonecut](https://tools.ietf.org/html/rfc2181#section-6), we should only return an authority section that points to the authoritative servers.

There are two primary behaviors implemented:
* If a record is queried that is under a zonecut, do not send back answer, only authority
* If a CNAME record is queried, DO send back answer if pointing to a name in the zone (we are authority).

This behavior is tested in [dnstest](https://github.com/dnsimple/dnstest/pull/2).

This PR implements a solution that is not optimized, but does implement the desired behaviour. Expectation is that a new PR will be created to handle optimization.