### PR TITLE
 Addressing Mnesia backend failing on erldns_zone_cache functions

### DIFF
--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -43,7 +43,6 @@
          terminate/2,
          code_change/3]).
 
-
 -record(state, {}).
 
 -define(POLL_WAIT_HOURS, 1).

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -18,7 +18,6 @@
 -dialyzer({nowarn_function, list_table/1}).
 
 -include("erldns.hrl").
--include_lib("kernel/include/logger.hrl").
 
 %% API
 -export([create/1,

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -244,7 +244,6 @@ select(Table, [{{{ZoneName, Fqdn}, _}, _, _}], _Limit) ->
   mnesia:activity(transaction, SelectFun);
 select(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}], _Limit) ->
   SelectFun = fun() ->
-     %[{_, _, _, _, Records}] = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
      Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
      [Record || {_, _, _, _, Record} <- Records] 
   end,

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -170,10 +170,7 @@ get_records_by_name_and_type(Name, Type) ->
 get_records_by_name(Name) ->
   case find_zone_in_cache(Name) of
     {ok, Zone} ->
-      case erldns_storage:select(zone_records, {erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name)}) of
-        [] -> [];
-        [{_, Records}] -> Records
-      end; 
+      lists:flatten(erldns_storage:select(zone_records,[{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name)}, '$1'},[],['$$']}], infinite));
     _ ->
       []
   end.

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -192,7 +192,13 @@ in_zone(Name) ->
 %% for the zone.
 -spec zone_names_and_versions() -> [{dns:dname(), binary()}].
 zone_names_and_versions() ->
-  erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones).
+  % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
+  case erldns_config:storage_type() of 
+    erldns_storage_json -> 
+	erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
+    erldns_storage_mnesia ->
+	erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
+  end.
 
 % ----------------------------------------------------------------------------------------------------
 % Write API


### PR DESCRIPTION
Mnesia related changes addressing https://github.com/dnsimple/erldns/issues/102.

Addressing Mnesia backend failing on erldns_zone_cache functions:
    
    * added type bag on table creation (zone_records, zone_records_typed)
    * set explicit type set on table creation (zones)
    * refactored select/3: using ETS match spec converted to Mnesia's
    match_object pattern
    * using different pattern in erldns_zone_cache:zone_names_and_versions/0
    depending on backend (ETS/Mnesia foldl/3 return values are different)

