### PR TITLE
Switch from logging to events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: erlang
 sudo: false
 otp_release:
-  - 21.0
+  - 22.3.1
 
 script:
   - wget https://s3.amazonaws.com/rebar3/rebar3

--- a/priv/scapy.txt
+++ b/priv/scapy.txt
@@ -1,0 +1,31 @@
+# Basic example
+sr1(IP(dst="127.0.0.1")/UDP(sport=RandShort(), dport=8053)/DNS(rd=1,qd=DNSQR(qname="example.com",qtype="SOA")))
+
+# Constructing packets
+ip = IP(dst="127.0.0.1")/UDP(sport=RandShort(), dport=8053)
+
+q = DNS(rd=1,qd=DNSQR(qname="example.com",qtype="SOA"))
+
+sr1(ip/q)
+
+# Null byte
+sr1(ip/Raw(b'\x00'))
+
+# Good message
+sr1(ip/Raw(b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07example\x03com\x00\x00\x06\x00\x01'))
+
+# Truncated message
+sr1(ip/Raw(b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07example\x03com\x00\x00\x06\x00'), timeout=1)
+
+# Extra data message
+sr1(ip/Raw(b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07example\x03com\x00\x00\x06\x00\x01\x00'))
+
+# Not a question error
+sr1(ip/Raw(b'\x00\x00\xff\x00\x00\x01\x00\x00\x00\x00\x00\x00\x07example\x03com\x00\x00\x06\x00\x01'), timeout=1)
+
+# Bad pointer
+sr1(ip/Raw(b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\xffexample\x03com\x00\x00\x06\x00\x01'), timeout=1)
+
+# Refused response with trailing garbage
+sr1(ip/Raw(b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00example\x03com\x00\x00\x06\x00\x01'), timeout=1)
+

--- a/priv/scapy.txt
+++ b/priv/scapy.txt
@@ -8,6 +8,9 @@ q = DNS(rd=1,qd=DNSQR(qname="example.com",qtype="SOA"))
 
 sr1(ip/q)
 
+q = DNS(rd=1,qd=DNSQR(qname="example.com",qtype="SOA"))
+sr1(ip/q)
+
 # Null byte
 sr1(ip/Raw(b'\x00'))
 

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -87,4 +87,7 @@ setup_metrics() ->
   folsom_metrics:new_meter(cache_miss_meter),
 
   folsom_metrics:new_counter(dnssec_request_counter),
-  folsom_metrics:new_meter(dnssec_request_meter).
+  folsom_metrics:new_meter(dnssec_request_meter),
+
+  folsom_metrics:new_counter(erldns_handler_error_counter),
+  folsom_metrics:new_meter(erldns_handler_error_meter).

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -20,21 +20,21 @@
 -export([start/2, start_phase/3, stop/1]).
 
 start(_Type, _Args) ->
-  lager:debug("Starting erldns application"),
+  lager:info("Starting erldns application"),
   setup_metrics(),
   erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->
-  lager:debug("Post start phase for erldns application"),
+  % lager:debug("Post start phase for erldns application"),
   erldns_events:add_handler(erldns_event_handler),
 
-  lager:debug("Loading custom zone parsers"),
+  % lager:debug("Loading custom zone parsers"),
   case application:get_env(erldns, custom_zone_parsers) of
     {ok, Parsers} -> erldns_zone_parser:register_parsers(Parsers);
     _ -> ok
   end,
 
-  lager:debug("Loading custom zone encoders"),
+  % lager:debug("Loading custom zone encoders"),
   case application:get_env(erldns, custom_zone_encoders) of
     {ok, Encoders} -> erldns_zone_encoder:register_encoders(Encoders);
     _ -> ok
@@ -44,7 +44,7 @@ start_phase(post_start, _StartType, _PhaseArgs) ->
   erldns_zone_loader:load_zones(),
 
   lager:info("Notifying servers to start"),
-  erldns_events:notify(start_servers),
+  erldns_events:notify({?MODULE, start_servers}),
 
   ok.
 

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -25,16 +25,13 @@ start(_Type, _Args) ->
   erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->
-  % lager:debug("Post start phase for erldns application"),
   erldns_events:add_handler(erldns_event_handler),
 
-  % lager:debug("Loading custom zone parsers"),
   case application:get_env(erldns, custom_zone_parsers) of
     {ok, Parsers} -> erldns_zone_parser:register_parsers(Parsers);
     _ -> ok
   end,
 
-  % lager:debug("Loading custom zone encoders"),
   case application:get_env(erldns, custom_zone_encoders) of
     {ok, Encoders} -> erldns_zone_encoder:register_encoders(Encoders);
     _ -> ok

--- a/src/erldns_decoder.erl
+++ b/src/erldns_decoder.erl
@@ -34,7 +34,7 @@ decode_message(Bin) ->
         M -> M
       catch
         Exception:Reason ->
-          lager:error("Error decoding message (data: ~p, exception: ~p, reason: ~p)", [Bin, Exception, Reason]),
+          erldns_events:notify({erldns_decoder, decode_message_error, {Exception, Reason, Bin}}),
           {formerr, Reason, Bin}
       end
   end.

--- a/src/erldns_decoder.erl
+++ b/src/erldns_decoder.erl
@@ -34,7 +34,7 @@ decode_message(Bin) ->
         M -> M
       catch
         Exception:Reason ->
-          erldns_events:notify({erldns_decoder, decode_message_error, {Exception, Reason, Bin}}),
+          erldns_events:notify({?MODULE, decode_message_error, {Exception, Reason, Bin}}),
           {formerr, Reason, Bin}
       end
   end.

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -34,7 +34,7 @@ encode_message(Response) ->
         M -> M
       catch
         Exception:Reason ->
-          lager:error("Error encoding (response: ~p, exception: ~p, reason: ~p)", [Response, Exception, Reason]),
+          erldns_events:notify({erldns_encoder, encode_message_error, {Exception, Reason, Response}}),
           encode_message(build_error_response(Response))
       end
   end.
@@ -58,7 +58,7 @@ encode_message(Response, Opts) ->
         M -> M
       catch
         Exception:Reason ->
-          lager:error("Error encoding with truncation (response: ~p, exception: ~p, reason: ~p)", [Response, Exception, Reason]),
+          erldns_events:notify({erldns_encoder, encode_message_error, {Exception, Reason, Response, Opts}}),
           {false, encode_message(build_error_response(Response))}
       end
   end.

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -34,7 +34,7 @@ encode_message(Response) ->
         M -> M
       catch
         Exception:Reason ->
-          erldns_events:notify({erldns_encoder, encode_message_error, {Exception, Reason, Response}}),
+          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
           encode_message(build_error_response(Response))
       end
   end.
@@ -58,7 +58,7 @@ encode_message(Response, Opts) ->
         M -> M
       catch
         Exception:Reason ->
-          erldns_events:notify({erldns_encoder, encode_message_error, {Exception, Reason, Response, Opts}}),
+          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
           {false, encode_message(build_error_response(Response))}
       end
   end.

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -31,7 +31,7 @@
 init(_Args) ->
   {ok, #state{}}.
 
-handle_event(start_servers, State) ->
+handle_event({_M, start_servers}, State) ->
   case State#state.servers_running of
     false ->
       % Start up the UDP and TCP servers
@@ -44,36 +44,24 @@ handle_event(start_servers, State) ->
       {ok, State}
   end;
 
-handle_event({end_udp, [{host, _Host}]}, State) ->
+handle_event({_M, end_udp, [{host, _Host}]}, State) ->
   folsom_metrics:notify({udp_request_meter, 1}),
   folsom_metrics:notify({udp_request_counter, {inc, 1}}),
   {ok, State};
 
-handle_event({end_tcp, [{host, _Host}]}, State) ->
+handle_event({_M, end_tcp, [{host, _Host}]}, State) ->
   folsom_metrics:notify({tcp_request_meter, 1}),
   folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
   {ok, State};
 
-handle_event({udp_error, Reason}, State) ->
+handle_event({_M, udp_error, Reason}, State) ->
   folsom_metrics:notify({udp_error_meter, 1}),
   folsom_metrics:notify({udp_error_history, Reason}),
   {ok, State};
 
-handle_event({tcp_error, Reason}, State) ->
+handle_event({_M, tcp_error, Reason}, State) ->
   folsom_metrics:notify({tcp_error_meter, 1}),
   folsom_metrics:notify({tcp_error_history, Reason}),
-  {ok, State};
-
-handle_event({refused_response, Questions}, State) ->
-  folsom_metrics:notify({refused_response_meter, 1}),
-  folsom_metrics:notify({refused_response_counter, {inc, 1}}),
-  lager:debug("Refused response: ~p", [Questions]),
-  {ok, State};
-
-handle_event({empty_response, Message}, State) ->
-  folsom_metrics:notify({empty_response_meter, 1}),
-  folsom_metrics:notify({empty_response_counter, {inc, 1}}),
-  lager:info("Empty response: ~p", [Message]),
   {ok, State};
 
 handle_event({dnssec_request, _Host, _Qname}, State) ->
@@ -81,11 +69,86 @@ handle_event({dnssec_request, _Host, _Qname}, State) ->
   folsom_metrics:notify(dnssec_request_meter, 1),
   {ok, State};
 
-handle_event({erldns_handler_error, {Exception, Reason, Message}}, State) ->
+handle_event({M = erldns_handler, E = refused_response, Questions}, State) ->
+  folsom_metrics:notify({refused_response_meter, 1}),
+  folsom_metrics:notify({refused_response_counter, {inc, 1}}),
+  lager:info("Refused response (module: ~p, event: ~p, questions: ~p)", [M, E, Questions]),
+  {ok, State};
+
+handle_event({M = erldns_handler, E = empty_response, Message}, State) ->
+  folsom_metrics:notify({empty_response_meter, 1}),
+  folsom_metrics:notify({empty_response_counter, {inc, 1}}),
+  lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [M, E, Message]),
+  {ok, State};
+
+handle_event({M = erldns_handler, E = error, {Exception, Reason, Message}}, State) ->
   folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
   folsom_metrics:notify({erldns_handler_error_meter, 1}),
-  lager:error("Error answering request (exception: ~p, reason: ~p, message: ~p)", [Exception, Reason, Message]),
+  lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p)", [M, E, Exception, Reason, Message]),
   {ok, State};
+
+handle_event({M = erldns_zone_loader, E = read_file_error, Reason}, State) ->
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_zone_loader, E = put_zone_error, {JsonZone, Reason}}, State) ->
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
+  {ok, State};
+
+handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Reason}}, State) ->
+  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Exception, Reason}}, State) ->
+  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Name, Type, Data, Exception, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_zone_parser, E = unsupported_record, Data}, State) ->
+  lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+  {ok, State};
+
+handle_event({M = erldns_decoder, E = decode_message_error, {Exception, Reason, Bin}}, State) ->
+  lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
+  {ok, State};
+
+handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, Response}}, State) ->
+  lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
+  lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)", [M, E, Response, Opts,Exception, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = handle_udp_query_error, {Error}}, State) ->
+  lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = decode_message_error, {Error, Message}}, State) ->
+  lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [M, E, Error, Message]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = decode_message_trailing_garbage, {Message, Garbage}}, State) ->
+  lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [M, E, Message, Garbage]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = process_crashed, {Protocol, Error, Reason, DecodedMessage}}, State) ->
+  lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [M, E, Protocol, Error, Reason, DecodedMessage]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = bad_packet, {Protocol, BadPacket}}, State) ->
+  lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [M, E, Protocol, BadPacket]),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = timeout, {Protocol, Message}}, State) ->
+  lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [M, E, Protocol, Message]),
+  folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
+  folsom_metrics:notify({worker_timeout_meter, 1}),
+  {ok, State};
+
+handle_event({M = erldns_worker, E = restart_failed, Error}, State) ->
+  lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
+  {ok, State};
+
 
 
 handle_event(_Event, State) ->

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -81,6 +81,13 @@ handle_event({dnssec_request, _Host, _Qname}, State) ->
   folsom_metrics:notify(dnssec_request_meter, 1),
   {ok, State};
 
