### PR TITLE
Distributed Mnesia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ priv/_*.json
 db/
 _build/
 Mnesia.nonode@nohost/
+*.DCD
+*.DCL
+*.DAT
+*.LOG

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,8 @@
         folsom,
         jsx,
         dns_erlang,
-        iso8601
+        iso8601,
+	{nodefinder, "2.0.0"}
 ]}.
 
 {profiles, [{test, [{deps, [proper]}]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,6 +7,7 @@
  {<<"iso8601">>,{pkg,<<"iso8601">>,<<"1.3.1">>},0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.10.0">>},0},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.8.0">>},0},
+ {<<"nodefinder">>,{pkg,<<"nodefinder">>,<<"1.8.0">>},0},
  {<<"recon">>,{pkg,<<"recon">>,<<"2.5.0">>},0}]}.
 [
 {pkg_hash,[
@@ -18,5 +19,6 @@
  {<<"iso8601">>, <<"D1CEE73F56D71C35590C6B2DB2074873BF410BABAAB768F6EA566366D8CA4810">>},
  {<<"jsx">>, <<"77760560D6AC2B8C51FD4C980E9E19B784016AA70BE354CE746472C33BEB0B1C">>},
  {<<"lager">>, <<"3402B9A7E473680CA179FC2F1D827CAB88DD37DD1E6113090C6F45EF05228A1C">>},
+ {<<"nodefinder">>, <<"2BFDF001C7EA6662A4671283A902EDCA60EFE04D245C790A40C625CEDF2A5F9F">>},
  {<<"recon">>, <<"2F7FCBEC2C35034BADE2F9717F77059DC54EB4E929A3049CA7BA6775C0BD66CD">>}]}
 ].

--- a/src/erldns.app.src
+++ b/src/erldns.app.src
@@ -15,6 +15,7 @@
                   mnesia,
                   bear,
                   folsom,
-                  iso8601]},
+                  iso8601,
+		  nodefinder]},
   {start_phases, [{post_start, []}]}
   ]}.

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -22,6 +22,7 @@
 start(_Type, _Args) ->
   lager:info("Starting erldns application"),
   setup_metrics(),
+  nodefinder:multicast_start(),
   erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->


### PR DESCRIPTION
## Makes mnesia replicate all data between nodes.
  
* Adds Nodefinder as a dependency.

On startup, if there are other nodes in the cluster the mnesia storage will replicate from the other nodes.  
Multiple nodes will then have all records synced between them.

## Testing:
* Create directories for two mnesia storage locations for example: one and two
* Enable mnesia storage backend in erldns.config.


```
{erldns
	  {storage, [
	  	     {type, erldns_storage_mnesia},
	  	     {dir, "./one"}
	  	    ]
	  }
}
{mnesia,
[
{dir, "./one"}
]},
```

### Run the first node:
```
rebar3 shell --sname one --setcookie dns
```

* Edit erldns.config to run on a different port (e.g. 8054)
* Change the storage location for mnesia to the second location you created ("./two").
* Empty the priv/example.zone.json to only contain "[]"

### Run the second node:
```
rebar3 shell --sname two --setcookie dns
```

Test that both nodes respond with the first node zones.
```
dig @127.0.0.1 -p 8053 example.com
dig @127.0.0.1 -p 8054 example.com
```
