### PR TITLE
Allow to run erldns in headless mode.

### DIFF
--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -88,12 +88,21 @@ get_servers() ->
              {processes, keyget(processes, Server, 1)}
             ]
         end, Servers);
-    _ -> []
+    undefined ->
+        lists:map(fun (Family) ->
+            [{name, Family},
+             {address, get_address(Family)},
+             {port, get_port()},
+             {family, Family}]
+        end, [inet, inet6])
   end.
 
 -ifdef(TEST).
 get_servers_undefined_test() ->
-  ?assertEqual([], get_servers()).
+  ?assertEqual([
+    [{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
+    [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]
+  ], get_servers()).
 
 get_servers_empty_list_test() ->
   application:set_env(erldns, servers, []),

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -36,14 +36,6 @@ start_link() ->
 init(_Args) ->
   {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
-define_servers([]) ->
-  [
-   {udp_inet, {erldns_udp_server, start_link, [udp_inet, inet]}, permanent, 5000, worker, [erldns_udp_server]},
-   {udp_inet6, {erldns_udp_server, start_link, [udp_inet6, inet6]}, permanent, 5000, worker, [erldns_udp_server]},
-   {tcp_inet, {erldns_tcp_server, start_link, [tcp_inet, inet]}, permanent, 5000, worker, [erldns_tcp_server]},
-   {tcp_inet6, {erldns_tcp_server, start_link, [tcp_inet6, inet6]}, permanent, 5000, worker, [erldns_tcp_server]}
-  ];
-
 define_servers(Servers) ->
   lists:flatten(
     lists:map(


### PR DESCRIPTION
DC/OS JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-1946
DC/OS PR: https://github.com/dcos/erldns/pull/3

The patch allows to run erldns as a library with no tcp/udp servers.