+handle_event({erldns_handler_error, {Exception, Reason, Message}}, State) ->
+  folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
+  folsom_metrics:notify({erldns_handler_error_meter, 1}),
+  lager:error("Error answering request (exception: ~p, reason: ~p, message: ~p)", [Exception, Reason, Message]),
+  {ok, State};
+
+
 handle_event(_Event, State) ->
   {ok, State}.
 

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -69,6 +69,10 @@ handle_event({_M, dnssec_request, _Host, _Qname}, State) ->
   folsom_metrics:notify(dnssec_request_meter, 1),
   {ok, State};
 
+handle_event({M = erldns_handler, E = bad_message, {Message, Host}}, State) ->
+  lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [M, E, Message, Host]),
+  {ok, State};
+
 handle_event({M = erldns_handler, E = refused_response, Questions}, State) ->
   folsom_metrics:notify({refused_response_meter, 1}),
   folsom_metrics:notify({refused_response_counter, {inc, 1}}),
@@ -117,6 +121,10 @@ handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, R
 
 handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
   lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)", [M, E, Response, Opts,Exception, Reason]),
+  {ok, State};
+
+handle_event({M = erldns_storage, E = failed_zones_load, Reason}, State) ->
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
   {ok, State};
 
 handle_event({M = erldns_worker, E = handle_tcp_query_error, {Error}}, State) ->

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -85,10 +85,10 @@ handle_event({M = erldns_handler, E = empty_response, Message}, State) ->
   lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [M, E, Message]),
   {ok, State};
 
