### PR TITLE
Feature/remove zone record lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ log/
 ebin/
 deps/*
 rel/erl-dns
-zones.json
+priv/_*.json
 .eunit/
 db/
 _build/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ priv/_*.json
 .eunit/
 db/
 _build/
+Mnesia.nonode@nohost/

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -16,7 +16,7 @@
     version :: binary(),
     authority = [] :: [dns:rr()],
     record_count = 0 :: non_neg_integer(),
-    records = [] :: [dns:rr()],
+    records = [] :: [dns:rr()] | trimmed,
     records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
     %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
     %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -37,5 +37,18 @@
     nxdomain
 }).
 
+-record(zone_records, {
+    zone_name,
+    fqdn,
+    records
+}).
+
+-record(zone_records_typed, {
+    zone_name,
+    fqdn,
+    type,
+    records
+}).
+
 -define(DNSKEY_ZSK_TYPE, 256).
 -define(DNSKEY_KSK_TYPE, 257).

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,8 @@
         {dev_mode, true},
         {include_erts, false},
         {sys_config, "erldns.config"},
-        {overlay, [{copy, "priv/example.zone.json", "priv/example.zone.json"}]},
+        {overlay, [{copy, "priv/example.zone.json", "priv/example.zone.json"},
+                   {copy, "priv/test.zones.json", "priv/test.zones.json"}]},
 
         {extended_start_script, true}]}.
 

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -96,7 +96,6 @@ handle(Message, Zone, Qname, _Qtype, _DnssecRequested = true, _Keysets) ->
   % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
   Authority = lists:last(Zone#zone.authority),
   Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
-  {ok, ZoneWithRecords} = erldns_zone_cache:get_zone_with_records(Zone#zone.name),
   case Message#dns_message.answers of
     [] ->
       ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
@@ -104,8 +103,7 @@ handle(Message, Zone, Qname, _Qtype, _DnssecRequested = true, _Keysets) ->
       SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
 
       NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
-      Types = record_types_for_name(Qname, ZoneWithRecords#zone.records),
-      NsecRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NSEC, ttl = Ttl, data = #dns_rrdata_nsec{next_dname = NextDname, types = Types}}],
+      NsecRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NSEC, ttl = Ttl, data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
       NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
 
       erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords}, Zone));
@@ -141,7 +139,7 @@ find_unsigned_records(Records) ->
         (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
     end, Records).
 
-record_types_for_name(Name, _Records) ->
+record_types_for_name(Name) ->
   RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
   TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
   lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -28,8 +28,6 @@
 -spec resolve(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Host) ->
   resolve(Message, AuthorityRecords, Host, Message#dns_message.questions).
-  %t:t(<<"resolve(Message, AuthorityRecords, Host)">>, fun() -> resolve(Message, AuthorityRecords, Host, Message#dns_message.questions) end).
-
 
 %% There were no questions in the message so just return it.
 -spec resolve(dns:message(), [dns:rr()], dns:ip(), dns:questions() | dns:query()) -> dns:message().
@@ -58,12 +56,8 @@ resolve(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_
 %% If the request required DNSSEC, apply the DNSSEC records
 -spec resolve(dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  % lager:info("resolve(Qname = ~p, Qtype = ~p)", [Qname, Qtype]),
   Zone =erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), 
   Records = resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
-
-  %Zone = t:t(<<"! find zone">>, fun() -> erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) end),
-  %Records = t:t(<<"! resolve">>, fun() -> resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []) end),
   sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(Records), Host, Zone), Zone, Qname, Qtype)).
 
 sort_answers(Message) ->

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -56,7 +56,7 @@ resolve(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_
 %% If the request required DNSSEC, apply the DNSSEC records
 -spec resolve(dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  Zone =erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), 
+  Zone = erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), 
   Records = resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
   sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(Records), Host, Zone), Zone, Qname, Qtype)).
 

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -22,10 +22,13 @@
 
 -callback get_records_by_name(dns:dname()) -> [dns:rr()].
 
+
+
 %% @doc Resolve the questions in the message.
 -spec resolve(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Host) ->
   resolve(Message, AuthorityRecords, Host, Message#dns_message.questions).
+  %t:t(<<"resolve(Message, AuthorityRecords, Host)">>, fun() -> resolve(Message, AuthorityRecords, Host, Message#dns_message.questions) end).
 
 
 %% There were no questions in the message so just return it.
@@ -55,8 +58,12 @@ resolve(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_
 %% If the request required DNSSEC, apply the DNSSEC records
 -spec resolve(dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  Zone = erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), % Zone lookup
+  % lager:info("resolve(Qname = ~p, Qtype = ~p)", [Qname, Qtype]),
+  Zone =erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), 
   Records = resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
+
+  %Zone = t:t(<<"! find zone">>, fun() -> erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) end),
+  %Records = t:t(<<"! resolve">>, fun() -> resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []) end),
   sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(Records), Host, Zone), Zone, Qname, Qtype)).
 
 sort_answers(Message) ->

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -24,6 +24,7 @@
          insert/2,
          delete_table/1,
          delete/2,
+         select_delete/2,
          backup_table/1,
          backup_tables/0,
          select/2,
@@ -107,6 +108,11 @@ delete_table(Table)->
 delete(Table, Key) ->
   Module = mod(Table),
   Module:delete(Table, Key).
+
+-spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
+select_delete(Table, MatchSpec) ->
+  Module = mod(Table),
+  Module:select_delete(Table, MatchSpec).
 
 %% @doc Backup the table to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -168,7 +168,7 @@ load_zones(Filename) when is_list(Filename) ->
       lists:foreach(
         fun(JsonZone) ->
             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-            ok = erldns_zone_cache:put_zone(Zone)
+            erldns_zone_cache:put_zone(Zone)
         end, JsonZones),
       lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
       {ok, length(JsonZones)};

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -168,7 +168,7 @@ load_zones(Filename) when is_list(Filename) ->
       lists:foreach(
         fun(JsonZone) ->
             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-            erldns_zone_cache:put_zone(Zone)
+            ok = erldns_zone_cache:put_zone(Zone)
         end, JsonZones),
       lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
       {ok, length(JsonZones)};

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -34,6 +34,8 @@ create(schema) ->
   not_implemented;
 create(Name = zones) ->
   create_ets_table(Name, set);
+create(Name = zone_records) ->
+  create_ets_table(Name, set);
 create(Name = authorities) ->
   create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -35,9 +35,9 @@ create(schema) ->
 create(Name = zones) ->
   create_ets_table(Name, set);
 create(Name = zone_records) ->
-  create_ets_table(Name, set);
+  create_ets_table(Name, ordered_set);
 create(Name = zone_records_typed) ->
-  create_ets_table(Name, set);
+  create_ets_table(Name, ordered_set);
 create(Name = authorities) ->
   create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -19,6 +19,7 @@
          insert/2,
          delete_table/1,
          delete/2,
+         select_delete/2,
          backup_table/1,
          backup_tables/0,
          select/2,
@@ -67,6 +68,12 @@ delete_table(Table)->
 delete(Table, Key) ->
   ets:delete(Table, Key),
   ok.
+
+%% @doc Delete entries in the ets table that match the provided spec.
+-spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
+select_delete(Table, MatchSpec) ->
+  Count = ets:select_delete(Table, MatchSpec),
+  {ok, Count}.
 
 %% @doc Backup a specific ets table.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -36,6 +36,8 @@ create(Name = zones) ->
   create_ets_table(Name, set);
 create(Name = zone_records) ->
   create_ets_table(Name, set);
+create(Name = zone_records_typed) ->
+  create_ets_table(Name, set);
 create(Name = authorities) ->
   create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -24,6 +24,7 @@
          insert/2,
          delete_table/1,
          delete/2,
+         select_delete/2,
          backup_table/1,
          backup_tables/0,
          select/2,
@@ -145,7 +146,11 @@ delete(Table, Key)->
       mnesia:dirty_delete({Table, Key})
   end.
 
+-spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
+select_delete(_Table, _MatchSpec)->
+  {error, not_implemented}.
 
+%%
 %% @doc Should backup the tables in the schema.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -192,25 +192,17 @@ delete(Table, Key)->
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, [{{{ZoneName, Fqdn}, _}, _, _}])->
   SelectDelete = fun() ->
-               case mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, write) of
-                 Records when is_list(Records)->
-                  lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
-                  {ok, length(Records)};
-                 _ ->
-                   {error, transaction_abort}
-               end
-           end,
+                     Records =  mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, write),
+                     lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
+                     {ok, length(Records)}
+                 end,
   mnesia:activity(transaction, SelectDelete);
 select_delete(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}])->
   SelectDelete = fun() ->
-               case mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write) of
-                 Records when is_list(Records)->
-                  lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
-                  {ok, length(Records)};
-                 _ ->
-                   {error, transaction_abort}
-               end
-           end,
+                     Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write),
+                     lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
+                     {ok, length(Records)}
+                 end,
   mnesia:activity(transaction, SelectDelete).
 
 %%

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -244,9 +244,9 @@ delete_zone(Name) ->
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
   lager:info("Delete zone records for ~p", [Name]),
-  ZoneRecordsDeleted = erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],['$$']}]),
+  ZoneRecordsDeleted = erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],[true]}]),
   lager:info("zone_records deleted: ~p", [ZoneRecordsDeleted]),
-  ZoneRecordsTypedDeleted = erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],['$$']}]),
+  ZoneRecordsTypedDeleted = erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]),
   lager:info("zone_records_typed deleted: ~p", [ZoneRecordsTypedDeleted]).
 
 

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -195,8 +195,7 @@ zone_names_and_versions() ->
 put_zone({Name, Sha, Records}) ->
     put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
-  {Zone, _} = build_zone(Name, Sha, Records, Keys),
-  SignedZone = sign_zone(Zone),
+  SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
   NamedRecords = build_named_index(SignedZone#zone.records),
   case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
     ok -> put_zone_records(erldns:normalize_name(Name), NamedRecords);
@@ -300,7 +299,7 @@ find_zone_in_cache(Name, [_|Labels]) ->
 
 build_zone(Qname, Version, Records, Keys) ->
   Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
-  {#zone{name = Qname, version = Version, record_count = length(Records), authority = Authorities, records = Records, records_by_name = trimmed, keysets = Keys}, []}. 
+  #zone{name = Qname, version = Version, record_count = length(Records), authority = Authorities, records = Records, records_by_name = trimmed, keysets = Keys}.
 
 -spec(build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}).
 build_named_index(Records) ->

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -34,6 +34,7 @@
          get_zone_with_records/1,
          get_authority/1,
          get_delegations/1,
+         get_zone_records/1,
          get_records_by_name/1,
          get_records_by_name_and_type/2,
          in_zone/1,
@@ -140,6 +141,16 @@ get_delegations(Name) ->
     {ok, Zone} ->
       Records = lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'},[],['$$']}], infinite)),
       lists:filter(erldns_records:match_delegation(Name), Records);
+    _ ->
+      []
+  end.
+
+%% @doc Get all records for the given zone.
+-spec get_zone_records(dns:dname()) -> [dns:rr()].
+get_zone_records(Name) ->
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      lists:flatten(erldns_storage:select(zone_records, [{{{erldns:normalize_name(Zone#zone.name), '_'}, '$1'},[],['$$']}], infinite));
     _ ->
       []
   end.

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -203,7 +203,7 @@ put_zone({Name, Sha, Records, Keys}) ->
   end.
 
 %% @doc Put a zone into the cache and wait for a response.
--spec put_zone(dns:name(), _) -> ok | {error, Reason :: term()}.
+-spec put_zone(dns:name(), erldns:zone()) -> ok | {error, Reason :: term()}.
 put_zone(Name, Zone) ->
   erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
 

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -244,8 +244,10 @@ delete_zone(Name) ->
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
   lager:info("Delete zone records for ~p", [Name]),
-  erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],['$$']}]),
-  erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],['$$']}]).
+  ZoneRecordsDeleted = erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],['$$']}]),
+  lager:info("zone_records deleted: ~p", [ZoneRecordsDeleted]),
+  ZoneRecordsTypedDeleted = erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],['$$']}]),
+  lager:info("zone_records_typed deleted: ~p", [ZoneRecordsTypedDeleted]).
 
 
 

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -243,6 +243,7 @@ delete_zone(Name) ->
 
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
+  lager:info("Delete zone records for ~p", [Name]),
   erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],['$$']}]),
   erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],['$$']}]).
 

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -243,11 +243,8 @@ delete_zone(Name) ->
 
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
-  lager:info("Delete zone records for ~p", [Name]),
-  ZoneRecordsDeleted = erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],[true]}]),
-  lager:info("zone_records deleted: ~p", [ZoneRecordsDeleted]),
-  ZoneRecordsTypedDeleted = erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]),
-  lager:info("zone_records_typed deleted: ~p", [ZoneRecordsTypedDeleted]).
+  erldns_storage:select_delete(zone_records, [{{{erldns:normalize_name(Name), '_'}, '_'},[],[true]}]),
+  erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]).
 
 
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -115,7 +115,7 @@ record_filter() ->
   end.
 
 records_to_json(Zone, Encoders) ->
-  lists:map(encode(Encoders), Zone#zone.records).
+  lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
 
 encode(Encoders) ->
   fun(Record) ->

--- a/src/t.erl
+++ b/src/t.erl
@@ -1,0 +1,8 @@
+-module(t).
+
+-export([t/2] ).
+
+t(N, F) ->
+  {T, V} = timer:tc(F),
+  lager:info("~s: ~p", [N, T / 1000]),
+  V.


### PR DESCRIPTION
Reduce the impact of large zones on query response time by significantly reducing the amount of data copied from storage into process memory on each request.

Note that the records in the zone is now replaced with two tables:

- `zone_records` - Record sets indexed by {zonename, FQDN}
- `zone_records_typed` - Record sets indexed by {zonename, FQDN, RRtype}

This allows for faster searches when all of the records are needed at a given name (using the `zone_records` table) as well as when records are needed by name & type (using `zone_records_typed`)