### PR TITLE
Zone encoder function for metadata only

### DIFF
--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -56,7 +56,7 @@ zone_meta_to_json(Zone) ->
                                 {<<"name">>, Zone#zone.name},
                                 {<<"version">>, Zone#zone.version},
                                 % Note: Private key material is purposely omitted
-                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone))}
+                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}
                                ]}
                  ]
                }]).

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -140,13 +140,11 @@ encode_zone_to_json(Zone, Encoders) ->
                ]
               }]).
 
-encode_zone_records_to_json(ZoneName, RecordName, Encoders) ->
-  lager:debug("encode_zone_records_to_json (zone: ~p, record_name: ~p, Encoders)", [ZoneName, RecordName]),
+encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->
   Records = erldns_zone_cache:get_typed_records_by_name(RecordName),
   jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
-encode_zone_records_to_json(ZoneName, RecordName, RecordType, Encoders) ->
-  lager:debug("encode_zone_records_to_json (zone: ~p, record_name: ~p, record_type: ~p, Encoders)", [ZoneName, RecordName, RecordType]),
+encode_zone_records_to_json(_ZoneName, RecordName, RecordType, Encoders) ->
   Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
   jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -55,6 +55,7 @@ zone_meta_to_json(Zone) ->
                   {<<"zone">>, [
                                 {<<"name">>, Zone#zone.name},
                                 {<<"version">>, Zone#zone.version},
+                                % Note: Private key material is purposely omitted
                                 {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone))}
                                ]}
                  ]

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -140,11 +140,13 @@ encode_zone_to_json(Zone, Encoders) ->
                ]
               }]).
 
-encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->
+encode_zone_records_to_json(ZoneName, RecordName, Encoders) ->
+  lager:debug("encode_zone_records_to_json (zone: ~p, record_name: ~p, Encoders)", [ZoneName, RecordName]),
   Records = erldns_zone_cache:get_typed_records_by_name(RecordName),
   jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
-encode_zone_records_to_json(_ZoneName, RecordName, RecordType, Encoders) ->
+encode_zone_records_to_json(ZoneName, RecordName, RecordType, Encoders) ->
+  lager:debug("encode_zone_records_to_json (zone: ~p, record_name: ~p, record_type: ~p, Encoders)", [ZoneName, RecordName, RecordType]),
   Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
   jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -22,7 +22,10 @@
 -include("erldns.hrl").
 
 -export([start_link/0]).
--export([zone_to_json/1, register_encoders/1, register_encoder/1]).
+-export([zone_meta_to_json/1,
+         zone_to_json/1,
+         register_encoders/1,
+         register_encoder/1]).
 
 % Gen server hooks
 -export([init/1,
@@ -44,7 +47,19 @@
 start_link() ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-%% @doc Encode a Zone record into JSON.
+%% @doc Encode a Zone meta data into JSON.
+-spec zone_meta_to_json(#zone{}) -> binary().
+zone_meta_to_json(Zone) ->
+  jsx:encode([{<<"erldns">>,
+                 [
+                  {<<"zone">>, [
+                                {<<"name">>, Zone#zone.name},
+                                {<<"version">>, Zone#zone.version}
+                               ]}
+                 ]
+               }]).
+
+%% @doc Encode a Zone meta data plus all of its records into JSON.
 -spec zone_to_json(#zone{}) -> binary().
 zone_to_json(Zone) ->
   gen_server:call(?SERVER, {encode_zone, Zone}).

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -54,7 +54,8 @@ zone_meta_to_json(Zone) ->
                  [
                   {<<"zone">>, [
                                 {<<"name">>, Zone#zone.name},
-                                {<<"version">>, Zone#zone.version}
+                                {<<"version">>, Zone#zone.version},
+                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone))}
                                ]}
                  ]
                }]).

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -166,10 +166,10 @@ encode(Encoders) ->
   end.
 
 encode_record(Record, Encoders) ->
-  lager:debug("Encoding record (record: ~p)", [Record]),
+  % lager:debug("Encoding record (record: ~p)", [Record]),
   case encode_record(Record) of
     [] ->
-      lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
+      % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
       try_custom_encoders(Record, Encoders);
     EncodedRecord -> EncodedRecord
   end.
@@ -226,7 +226,7 @@ encode_record(Name, Type, Ttl, Data) ->
 try_custom_encoders(_Record, []) ->
   {};
 try_custom_encoders(Record, [Encoder|Rest]) ->
-  lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
+  % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
   case Encoder:encode_record(Record) of
     [] -> try_custom_encoders(Record, Rest);
     EncodedData -> EncodedData


### PR DESCRIPTION
Enhance the erldns zone encoder so it has additional functions for encoding only the zone meta data, and encoding specific record sets.

Supports https://github.com/dnsimple/erldns-admin/pull/5