-handle_event({M = erldns_handler, E = error, {Exception, Reason, Message}}, State) ->
+handle_event({M = erldns_handler, E = resolve_error, {Exception, Reason, Message, Stacktrace}}, State) ->
   folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
   folsom_metrics:notify({erldns_handler_error_meter, 1}),
-  lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p)", [M, E, Exception, Reason, Message]),
+  lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: ~p)", [M, E, Exception, Reason, Message, Stacktrace]),
   {ok, State};
 
 handle_event({M = erldns_zone_encoder, E = unsupported_rrdata_type, Data}, State) ->

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -91,6 +91,10 @@ handle_event({M = erldns_handler, E = error, {Exception, Reason, Message}}, Stat
   lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p)", [M, E, Exception, Reason, Message]),
   {ok, State};
 
+handle_event({M = erldns_zone_encoder, E = unsupported_rrdata_type, Data}, State) ->
+  lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+  {ok, State};
+
 handle_event({M = erldns_zone_loader, E = read_file_error, Reason}, State) ->
   lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
   {ok, State};

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -174,7 +174,7 @@ safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
         Response -> maybe_cache_packet(Response, Response#dns_message.aa)
       catch
         Exception:Reason ->
-          lager:error("Error answering request (exception: ~p, reason: ~p)", [Exception, Reason]),
+          erldns_events:notify({erldns_handler_error, {Exception, Reason, Message}}),
           Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
       end
   end.

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -103,9 +103,9 @@ handle(Message, Context = {_, Host}) when is_record(Message, dns_message) ->
   handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
 %% The message was bad so just return it.
 %% TODO: consider just throwing away the message
-handle(BadMessage, {_, Host}) ->
-  lager:error("Received a bad message (message: ~p, host: ~p)", [BadMessage, Host]),
-  BadMessage.
+handle(Message, {_, Host}) ->
+  erldns_events:notify({?MODULE, bad_message, {Message, Host}}),
+  Message.
 
 %% We throttle ANY queries to discourage use of our authoritative name servers
 %% for reflection attacks.

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -174,7 +174,7 @@ safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
         Response -> maybe_cache_packet(Response, Response#dns_message.aa)
       catch
         Exception:Reason ->
-          erldns_events:notify({erldns_handler_error, {Exception, Reason, Message}}),
+          erldns_events:notify({erldns_handler, error, {Exception, Reason, Message}}),
           Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
       end
   end.
@@ -207,10 +207,10 @@ complete_response(Message) ->
 notify_empty_response(Message) ->
   case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
     {?DNS_RCODE_REFUSED, _} ->
-      erldns_events:notify({refused_response, Message#dns_message.questions}),
+      erldns_events:notify({erldns_handler, refused_response, Message#dns_message.questions}),
       Message;
     {_, 0} ->
-      erldns_events:notify({empty_response, Message}),
+      erldns_events:notify({erldns_handler, empty_response, Message}),
       Message;
     _ ->
       Message

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -173,8 +173,8 @@ safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
       try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
         Response -> maybe_cache_packet(Response, Response#dns_message.aa)
       catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, error, {Exception, Reason, Message}}),
+        Exception:Reason:Stacktrace ->
+          erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
           Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
       end
   end.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -538,7 +538,7 @@ requires_additional_processing([Answer|Rest], RequiresAdditional) ->
 check_dnssec(Message, Host, Question) ->
   case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
     true ->
-      erldns_events:notify({dnssec_request, Host, Question#dns_query.name});
+      erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name});
     false ->
       ok
   end.

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -179,7 +179,7 @@ load_zones(Filename) when is_list(Filename) ->
       lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
       {ok, length(JsonZones)};
     {error, Reason} ->
-      lager:error("Failed to load zones (reason: ~p)", [Reason]),
+      erldns_events:notify({?MODULE, failed_zones_load, Reason}),
       {err, Reason}
   end.
 

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -79,6 +79,7 @@ handle_cast(_Message, State) ->
 handle_info(timeout, State) ->
   {noreply, State};
 handle_info({udp, Socket, Host, Port, Bin}, State) ->
+  lager:debug("Received request: ~p", [Bin]),
   Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
   inet:setopts(State#state.socket, [{active, 100}]),
   Response;

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -79,7 +79,7 @@ handle_cast(_Message, State) ->
 handle_info(timeout, State) ->
   {noreply, State};
 handle_info({udp, Socket, Host, Port, Bin}, State) ->
-  lager:debug("Received request: ~p", [Bin]),
+  % lager:debug("Received request: ~p", [Bin]),
   Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
   inet:setopts(State#state.socket, [{active, 100}]),
   Response;

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -54,7 +54,7 @@ handle_cast({tcp_query, Socket, Bin}, State) ->
       {Id, _, Type, Modules} = State#state.worker_process,
       {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
     Error ->
-      lager:error("Error handling TCP query (error: ~p)", [Error]),
+      erldns_events:notify({?MODULE, handle_tcp_query_Error, {Error}}),
       {noreply, State}
   end;
 handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
@@ -65,7 +65,7 @@ handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
       {Id, _, Type, Modules} = State#state.worker_process,
       {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
     Error ->
-      erldns_events:notify({erldns_worker_handle_udp_query_error, {Error}}),
+      erldns_events:notify({?MODULE, handle_udp_query_error, {Error}}),
       {noreply, State}
   end;
 handle_cast(_Msg, State) ->
@@ -129,7 +129,7 @@ handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {
 %% @doc Handle DNS query that comes in over UDP
 -spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
-  erldns_events:notify({start_udp, [{host, Host}]}),
+  erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
   Result = case erldns_decoder:decode_message(Bin) of
              {trailing_garbage, DecodedMessage, TrailingGarbage} ->
                erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -65,7 +65,7 @@ handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
       {Id, _, Type, Modules} = State#state.worker_process,
       {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
     Error ->
-      lager:error("Error handling UDP query (error: ~p)", [Error]),
+      erldns_events:notify({erldns_worker_handle_udp_query_error, {Error}}),
       {noreply, State}
   end;
 handle_cast(_Msg, State) ->
@@ -82,31 +82,30 @@ code_change(_OldVsn, State, _Extra) ->
 handle_tcp_dns_query(Socket, <<_Len:16, Bin/binary>>, {WorkerProcessSup, WorkerProcess}) ->
   case inet:peername(Socket) of
     {ok, {Address, _Port}} ->
-      erldns_events:notify({start_tcp, [{host, Address}]}),
+      erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
       Result = case Bin of
         <<>> -> ok;
         _ ->
           case erldns_decoder:decode_message(Bin) of
-            {truncated, _, _} ->
-              lager:info("received truncated request (address: ~p)", [Address]),
-              ok;
-            {trailing_garbage, DecodedMessage, _} ->
+            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+              erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
               handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
-            {_Error, _, _} ->
+            {Error, Message, _} ->
+              erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
               ok;
             DecodedMessage ->
               handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
           end
       end,
-      erldns_events:notify({end_tcp, [{host, Address}]}),
+      erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
       gen_tcp:close(Socket),
       Result;
     {error, Reason} ->
-      erldns_events:notify({tcp_error, Reason})
+      erldns_events:notify({?MODULE, tcp_error, Reason})
   end;
 
 handle_tcp_dns_query(Socket, BadPacket, _) ->
-  lager:error("Received bad packet (packet: ~p)", BadPacket),
+  erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
   gen_tcp:close(Socket).
 
 handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
@@ -116,13 +115,13 @@ handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {
         _ -> ok
       catch
         exit:{timeout, _} ->
-          handle_timeout(DecodedMessage, WorkerProcessSup, WorkerProcessId);
+          erldns_events:notify({?MODULE, timeout, {tcp, DecodedMessage}}),
+          handle_timeout(WorkerProcessSup, WorkerProcessId);
         Error:Reason ->
-          lager:error("Worker process crashed (error: ~p, reason: ~p)", [Error, Reason]),
+          erldns_events:notify({?MODULE, process_crashed, {tcp, Error, Reason, DecodedMessage}}),
           {error, {Error, Reason}}
       end;
     true ->
-      lager:info("Dropping request that is not a question"),
       {error, not_a_question}
   end.
 
@@ -132,14 +131,16 @@ handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
   erldns_events:notify({start_udp, [{host, Host}]}),
   Result = case erldns_decoder:decode_message(Bin) of
-    {trailing_garbage, DecodedMessage, _} ->
-      handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
-    {_Error, _, _} ->
-      ok;
-    DecodedMessage ->
-      handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
+             {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+               erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
+             {Error, Message, _} ->
+               erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+               ok;
+             DecodedMessage ->
+               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
   end,
-  erldns_events:notify({end_udp, [{host, Host}]}),
+  erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
   Result.
 
 -spec handle_decoded_udp_message(dns:message(), gen_udp:socket(), gen_udp:ip(), inet:port_number(), {pid(), term()}) ->
@@ -151,23 +152,18 @@ handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup
         _ -> ok
       catch
         exit:{timeout, _} ->
-          handle_timeout(DecodedMessage, WorkerProcessSup, WorkerProcessId);
+          erldns_events:notify({?MODULE, timeout, {udp, DecodedMessage}}),
+          handle_timeout(WorkerProcessSup, WorkerProcessId);
         Error:Reason ->
-          lager:error("Worker process crashed (error: ~p, reason: ~p)", [Error, Reason]),
+          erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
           {error, {Error, Reason}}
       end;
     true ->
-      lager:info("Dropping request that is not a question"),
       {error, not_a_question}
   end.
 
--spec handle_timeout(dns:message(), pid(), term()) -> {error, timeout, term()} | {error, timeout}.
-handle_timeout(DecodedMessage, WorkerProcessSup, WorkerProcessId) ->
-  lager:debug("Worker timeout (message: ~p)", [DecodedMessage]),
-  
-  folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
-  folsom_metrics:notify({worker_timeout_meter, 1}),
-
+-spec handle_timeout(pid(), term()) -> {error, timeout, term()} | {error, timeout}.
+handle_timeout(WorkerProcessSup, WorkerProcessId) ->
   TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
   lager:debug("Terminate result: ~p", [TerminateResult]),
 
@@ -177,6 +173,6 @@ handle_timeout(DecodedMessage, WorkerProcessSup, WorkerProcessId) ->
     {ok, NewChild, _} ->
       {error, timeout, NewChild};
     {error, Error} ->
-      lager:debug("Restart failed (error: ~p)", Error),
+      erldns_events:notify({?MODULE, restart_failed, {Error}}),
       {error, timeout}
   end.

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -52,9 +52,7 @@ handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
   % querying www.example.com with the test zones
   % simulate_timeout(DecodedMessage),  
   
-  erldns_events:notify({start_handle, tcp, [{host, Address}]}),
   Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
-  erldns_events:notify({end_handle, tcp, [{host, Address}]}),
   EncodedMessage = erldns_encoder:encode_message(Response),
   send_tcp_message(Socket, EncodedMessage),
   {reply, ok, State}; 

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -70,7 +70,7 @@ handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) 
 
   case erldns_encoder:encode_message(Response, [{'max_size', max_payload_size(Response)}]) of
     {false, EncodedMessage} ->
-      lager:debug("Sending encoded response to ~p", [DestHost]),
+      % lager:debug("Sending encoded response to ~p", [DestHost]),
       gen_udp:send(Socket, DestHost, Port, EncodedMessage);
     {true, EncodedMessage, Message} when is_record(Message, dns_message)->
       gen_udp:send(Socket, DestHost, Port, EncodedMessage);

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -338,7 +338,7 @@ build_typed_index(Records) ->
 sign_zone(Zone = #zone{keysets = []}) ->
   Zone;
 sign_zone(Zone) ->
-  lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
+  % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
   DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
   KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
   verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
@@ -348,17 +348,17 @@ sign_zone(Zone) ->
   #zone{name = Zone#zone.name, version = Zone#zone.version, record_count = length(Records), authority = Zone#zone.authority, records = Records, records_by_name = build_named_index(Records), keysets = Zone#zone.keysets}.
 
 -spec(verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean()).
-verify_zone(Zone, DnskeyRRs, KeyRRSigRecords) ->
-  lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
+verify_zone(_Zone, DnskeyRRs, KeyRRSigRecords) ->
+  % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
   case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= 257 end, DnskeyRRs) of
     [] -> false;
     KSKs -> 
-      lager:debug("KSKs: ~p", [KSKs]),
+      % lager:debug("KSKs: ~p", [KSKs]),
       KSKDnskey = lists:last(KSKs),
       RRSig = lists:last(KeyRRSigRecords),
-      lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
+      % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
       VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
-      lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
+      % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
       VerifyResult
   end.
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -227,5 +227,5 @@ encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
   erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s", [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
 encode_data(Data) ->
-  lager:debug("Unable to encode rrdata (data: ~p)", [Data]),
+  lager:info("Unable to encode rrdata (data: ~p)", [Data]),
   {}.

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -58,7 +58,7 @@ register_encoders(Modules) ->
 %% @doc Register a single encoder module.
 -spec register_encoder(module()) -> ok.
 register_encoder(Module) ->
-  lager:info("Registering custome encoder (module: ~p)", [Module]),
+  lager:info("Registering custom encoder (module: ~p)", [Module]),
   gen_server:call(?SERVER, {register_encoder, Module}).
 
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -58,7 +58,7 @@ register_encoders(Modules) ->
 %% @doc Register a single encoder module.
 -spec register_encoder(module()) -> ok.
 register_encoder(Module) ->
-  lager:info("Registering customer encoder (module: ~p)", [Module]),
+  lager:info("Registering custome encoder (module: ~p)", [Module]),
   gen_server:call(?SERVER, {register_encoder, Module}).
 
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -227,5 +227,5 @@ encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
   erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s", [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
 encode_data(Data) ->
-  lager:info("Unable to encode rrdata (data: ~p)", [Data]),
+  erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
   {}.

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -226,7 +226,7 @@ try_custom_parsers(Data, [Parser|Rest]) ->
 
 % Internal converters
 json_record_to_erlang([Name, Type, _Ttl, Data = null, _]) ->
-  erldns_events:notify({?MODULE, parser_error, {Name, Type, Data, null_data}}),
+  erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
   {};
 
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _Context]) ->
@@ -489,8 +489,9 @@ base64_to_bin(Bin) when is_binary(Bin) ->
 
 -ifdef(TEST).
 json_record_to_erlang_test() ->
-  Name = <<"example.com">>,
+  erldns_events:start_link(),
   ?assertEqual({}, json_record_to_erlang([])),
+  Name = <<"example.com">>,
   ?assertEqual({}, json_record_to_erlang([Name, <<"SOA">>, 3600, null, null])).
 
 json_record_soa_to_erlang_test() ->

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -129,7 +129,7 @@ json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecord
                         {} ->
                           case try_custom_parsers(Data, Parsers) of
                             {} ->
-                              erldns_events:notify({erldns_zone, unsupported_record, Data}),
+                              erldns_events:notify({?MODULE, unsupported_record, Data}),
                               {};
                             ParsedRecord -> ParsedRecord
                           end;
@@ -226,7 +226,7 @@ try_custom_parsers(Data, [Parser|Rest]) ->
 
 % Internal converters
 json_record_to_erlang([Name, Type, _Ttl, Data = null, _]) ->
-  erldns_events:notify({erldns_zone, parser_error, {Name, Type, Data, null_data}}),
+  erldns_events:notify({?MODULE, parser_error, {Name, Type, Data, null_data}}),
   {};
 
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _Context]) ->
@@ -258,7 +258,7 @@ json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) ->
     {ok, Address} ->
       #dns_rr{name = Name, type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}, ttl = Ttl};
     {error, Reason} ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
       {}
   end;
 
@@ -267,7 +267,7 @@ json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) ->
     {ok, Address} ->
       #dns_rr{name = Name, type = ?DNS_TYPE_AAAA, data = #dns_rrdata_aaaa{ip = Address}, ttl = Ttl};
     {error, Reason} ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
       {}
   end;
 
@@ -330,7 +330,7 @@ json_record_to_erlang([Name, Type = <<"TXT">>, Ttl, Data, _Context]) ->
          ttl = Ttl}
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 
@@ -364,7 +364,7 @@ json_record_to_erlang([Name, Type = <<"SSHFP">>, Ttl, Data, _Context]) ->
          ttl = Ttl}
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 
@@ -409,7 +409,7 @@ json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) ->
          ttl = Ttl}
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 
@@ -428,7 +428,7 @@ json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) ->
          ttl = Ttl}
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 
@@ -448,7 +448,7 @@ json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) ->
            ttl = Ttl})
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 
@@ -468,7 +468,7 @@ json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) ->
            ttl = Ttl})
   catch
     Exception:Reason ->
-      erldns_events:notify({erldns_zone_parser, error, {Name, Type, Data, Exception, Reason}}),
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
       {}
   end;
 


### PR DESCRIPTION
Important events that occur in the erldns application now fire events, allowing better handling of error and info.