### PR TITLE
jsx: v3.x uses maps unless proplists are explicitly forced

### DIFF
--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -166,7 +166,7 @@ load_zones(Filename) when is_list(Filename) ->
     case file:read_file(Filename) of
         {ok, Binary} ->
             lager:debug("Parsing zones JSON"),
-            JsonZones = jsx:decode(Binary),
+            JsonZones = jsx:decode(Binary, [{return_maps, false}]),
             lager:debug("Putting zones into cache"),
             lists:foreach(fun(JsonZone) ->
                              Zone = erldns_zone_parser:zone_to_erlang(JsonZone),


### PR DESCRIPTION
I'm using erldns inside another project where I have a jsx version
incompatibility, we just add a simple test here and you can bump
jsx as you prefer without issue.

- tested with OTP 22.3.4.2
- works with jsx 2.10.0 and 3.0
```
Finished in 1.697 seconds
33 tests, 0 failures
```

> replaces PR#107 which was done off my master branch sorry
