### PR TITLE
2.x.x

### DIFF
--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -17,6 +17,7 @@
     authority = [] :: [dns:rr()],
     record_count = 0 :: non_neg_integer(),
     records = [] :: [dns:rr()] | trimmed,
+    %% records_by_name is deprecated
     records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
     %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
     %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -1,58 +1,29 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--record(keyset, {
-    key_signing_key :: crypto:rsa_private(),
-    key_signing_key_tag :: non_neg_integer(),
-    key_signing_alg :: non_neg_integer(),
-    zone_signing_key :: crypto:rsa_private(),
-    zone_signing_key_tag :: non_neg_integer(),
-    zone_signing_alg :: non_neg_integer(),
-    inception :: erlang:timestamp() | calendar:datetime1970(),
-    valid_until :: erlang:timestamp() | calendar:datetime1970()
-  }).
-
--record(zone, {
-    name :: dns:dname(),
-    version :: binary(),
-    authority = [] :: [dns:rr()],
-    record_count = 0 :: non_neg_integer(),
-    records = [] :: [dns:rr()] | trimmed,
-    records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
-    %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
-    %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
-    records_by_type :: term(),
-    keysets :: [erldns:keyset()]
-  }).
-
--record(authorities, {
-    owner_name,
-    ttl,
-    class,
-    name_server,
-    email_addr,
-    serial_num,
-    refresh,
-    retry,
-    expiry,
-    nxdomain
-}).
-
--record(zone_records, {
-    zone_name,
-    fqdn,
-    records
-}).
-
--record(zone_records_typed, {
-    zone_name,
-    fqdn,
-    type,
-    records
-}).
-
--record(sync_counters, {
-	counter :: integer()
-}).
+-record(keyset,
+        {key_signing_key :: crypto:rsa_private(),
+         key_signing_key_tag :: non_neg_integer(),
+         key_signing_alg :: non_neg_integer(),
+         zone_signing_key :: crypto:rsa_private(),
+         zone_signing_key_tag :: non_neg_integer(),
+         zone_signing_alg :: non_neg_integer(),
+         inception :: erlang:timestamp() | calendar:datetime1970(),
+         valid_until :: erlang:timestamp() | calendar:datetime1970()}).
+-record(zone,
+        {name :: dns:dname(),
+         version :: binary(),
+         authority = [] :: [dns:rr()],
+         record_count = 0 :: non_neg_integer(),
+         records = [] :: [dns:rr()] | trimmed,
+         records_by_name :: #{binary() => [dns:rr()]} | trimmed,
+         %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
+         %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
+         records_by_type :: term(),
+         keysets :: [erldns:keyset()]}).
+-record(authorities, {owner_name, ttl, class, name_server, email_addr, serial_num, refresh, retry, expiry, nxdomain}).
+-record(zone_records, {zone_name, fqdn, records}).
+-record(zone_records_typed, {zone_name, fqdn, type, records}).
+-record(sync_counters, {counter :: integer()}).
 
 -define(DNSKEY_ZSK_TYPE, 256).
 -define(DNSKEY_KSK_TYPE, 257).

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -1,29 +1,58 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--record(keyset,
-        {key_signing_key :: crypto:rsa_private(),
-         key_signing_key_tag :: non_neg_integer(),
-         key_signing_alg :: non_neg_integer(),
-         zone_signing_key :: crypto:rsa_private(),
-         zone_signing_key_tag :: non_neg_integer(),
-         zone_signing_alg :: non_neg_integer(),
-         inception :: erlang:timestamp() | calendar:datetime1970(),
-         valid_until :: erlang:timestamp() | calendar:datetime1970()}).
--record(zone,
-        {name :: dns:dname(),
-         version :: binary(),
-         authority = [] :: [dns:rr()],
-         record_count = 0 :: non_neg_integer(),
-         records = [] :: [dns:rr()] | trimmed,
-         records_by_name :: #{binary() => [dns:rr()]} | trimmed,
-         %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
-         %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
-         records_by_type :: term(),
-         keysets :: [erldns:keyset()]}).
--record(authorities, {owner_name, ttl, class, name_server, email_addr, serial_num, refresh, retry, expiry, nxdomain}).
--record(zone_records, {zone_name, fqdn, records}).
--record(zone_records_typed, {zone_name, fqdn, type, records}).
--record(sync_counters, {counter :: integer()}).
+-record(keyset, {
+    key_signing_key :: crypto:rsa_private(),
+    key_signing_key_tag :: non_neg_integer(),
+    key_signing_alg :: non_neg_integer(),
+    zone_signing_key :: crypto:rsa_private(),
+    zone_signing_key_tag :: non_neg_integer(),
+    zone_signing_alg :: non_neg_integer(),
+    inception :: erlang:timestamp() | calendar:datetime1970(),
+    valid_until :: erlang:timestamp() | calendar:datetime1970()
+  }).
+
+-record(zone, {
+    name :: dns:dname(),
+    version :: binary(),
+    authority = [] :: [dns:rr()],
+    record_count = 0 :: non_neg_integer(),
+    records = [] :: [dns:rr()] | trimmed,
+    records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
+    %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
+    %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
+    records_by_type :: term(),
+    keysets :: [erldns:keyset()]
+  }).
+
+-record(authorities, {
+    owner_name,
+    ttl,
+    class,
+    name_server,
+    email_addr,
+    serial_num,
+    refresh,
+    retry,
+    expiry,
+    nxdomain
+}).
+
+-record(zone_records, {
+    zone_name,
+    fqdn,
+    records
+}).
+
+-record(zone_records_typed, {
+    zone_name,
+    fqdn,
+    type,
+    records
+}).
+
+-record(sync_counters, {
+	counter :: integer()
+}).
 
 -define(DNSKEY_ZSK_TYPE, 256).
 -define(DNSKEY_KSK_TYPE, 257).

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -1,59 +1,30 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--record(keyset, {
-    key_signing_key :: crypto:rsa_private(),
-    key_signing_key_tag :: non_neg_integer(),
-    key_signing_alg :: non_neg_integer(),
-    zone_signing_key :: crypto:rsa_private(),
-    zone_signing_key_tag :: non_neg_integer(),
-    zone_signing_alg :: non_neg_integer(),
-    inception :: erlang:timestamp() | calendar:datetime1970(),
-    valid_until :: erlang:timestamp() | calendar:datetime1970()
-  }).
-
--record(zone, {
-    name :: dns:dname(),
-    version :: binary(),
-    authority = [] :: [dns:rr()],
-    record_count = 0 :: non_neg_integer(),
-    records = [] :: [dns:rr()] | trimmed,
-    %% records_by_name is deprecated
-    records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
-    %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
-    %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
-    records_by_type :: term(),
-    keysets :: [erldns:keyset()]
-  }).
-
--record(authorities, {
-    owner_name,
-    ttl,
-    class,
-    name_server,
-    email_addr,
-    serial_num,
-    refresh,
-    retry,
-    expiry,
-    nxdomain
-}).
-
--record(zone_records, {
-    zone_name,
-    fqdn,
-    records
-}).
-
--record(zone_records_typed, {
-    zone_name,
-    fqdn,
-    type,
-    records
-}).
-
--record(sync_counters, {
-	counter :: integer()
-}).
+-record(keyset,
+        {key_signing_key :: crypto:rsa_private(),
+         key_signing_key_tag :: non_neg_integer(),
+         key_signing_alg :: non_neg_integer(),
+         zone_signing_key :: crypto:rsa_private(),
+         zone_signing_key_tag :: non_neg_integer(),
+         zone_signing_alg :: non_neg_integer(),
+         inception :: erlang:timestamp() | calendar:datetime1970(),
+         valid_until :: erlang:timestamp() | calendar:datetime1970()}).
+-record(zone,
+        {name :: dns:dname(),
+         version :: binary(),
+         authority = [] :: [dns:rr()],
+         record_count = 0 :: non_neg_integer(),
+         records = [] :: [dns:rr()] | trimmed,
+         %% records_by_name is deprecated
+         records_by_name :: #{binary() => [dns:rr()]} | trimmed,
+         %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
+         %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
+         records_by_type :: term(),
+         keysets :: [erldns:keyset()]}).
+-record(authorities, {owner_name, ttl, class, name_server, email_addr, serial_num, refresh, retry, expiry, nxdomain}).
+-record(zone_records, {zone_name, fqdn, records}).
+-record(zone_records_typed, {zone_name, fqdn, type, records}).
+-record(sync_counters, {counter :: integer()}).
 
 -define(DNSKEY_ZSK_TYPE, 256).
 -define(DNSKEY_KSK_TYPE, 257).

--- a/rebar.config
+++ b/rebar.config
@@ -16,21 +16,6 @@
 
 {profiles, [{test, [{deps, [proper]}]}]}.
 
-{project_plugins, [rebar3_format]}.
-
-{format, [
-          {formatter, default_formatter},
-          {files, [
-                   "src/**/*.?rl", "include/**/*.?rl"
-                  ]},
-          {options, #{
-             paper => 160,
-             ribbon => 150,
-             inline_attributes => {when_under, 3},
-             inline_qualified_function_composition => true}
-          }]
-}.
-
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
           {options, #{
              paper => 160,
              ribbon => 150,
-             inline_attributes => {when_under, 3},
+             inline_attributes => none,
              inline_qualified_function_composition => true}
           }]
 }.

--- a/rebar.config
+++ b/rebar.config
@@ -16,6 +16,21 @@
 
 {profiles, [{test, [{deps, [proper]}]}]}.
 
+{project_plugins, [rebar3_format]}.
+
+{format, [
+          {formatter, default_formatter},
+          {files, [
+                   "src/**/*.?rl", "include/**/*.?rl"
+                  ]},
+          {options, #{
+             paper => 160,
+             ribbon => 150,
+             inline_attributes => {when_under, 3},
+             inline_qualified_function_composition => true}
+          }]
+}.
+
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -16,6 +16,21 @@
 
 {profiles, [{test, [{deps, [proper]}]}]}.
 
+{project_plugins, [rebar3_format]}.
+
+{format, [
+          {formatter, default_formatter},
+          {files, [
+                   "src/**/*.?rl", "include/**/*.?rl"
+                  ]},
+          {options, #{
+             paper => 160,
+             ribbon => 150,
+             inline_attributes => none,
+             inline_qualified_function_composition => true}
+          }]
+}.
+
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
           {options, #{
              paper => 160,
              ribbon => 150,
-             inline_attributes => none,
+             inline_attributes => {when_under, 3},
              inline_qualified_function_composition => true}
           }]
 }.

--- a/src/erldns.app.src
+++ b/src/erldns.app.src
@@ -1,7 +1,7 @@
 % -*- mode: Erlang; -*-
 {application, erldns,
  [{description, "Erlang Authoritative DNS Server"},
-  {vsn, "4.0.0"},
+  {vsn, "2.0.0"},
   {licenses, ["MIT"]},
   {mod, { erldns_app, []}},
   {applications, [kernel,

--- a/src/erldns.app.src
+++ b/src/erldns.app.src
@@ -1,7 +1,7 @@
 % -*- mode: Erlang; -*-
 {application, erldns,
  [{description, "Erlang Authoritative DNS Server"},
-  {vsn, "1.0.0"},
+  {vsn, "4.0.0"},
   {licenses, ["MIT"]},
   {mod, { erldns_app, []}},
   {applications, [kernel,

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020,  DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -18,19 +18,17 @@
 -include("erldns.hrl").
 
 -export([start/0]).
+
 -export([normalize_name/1]).
 
 -export_type([keyset/0, zone/0]).
-
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.
 
 -spec start() -> any().
 start() ->
-    application:ensure_all_started(erldns).
+  application:ensure_all_started(erldns).
 
 %% @doc Converts a domain name to lower case.
-normalize_name(Name) when is_list(Name) ->
-    string:to_lower(Name);
-normalize_name(Name) when is_binary(Name) ->
-    list_to_binary(string:to_lower(binary_to_list(Name))).
+normalize_name(Name) when is_list(Name) -> string:to_lower(Name);
+normalize_name(Name) when is_binary(Name) -> list_to_binary(string:to_lower(binary_to_list(Name))).

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -18,17 +18,20 @@
 -include("erldns.hrl").
 
 -export([start/0]).
-
 -export([normalize_name/1]).
 
--export_type([keyset/0, zone/0]).
+-export_type([keyset/0,
+              zone/0]).
+
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.
 
 -spec start() -> any().
 start() ->
-  application:ensure_all_started(erldns).
+    application:ensure_all_started(erldns).
 
 %% @doc Converts a domain name to lower case.
-normalize_name(Name) when is_list(Name) -> string:to_lower(Name);
-normalize_name(Name) when is_binary(Name) -> list_to_binary(string:to_lower(binary_to_list(Name))).
+normalize_name(Name) when is_list(Name) ->
+    string:to_lower(Name);
+normalize_name(Name) when is_binary(Name) ->
+    list_to_binary(string:to_lower(binary_to_list(Name))).

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -20,7 +20,8 @@
 -export([start/0]).
 -export([normalize_name/1]).
 
--export_type([keyset/0, zone/0]).
+-export_type([keyset/0,
+              zone/0]).
 
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -18,17 +18,19 @@
 -include("erldns.hrl").
 
 -export([start/0]).
-
 -export([normalize_name/1]).
 
 -export_type([keyset/0, zone/0]).
+
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.
 
 -spec start() -> any().
 start() ->
-  application:ensure_all_started(erldns).
+    application:ensure_all_started(erldns).
 
 %% @doc Converts a domain name to lower case.
-normalize_name(Name) when is_list(Name) -> string:to_lower(Name);
-normalize_name(Name) when is_binary(Name) -> list_to_binary(string:to_lower(binary_to_list(Name))).
+normalize_name(Name) when is_list(Name) ->
+    string:to_lower(Name);
+normalize_name(Name) when is_binary(Name) ->
+    list_to_binary(string:to_lower(binary_to_list(Name))).

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -20,8 +20,7 @@
 -export([start/0]).
 -export([normalize_name/1]).
 
--export_type([keyset/0,
-              zone/0]).
+-export_type([keyset/0, zone/0]).
 
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -14,78 +14,70 @@
 
 %% @doc The erldns OTP application.
 -module(erldns_app).
+
 -behavior(application).
 
 % Application hooks
--export([start/2, start_phase/3, stop/1]).
+-export([start/2,
+         start_phase/3,
+         stop/1]).
 
 start(_Type, _Args) ->
-  lager:info("Starting erldns application"),
-  setup_metrics(),
-  nodefinder:multicast_start(),
-  erldns_sup:start_link().
+    lager:info("Starting erldns application"),
+    setup_metrics(),
+    nodefinder:multicast_start(),
+    erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->
-  erldns_events:add_handler(erldns_event_handler),
-
-  case application:get_env(erldns, custom_zone_parsers) of
-    {ok, Parsers} -> erldns_zone_parser:register_parsers(Parsers);
-    _ -> ok
-  end,
-
-  case application:get_env(erldns, custom_zone_encoders) of
-    {ok, Encoders} -> erldns_zone_encoder:register_encoders(Encoders);
-    _ -> ok
-  end,
-
-  lager:info("Loading zones from local file"),
-  erldns_zone_loader:load_zones(),
-
-  lager:info("Notifying servers to start"),
-  erldns_events:notify({?MODULE, start_servers}),
-
-  ok.
+    erldns_events:add_handler(erldns_event_handler),
+    case application:get_env(erldns, custom_zone_parsers) of
+        {ok, Parsers} ->
+            erldns_zone_parser:register_parsers(Parsers);
+        _ ->
+            ok
+    end,
+    case application:get_env(erldns, custom_zone_encoders) of
+        {ok, Encoders} ->
+            erldns_zone_encoder:register_encoders(Encoders);
+        _ ->
+            ok
+    end,
+    lager:info("Loading zones from local file"),
+    erldns_zone_loader:load_zones(),
+    lager:info("Notifying servers to start"),
+    erldns_events:notify({?MODULE, start_servers}),
+    ok.
 
 stop(_State) ->
-  lager:info("Stop erldns application"),
-  ok.
+    lager:info("Stop erldns application"),
+    ok.
 
 setup_metrics() ->
-  folsom_metrics:new_counter(udp_request_counter),
-  folsom_metrics:new_counter(tcp_request_counter),
-  folsom_metrics:new_meter(udp_request_meter),
-  folsom_metrics:new_meter(tcp_request_meter),
-
-  folsom_metrics:new_meter(udp_error_meter),
-  folsom_metrics:new_meter(tcp_error_meter),
-  folsom_metrics:new_history(udp_error_history),
-  folsom_metrics:new_history(tcp_error_history),
-
-  folsom_metrics:new_meter(refused_response_meter),
-  folsom_metrics:new_counter(refused_response_counter),
-
-  folsom_metrics:new_meter(empty_response_meter),
-  folsom_metrics:new_counter(empty_response_counter),
-
-  folsom_metrics:new_histogram(udp_handoff_histogram),
-  folsom_metrics:new_histogram(tcp_handoff_histogram),
-
-  folsom_metrics:new_counter(request_throttled_counter),
-  folsom_metrics:new_meter(request_throttled_meter),
-  folsom_metrics:new_histogram(request_handled_histogram),
-
-  folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
-  folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
-
-  folsom_metrics:new_counter(worker_timeout_counter),
-  folsom_metrics:new_meter(worker_timeout_meter),
-
-  folsom_metrics:new_meter(cache_hit_meter),
-  folsom_metrics:new_meter(cache_expired_meter),
-  folsom_metrics:new_meter(cache_miss_meter),
-
-  folsom_metrics:new_counter(dnssec_request_counter),
-  folsom_metrics:new_meter(dnssec_request_meter),
-
-  folsom_metrics:new_counter(erldns_handler_error_counter),
-  folsom_metrics:new_meter(erldns_handler_error_meter).
+    folsom_metrics:new_counter(udp_request_counter),
+    folsom_metrics:new_counter(tcp_request_counter),
+    folsom_metrics:new_meter(udp_request_meter),
+    folsom_metrics:new_meter(tcp_request_meter),
+    folsom_metrics:new_meter(udp_error_meter),
+    folsom_metrics:new_meter(tcp_error_meter),
+    folsom_metrics:new_history(udp_error_history),
+    folsom_metrics:new_history(tcp_error_history),
+    folsom_metrics:new_meter(refused_response_meter),
+    folsom_metrics:new_counter(refused_response_counter),
+    folsom_metrics:new_meter(empty_response_meter),
+    folsom_metrics:new_counter(empty_response_counter),
+    folsom_metrics:new_histogram(udp_handoff_histogram),
+    folsom_metrics:new_histogram(tcp_handoff_histogram),
+    folsom_metrics:new_counter(request_throttled_counter),
+    folsom_metrics:new_meter(request_throttled_meter),
+    folsom_metrics:new_histogram(request_handled_histogram),
+    folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
+    folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
+    folsom_metrics:new_counter(worker_timeout_counter),
+    folsom_metrics:new_meter(worker_timeout_meter),
+    folsom_metrics:new_meter(cache_hit_meter),
+    folsom_metrics:new_meter(cache_expired_meter),
+    folsom_metrics:new_meter(cache_miss_meter),
+    folsom_metrics:new_counter(dnssec_request_counter),
+    folsom_metrics:new_meter(dnssec_request_meter),
+    folsom_metrics:new_counter(erldns_handler_error_counter),
+    folsom_metrics:new_meter(erldns_handler_error_meter).

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -14,70 +14,78 @@
 
 %% @doc The erldns OTP application.
 -module(erldns_app).
-
 -behavior(application).
 
 % Application hooks
--export([start/2,
-         start_phase/3,
-         stop/1]).
+-export([start/2, start_phase/3, stop/1]).
 
 start(_Type, _Args) ->
-    lager:info("Starting erldns application"),
-    setup_metrics(),
-    nodefinder:multicast_start(),
-    erldns_sup:start_link().
+  lager:info("Starting erldns application"),
+  setup_metrics(),
+  nodefinder:multicast_start(),
+  erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->
-    erldns_events:add_handler(erldns_event_handler),
-    case application:get_env(erldns, custom_zone_parsers) of
-        {ok, Parsers} ->
-            erldns_zone_parser:register_parsers(Parsers);
-        _ ->
-            ok
-    end,
-    case application:get_env(erldns, custom_zone_encoders) of
-        {ok, Encoders} ->
-            erldns_zone_encoder:register_encoders(Encoders);
-        _ ->
-            ok
-    end,
-    lager:info("Loading zones from local file"),
-    erldns_zone_loader:load_zones(),
-    lager:info("Notifying servers to start"),
-    erldns_events:notify({?MODULE, start_servers}),
-    ok.
+  erldns_events:add_handler(erldns_event_handler),
+
+  case application:get_env(erldns, custom_zone_parsers) of
+    {ok, Parsers} -> erldns_zone_parser:register_parsers(Parsers);
+    _ -> ok
+  end,
+
+  case application:get_env(erldns, custom_zone_encoders) of
+    {ok, Encoders} -> erldns_zone_encoder:register_encoders(Encoders);
+    _ -> ok
+  end,
+
+  lager:info("Loading zones from local file"),
+  erldns_zone_loader:load_zones(),
+
+  lager:info("Notifying servers to start"),
+  erldns_events:notify({?MODULE, start_servers}),
+
+  ok.
 
 stop(_State) ->
-    lager:info("Stop erldns application"),
-    ok.
+  lager:info("Stop erldns application"),
+  ok.
 
 setup_metrics() ->
-    folsom_metrics:new_counter(udp_request_counter),
-    folsom_metrics:new_counter(tcp_request_counter),
-    folsom_metrics:new_meter(udp_request_meter),
-    folsom_metrics:new_meter(tcp_request_meter),
-    folsom_metrics:new_meter(udp_error_meter),
-    folsom_metrics:new_meter(tcp_error_meter),
-    folsom_metrics:new_history(udp_error_history),
-    folsom_metrics:new_history(tcp_error_history),
-    folsom_metrics:new_meter(refused_response_meter),
-    folsom_metrics:new_counter(refused_response_counter),
-    folsom_metrics:new_meter(empty_response_meter),
-    folsom_metrics:new_counter(empty_response_counter),
-    folsom_metrics:new_histogram(udp_handoff_histogram),
-    folsom_metrics:new_histogram(tcp_handoff_histogram),
-    folsom_metrics:new_counter(request_throttled_counter),
-    folsom_metrics:new_meter(request_throttled_meter),
-    folsom_metrics:new_histogram(request_handled_histogram),
-    folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
-    folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
-    folsom_metrics:new_counter(worker_timeout_counter),
-    folsom_metrics:new_meter(worker_timeout_meter),
-    folsom_metrics:new_meter(cache_hit_meter),
-    folsom_metrics:new_meter(cache_expired_meter),
-    folsom_metrics:new_meter(cache_miss_meter),
-    folsom_metrics:new_counter(dnssec_request_counter),
-    folsom_metrics:new_meter(dnssec_request_meter),
-    folsom_metrics:new_counter(erldns_handler_error_counter),
-    folsom_metrics:new_meter(erldns_handler_error_meter).
+  folsom_metrics:new_counter(udp_request_counter),
+  folsom_metrics:new_counter(tcp_request_counter),
+  folsom_metrics:new_meter(udp_request_meter),
+  folsom_metrics:new_meter(tcp_request_meter),
+
+  folsom_metrics:new_meter(udp_error_meter),
+  folsom_metrics:new_meter(tcp_error_meter),
+  folsom_metrics:new_history(udp_error_history),
+  folsom_metrics:new_history(tcp_error_history),
+
+  folsom_metrics:new_meter(refused_response_meter),
+  folsom_metrics:new_counter(refused_response_counter),
+
+  folsom_metrics:new_meter(empty_response_meter),
+  folsom_metrics:new_counter(empty_response_counter),
+
+  folsom_metrics:new_histogram(udp_handoff_histogram),
+  folsom_metrics:new_histogram(tcp_handoff_histogram),
+
+  folsom_metrics:new_counter(request_throttled_counter),
+  folsom_metrics:new_meter(request_throttled_meter),
+  folsom_metrics:new_histogram(request_handled_histogram),
+
+  folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
+  folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
+
+  folsom_metrics:new_counter(worker_timeout_counter),
+  folsom_metrics:new_meter(worker_timeout_meter),
+
+  folsom_metrics:new_meter(cache_hit_meter),
+  folsom_metrics:new_meter(cache_expired_meter),
+  folsom_metrics:new_meter(cache_miss_meter),
+
+  folsom_metrics:new_counter(dnssec_request_counter),
+  folsom_metrics:new_meter(dnssec_request_meter),
+
+  folsom_metrics:new_counter(erldns_handler_error_counter),
+  folsom_metrics:new_meter(erldns_handler_error_meter).

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -14,78 +14,85 @@
 
 %% @doc The erldns OTP application.
 -module(erldns_app).
+
 -behavior(application).
 
 % Application hooks
--export([start/2, start_phase/3, stop/1]).
+-export([start/2,
+         start_phase/3,
+         stop/1]).
 
 start(_Type, _Args) ->
-  lager:info("Starting erldns application"),
-  setup_metrics(),
-  nodefinder:multicast_start(),
-  erldns_sup:start_link().
+    lager:info("Starting erldns application"),
+    setup_metrics(),
+    nodefinder:multicast_start(),
+    erldns_sup:start_link().
 
 start_phase(post_start, _StartType, _PhaseArgs) ->
-  erldns_events:add_handler(erldns_event_handler),
+    erldns_events:add_handler(erldns_event_handler),
 
-  case application:get_env(erldns, custom_zone_parsers) of
-    {ok, Parsers} -> erldns_zone_parser:register_parsers(Parsers);
-    _ -> ok
-  end,
+    case application:get_env(erldns, custom_zone_parsers) of
+        {ok, Parsers} ->
+            erldns_zone_parser:register_parsers(Parsers);
+        _ ->
+            ok
+    end,
 
-  case application:get_env(erldns, custom_zone_encoders) of
-    {ok, Encoders} -> erldns_zone_encoder:register_encoders(Encoders);
-    _ -> ok
-  end,
+    case application:get_env(erldns, custom_zone_encoders) of
+        {ok, Encoders} ->
+            erldns_zone_encoder:register_encoders(Encoders);
+        _ ->
+            ok
+    end,
 
-  lager:info("Loading zones from local file"),
-  erldns_zone_loader:load_zones(),
+    lager:info("Loading zones from local file"),
+    erldns_zone_loader:load_zones(),
 
-  lager:info("Notifying servers to start"),
-  erldns_events:notify({?MODULE, start_servers}),
+    lager:info("Notifying servers to start"),
+    erldns_events:notify({?MODULE, start_servers}),
 
-  ok.
+    ok.
 
 stop(_State) ->
-  lager:info("Stop erldns application"),
-  ok.
+    lager:info("Stop erldns application"),
+    ok.
 
 setup_metrics() ->
-  folsom_metrics:new_counter(udp_request_counter),
-  folsom_metrics:new_counter(tcp_request_counter),
-  folsom_metrics:new_meter(udp_request_meter),
-  folsom_metrics:new_meter(tcp_request_meter),
+    folsom_metrics:new_counter(udp_request_counter),
+    folsom_metrics:new_counter(tcp_request_counter),
+    folsom_metrics:new_meter(udp_request_meter),
+    folsom_metrics:new_meter(tcp_request_meter),
 
-  folsom_metrics:new_meter(udp_error_meter),
-  folsom_metrics:new_meter(tcp_error_meter),
-  folsom_metrics:new_history(udp_error_history),
-  folsom_metrics:new_history(tcp_error_history),
+    folsom_metrics:new_meter(udp_error_meter),
+    folsom_metrics:new_meter(tcp_error_meter),
+    folsom_metrics:new_history(udp_error_history),
+    folsom_metrics:new_history(tcp_error_history),
 
-  folsom_metrics:new_meter(refused_response_meter),
-  folsom_metrics:new_counter(refused_response_counter),
+    folsom_metrics:new_meter(refused_response_meter),
+    folsom_metrics:new_counter(refused_response_counter),
 
-  folsom_metrics:new_meter(empty_response_meter),
-  folsom_metrics:new_counter(empty_response_counter),
+    folsom_metrics:new_meter(empty_response_meter),
+    folsom_metrics:new_counter(empty_response_counter),
 
-  folsom_metrics:new_histogram(udp_handoff_histogram),
-  folsom_metrics:new_histogram(tcp_handoff_histogram),
+    folsom_metrics:new_histogram(udp_handoff_histogram),
+    folsom_metrics:new_histogram(tcp_handoff_histogram),
 
-  folsom_metrics:new_counter(request_throttled_counter),
-  folsom_metrics:new_meter(request_throttled_meter),
-  folsom_metrics:new_histogram(request_handled_histogram),
+    folsom_metrics:new_counter(request_throttled_counter),
+    folsom_metrics:new_meter(request_throttled_meter),
+    folsom_metrics:new_histogram(request_handled_histogram),
 
-  folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
-  folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
+    folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
+    folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
 
-  folsom_metrics:new_counter(worker_timeout_counter),
-  folsom_metrics:new_meter(worker_timeout_meter),
+    folsom_metrics:new_counter(worker_timeout_counter),
+    folsom_metrics:new_meter(worker_timeout_meter),
 
-  folsom_metrics:new_meter(cache_hit_meter),
-  folsom_metrics:new_meter(cache_expired_meter),
-  folsom_metrics:new_meter(cache_miss_meter),
+    folsom_metrics:new_meter(cache_hit_meter),
+    folsom_metrics:new_meter(cache_expired_meter),
+    folsom_metrics:new_meter(cache_miss_meter),
 
-  folsom_metrics:new_counter(dnssec_request_counter),
-  folsom_metrics:new_meter(dnssec_request_meter),
+    folsom_metrics:new_counter(dnssec_request_counter),
+    folsom_metrics:new_meter(dnssec_request_meter),
 
-  folsom_metrics:new_counter(erldns_handler_error_counter),
-  folsom_metrics:new_meter(erldns_handler_error_meter).
+    folsom_metrics:new_counter(erldns_handler_error_counter),
+    folsom_metrics:new_meter(erldns_handler_error_meter).

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -17,37 +17,43 @@
 
 -include_lib("dns_erlang/include/dns.hrl").
 
--export([is_enabled/2, optionally_append_soa/1]).
+-export([is_enabled/2,
+         optionally_append_soa/1]).
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->
-  MatchingMetadata = lists:filter(
-                       fun(MetadataRow) ->
-                           [_Id, _DomainId, Kind, Content] = MetadataRow,
-                           {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
-                           AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
-                       end, Metadata),
-  length(MatchingMetadata) > 0.
+    MatchingMetadata =
+        lists:filter(fun(MetadataRow) ->
+                        [_Id, _DomainId, Kind, Content] = MetadataRow,
+                        {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
+                        AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
+                     end,
+                     Metadata),
+    length(MatchingMetadata) > 0.
 
 %% If the message is an AXFR request then append the SOA record.
 optionally_append_soa(Message) ->
-  optionally_append_soa(Message, Message#dns_message.questions).
+    optionally_append_soa(Message, Message#dns_message.questions).
+
 optionally_append_soa(Message, []) ->
-  Message;
-optionally_append_soa(Message, [Q|Rest]) ->
-  case Q#dns_query.type of 
-    ?DNS_TYPE_AXFR_NUMBER -> append_soa(Message, Message#dns_message.answers);
-    _ -> optionally_append_soa(Message, Rest)
-  end.
+    Message;
+optionally_append_soa(Message, [Q | Rest]) ->
+    case Q#dns_query.type of
+        ?DNS_TYPE_AXFR_NUMBER ->
+            append_soa(Message, Message#dns_message.answers);
+        _ ->
+            optionally_append_soa(Message, Rest)
+    end.
 
 append_soa(Message, []) ->
-  Message;
-append_soa(Message, [Answer|Rest]) ->
-  append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+    Message;
+append_soa(Message, [Answer | Rest]) ->
+    append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+
 append_soa(Message, ?DNS_TYPE_SOA_NUMBER, Answer, _) ->
-  Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
-  Message#dns_message{anc = length(Answers), answers = Answers};
+    Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
+    Message#dns_message{anc = length(Answers), answers = Answers};
 append_soa(Message, _, _, []) ->
-  Message;
-append_soa(Message, _, _, [Answer|Rest]) ->
-  append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+    Message;
+append_soa(Message, _, _, [Answer | Rest]) ->
+    append_soa(Message, Answer#dns_rr.type, Answer, Rest).

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -21,33 +21,38 @@
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->
-  MatchingMetadata = lists:filter(
-                       fun(MetadataRow) ->
-                           [_Id, _DomainId, Kind, Content] = MetadataRow,
-                           {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
-                           AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
-                       end, Metadata),
-  length(MatchingMetadata) > 0.
+    MatchingMetadata =
+        lists:filter(fun(MetadataRow) ->
+                        [_Id, _DomainId, Kind, Content] = MetadataRow,
+                        {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
+                        AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
+                     end,
+                     Metadata),
+    length(MatchingMetadata) > 0.
 
 %% If the message is an AXFR request then append the SOA record.
 optionally_append_soa(Message) ->
-  optionally_append_soa(Message, Message#dns_message.questions).
+    optionally_append_soa(Message, Message#dns_message.questions).
+
 optionally_append_soa(Message, []) ->
-  Message;
-optionally_append_soa(Message, [Q|Rest]) ->
-  case Q#dns_query.type of 
-    ?DNS_TYPE_AXFR_NUMBER -> append_soa(Message, Message#dns_message.answers);
-    _ -> optionally_append_soa(Message, Rest)
-  end.
+    Message;
+optionally_append_soa(Message, [Q | Rest]) ->
+    case Q#dns_query.type of
+        ?DNS_TYPE_AXFR_NUMBER ->
+            append_soa(Message, Message#dns_message.answers);
+        _ ->
+            optionally_append_soa(Message, Rest)
+    end.
 
 append_soa(Message, []) ->
-  Message;
-append_soa(Message, [Answer|Rest]) ->
-  append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+    Message;
+append_soa(Message, [Answer | Rest]) ->
+    append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+
 append_soa(Message, ?DNS_TYPE_SOA_NUMBER, Answer, _) ->
-  Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
-  Message#dns_message{anc = length(Answers), answers = Answers};
+    Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
+    Message#dns_message{anc = length(Answers), answers = Answers};
 append_soa(Message, _, _, []) ->
-  Message;
-append_soa(Message, _, _, [Answer|Rest]) ->
-  append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+    Message;
+append_soa(Message, _, _, [Answer | Rest]) ->
+    append_soa(Message, Answer#dns_rr.type, Answer, Rest).

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -17,8 +17,7 @@
 
 -include_lib("dns_erlang/include/dns.hrl").
 
--export([is_enabled/2,
-         optionally_append_soa/1]).
+-export([is_enabled/2, optionally_append_soa/1]).
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -21,38 +21,33 @@
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->
-    MatchingMetadata =
-        lists:filter(fun(MetadataRow) ->
-                        [_Id, _DomainId, Kind, Content] = MetadataRow,
-                        {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
-                        AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
-                     end,
-                     Metadata),
-    length(MatchingMetadata) > 0.
+  MatchingMetadata = lists:filter(
+                       fun(MetadataRow) ->
+                           [_Id, _DomainId, Kind, Content] = MetadataRow,
+                           {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
+                           AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
+                       end, Metadata),
+  length(MatchingMetadata) > 0.
 
 %% If the message is an AXFR request then append the SOA record.
 optionally_append_soa(Message) ->
-    optionally_append_soa(Message, Message#dns_message.questions).
-
+  optionally_append_soa(Message, Message#dns_message.questions).
 optionally_append_soa(Message, []) ->
-    Message;
-optionally_append_soa(Message, [Q | Rest]) ->
-    case Q#dns_query.type of
-        ?DNS_TYPE_AXFR_NUMBER ->
-            append_soa(Message, Message#dns_message.answers);
-        _ ->
-            optionally_append_soa(Message, Rest)
-    end.
+  Message;
+optionally_append_soa(Message, [Q|Rest]) ->
+  case Q#dns_query.type of 
+    ?DNS_TYPE_AXFR_NUMBER -> append_soa(Message, Message#dns_message.answers);
+    _ -> optionally_append_soa(Message, Rest)
+  end.
 
 append_soa(Message, []) ->
-    Message;
-append_soa(Message, [Answer | Rest]) ->
-    append_soa(Message, Answer#dns_rr.type, Answer, Rest).
-
+  Message;
+append_soa(Message, [Answer|Rest]) ->
+  append_soa(Message, Answer#dns_rr.type, Answer, Rest).
 append_soa(Message, ?DNS_TYPE_SOA_NUMBER, Answer, _) ->
-    Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
-    Message#dns_message{anc = length(Answers), answers = Answers};
+  Answers = lists:flatten(Message#dns_message.answers ++ [Answer]),
+  Message#dns_message{anc = length(Answers), answers = Answers};
 append_soa(Message, _, _, []) ->
-    Message;
-append_soa(Message, _, _, [Answer | Rest]) ->
-    append_soa(Message, Answer#dns_rr.type, Answer, Rest).
+  Message;
+append_soa(Message, _, _, [Answer|Rest]) ->
+  append_soa(Message, Answer#dns_rr.type, Answer, Rest).

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -17,7 +17,8 @@
 
 -include_lib("dns_erlang/include/dns.hrl").
 
--export([is_enabled/2, optionally_append_soa/1]).
+-export([is_enabled/2,
+         optionally_append_soa/1]).
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -15,114 +15,89 @@
 %% @doc Provide application-wide configuration access.
 -module(erldns_config).
 
--export([
-         get_servers/0,
+-export([get_servers/0,
          get_address/1,
          get_port/0,
-         get_num_workers/0
-        ]).
--export([
-         use_root_hints/0
-        ]).
--export([
-         packet_cache_enabled/0,
+         get_num_workers/0]).
+-export([use_root_hints/0]).
+-export([packet_cache_enabled/0,
          packet_cache_default_ttl/0,
          packet_cache_sweep_interval/0,
-         packet_cache_ttl_overrides/0
-        ]).
--export([
-         zone_server_env/0,
+         packet_cache_ttl_overrides/0]).
+-export([zone_server_env/0,
          zone_server_max_processes/0,
          zone_server_protocol/0,
          zone_server_host/0,
-         zone_server_port/0
-        ]).
--export([
-         websocket_env/0,
+         zone_server_port/0]).
+-export([websocket_env/0,
          websocket_protocol/0,
          websocket_host/0,
          websocket_port/0,
          websocket_path/0,
-         websocket_url/0
-        ]).
-
--export([
-         storage_env/0,
+         websocket_url/0]).
+-export([storage_env/0,
          storage_type/0,
          storage_user/0,
          storage_pass/0,
          storage_host/0,
          storage_port/0,
-         storage_dir/0
-        ]).
-
--export([
-         keyget/2,
-         keyget/3
-        ]).
+         storage_dir/0]).
+-export([keyget/2, keyget/3]).
 
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
--define(DEFAULT_IPV4_ADDRESS, {127,0,0,1}).
--define(DEFAULT_IPV6_ADDRESS, {0,0,0,0,0,0,0,1}).
+-define(DEFAULT_IPV4_ADDRESS, {127, 0, 0, 1}).
+-define(DEFAULT_IPV6_ADDRESS, {0, 0, 0, 0, 0, 0, 0, 1}).
 -define(DEFAULT_PORT, 53).
 -define(DEFAULT_NUM_WORKERS, 10).
 -define(DEFAULT_CACHE_TTL, 20).
--define(DEFAULT_SWEEP_INTERVAL, 1000 * 60 * 3). % Every 3 minutes
+-define(DEFAULT_SWEEP_INTERVAL,
+        1000 * 60 * 3). % Every 3 minutes
 -define(DEFAULT_ZONE_SERVER_PORT, 443).
 -define(DEFAULT_WEBSOCKET_PATH, "/ws").
 
 get_servers() ->
-  case application:get_env(erldns, servers) of
-    {ok, Servers} ->
-      lists:map(
-        fun(Server) ->
-            [
-             {name, keyget(name, Server)},
-             {address, parse_address(keyget(address, Server))},
-             {port, keyget(port, Server)},
-             {family, keyget(family, Server)},
-             {processes, keyget(processes, Server, 1)}
-            ]
-        end, Servers);
-    undefined ->
-        lists:map(fun (Family) ->
-            [{name, Family},
-             {address, get_address(Family)},
-             {port, get_port()},
-             {family, Family}]
-        end, [inet, inet6])
-  end.
+    case application:get_env(erldns, servers) of
+        {ok, Servers} ->
+            lists:map(fun(Server) ->
+                         [{name, keyget(name, Server)},
+                          {address, parse_address(keyget(address, Server))},
+                          {port, keyget(port, Server)},
+                          {family, keyget(family, Server)},
+                          {processes, keyget(processes, Server, 1)}]
+                      end,
+                      Servers);
+        undefined ->
+            lists:map(fun(Family) -> [{name, Family}, {address, get_address(Family)}, {port, get_port()}, {family, Family}] end, [inet, inet6])
+    end.
 
 -ifdef(TEST).
+
 get_servers_undefined_test() ->
-  ?assertEqual([
-    [{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
-    [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]
-  ], get_servers()).
+    ?assertEqual([[{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
+                  [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]],
+                 get_servers()).
 
 get_servers_empty_list_test() ->
-  application:set_env(erldns, servers, []),
-  ?assertEqual([], get_servers()).
-
+    application:set_env(erldns, servers, []),
+    ?assertEqual([], get_servers()).
 
 get_servers_single_server_test() ->
-  application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
-  ?assertEqual([
-                [{name, example}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}]
-               ], get_servers()).
+    application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
+    ?assertEqual([[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}]], get_servers()).
 
 get_servers_multiple_servers_test() ->
-  application:set_env(erldns, servers, [
-                                        [{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
-                                        [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]
-                                       ]),
-  ?assertEqual([
-                [{name, example_inet}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}],
-                [{name, example_inet6}, {address, {0,0,0,0,0,0,0,1}}, {port, 8053}, {family, inet6}, {processes, 1}]
-               ], get_servers()).
+    application:set_env(erldns,
+                        servers,
+                        [[{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
+                         [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]]),
+    ?assertEqual([[{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
+                  [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]],
+                 get_servers()).
 
 -endif.
 
@@ -133,157 +108,161 @@ get_servers_multiple_servers_test() ->
 %% IPv6 default: ::1
 -spec get_address(inet | inet6) -> inet:ip_address().
 get_address(inet) ->
-  case application:get_env(erldns, inet4) of
-    {ok, Address} -> parse_address(Address);
-    _ -> ?DEFAULT_IPV4_ADDRESS
-  end;
+    case application:get_env(erldns, inet4) of
+        {ok, Address} ->
+            parse_address(Address);
+        _ ->
+            ?DEFAULT_IPV4_ADDRESS
+    end;
 get_address(inet6) ->
-  case application:get_env(erldns, inet6) of
-    {ok, Address} -> parse_address(Address);
-    _ -> ?DEFAULT_IPV6_ADDRESS
-  end.
+    case application:get_env(erldns, inet6) of
+        {ok, Address} ->
+            parse_address(Address);
+        _ ->
+            ?DEFAULT_IPV6_ADDRESS
+    end.
 
 %% @doc The the port that the DNS server should listen on.
 %%
 %% Default: 53
 -spec get_port() -> inet:port_number().
 get_port() ->
-  case application:get_env(erldns, port) of
-    {ok, Port} -> Port;
-    _ -> ?DEFAULT_PORT
-  end.
+    case application:get_env(erldns, port) of
+        {ok, Port} ->
+            Port;
+        _ ->
+            ?DEFAULT_PORT
+    end.
 
 %% @doc Get the number of workers to run for handling DNS requests.
 %%
 %% Default: 10
 -spec get_num_workers() -> non_neg_integer().
 get_num_workers() ->
-  case application:get_env(erldns, num_workers) of
-    {ok, NumWorkers} -> NumWorkers;
-    _ -> ?DEFAULT_NUM_WORKERS
-  end.
+    case application:get_env(erldns, num_workers) of
+        {ok, NumWorkers} ->
+            NumWorkers;
+        _ ->
+            ?DEFAULT_NUM_WORKERS
+    end.
 
 -spec use_root_hints() -> boolean().
 use_root_hints() ->
-  case application:get_env(erldns, use_root_hints) of
-    {ok, Flag} -> Flag;
-    _ -> true
-  end.
+    case application:get_env(erldns, use_root_hints) of
+        {ok, Flag} ->
+            Flag;
+        _ ->
+            true
+    end.
 
 packet_cache() ->
-  application:get_env(erldns, packet_cache, []).
+    application:get_env(erldns, packet_cache, []).
 
 packet_cache_enabled() ->
-  keyget(enabled, packet_cache(), true).
+    keyget(enabled, packet_cache(), true).
 
 packet_cache_default_ttl() ->
-  keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
+    keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
 
 packet_cache_sweep_interval() ->
-  keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
+    keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
 
 packet_cache_ttl_overrides() ->
-  keyget(ttl_overrides, packet_cache(), []).
+    keyget(ttl_overrides, packet_cache(), []).
 
 keyget(Key, Data) ->
-  keyget(Key, Data, undefined).
+    keyget(Key, Data, undefined).
 
 keyget(Key, Data, Default) ->
-  case lists:keyfind(Key, 1, Data) of
-    false ->
-      Default;
-    {Key, Value} ->
-      Value
-  end.
-
+    case lists:keyfind(Key, 1, Data) of
+        false ->
+            Default;
+        {Key, Value} ->
+            Value
+    end.
 
 %% Zone server configuration
 %% TODO: remove as zone server client logic has been removed
 zone_server_env() ->
-  {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
-  ZoneServerEnv.
+    {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
+    ZoneServerEnv.
 
 zone_server_max_processes() ->
-  keyget(max_processes, zone_server_env(), 16).
+    keyget(max_processes, zone_server_env(), 16).
 
 zone_server_protocol() ->
-  keyget(protocol, zone_server_env(), "https").
+    keyget(protocol, zone_server_env(), "https").
 
 zone_server_host() ->
-  keyget(host, zone_server_env(), "localhost").
+    keyget(host, zone_server_env(), "localhost").
 
 zone_server_port() ->
-  keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
+    keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
 
 websocket_env() ->
-  keyget(websocket, zone_server_env(), []).
+    keyget(websocket, zone_server_env(), []).
 
 websocket_protocol() ->
-  keyget(protocol, websocket_env(), wss).
+    keyget(protocol, websocket_env(), wss).
 
 websocket_host() ->
-  keyget(host, websocket_env(), zone_server_host()).
+    keyget(host, websocket_env(), zone_server_host()).
 
 websocket_port() ->
-  keyget(port, websocket_env(), zone_server_port()).
+    keyget(port, websocket_env(), zone_server_port()).
 
 websocket_path() ->
-  keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
+    keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
 
 websocket_url() ->
-  atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
+    atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
 
 %% Storage configuration
 
 storage_type() ->
-  storage_get(type).
+    storage_get(type).
 
 storage_dir() ->
-  storage_get(dir).
+    storage_get(dir).
 
 storage_user() ->
-  storage_get(user).
+    storage_get(user).
 
 storage_pass() ->
-  storage_get(pass).
+    storage_get(pass).
 
 storage_host() ->
-  storage_get(host).
+    storage_get(host).
 
 storage_port() ->
-  storage_get(port).
+    storage_get(port).
 
 storage_env() ->
-  get_env(storage).
+    get_env(storage).
 
 storage_get(Key) ->
-  get_env_value(Key, storage).
+    get_env_value(Key, storage).
 
 % Private functions
 
 parse_address(Address) when is_list(Address) ->
-  {ok, Tuple} = inet_parse:address(Address),
-  Tuple;
-parse_address(Address) -> Address.
+    {ok, Tuple} = inet_parse:address(Address),
+    Tuple;
+parse_address(Address) ->
+    Address.
 
 get_env_value(Key, Name) ->
-  case lists:keyfind(Key, 1, get_env(Name)) of
-    false ->
-      undefined;
-    {Key, Value} ->
-      Value
-  end.
-
+    case lists:keyfind(Key, 1, get_env(Name)) of
+        false ->
+            undefined;
+        {Key, Value} ->
+            Value
+    end.
 
 get_env(storage) ->
-  case application:get_env(erldns, storage) of
-    undefined ->
-      [{type, erldns_storage_json},
-       {dir, undefined},
-       {user, undefined},
-       {pass, undefined},
-       {host, undefined},
-       {port, undefined}];
-    {ok, Env} ->
-      Env
-  end.
+    case application:get_env(erldns, storage) of
+        undefined ->
+            [{type, erldns_storage_json}, {dir, undefined}, {user, undefined}, {pass, undefined}, {host, undefined}, {port, undefined}];
+        {ok, Env} ->
+            Env
+    end.

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -15,89 +15,114 @@
 %% @doc Provide application-wide configuration access.
 -module(erldns_config).
 
--export([get_servers/0,
+-export([
+         get_servers/0,
          get_address/1,
          get_port/0,
-         get_num_workers/0]).
--export([use_root_hints/0]).
--export([packet_cache_enabled/0,
+         get_num_workers/0
+        ]).
+-export([
+         use_root_hints/0
+        ]).
+-export([
+         packet_cache_enabled/0,
          packet_cache_default_ttl/0,
          packet_cache_sweep_interval/0,
-         packet_cache_ttl_overrides/0]).
--export([zone_server_env/0,
+         packet_cache_ttl_overrides/0
+        ]).
+-export([
+         zone_server_env/0,
          zone_server_max_processes/0,
          zone_server_protocol/0,
          zone_server_host/0,
-         zone_server_port/0]).
--export([websocket_env/0,
+         zone_server_port/0
+        ]).
+-export([
+         websocket_env/0,
          websocket_protocol/0,
          websocket_host/0,
          websocket_port/0,
          websocket_path/0,
-         websocket_url/0]).
--export([storage_env/0,
+         websocket_url/0
+        ]).
+
+-export([
+         storage_env/0,
          storage_type/0,
          storage_user/0,
          storage_pass/0,
          storage_host/0,
          storage_port/0,
-         storage_dir/0]).
--export([keyget/2, keyget/3]).
+         storage_dir/0
+        ]).
+
+-export([
+         keyget/2,
+         keyget/3
+        ]).
 
 -ifdef(TEST).
-
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
--define(DEFAULT_IPV4_ADDRESS, {127, 0, 0, 1}).
--define(DEFAULT_IPV6_ADDRESS, {0, 0, 0, 0, 0, 0, 0, 1}).
+-define(DEFAULT_IPV4_ADDRESS, {127,0,0,1}).
+-define(DEFAULT_IPV6_ADDRESS, {0,0,0,0,0,0,0,1}).
 -define(DEFAULT_PORT, 53).
 -define(DEFAULT_NUM_WORKERS, 10).
 -define(DEFAULT_CACHE_TTL, 20).
--define(DEFAULT_SWEEP_INTERVAL,
-        1000 * 60 * 3). % Every 3 minutes
+-define(DEFAULT_SWEEP_INTERVAL, 1000 * 60 * 3). % Every 3 minutes
 -define(DEFAULT_ZONE_SERVER_PORT, 443).
 -define(DEFAULT_WEBSOCKET_PATH, "/ws").
 
 get_servers() ->
-    case application:get_env(erldns, servers) of
-        {ok, Servers} ->
-            lists:map(fun(Server) ->
-                         [{name, keyget(name, Server)},
-                          {address, parse_address(keyget(address, Server))},
-                          {port, keyget(port, Server)},
-                          {family, keyget(family, Server)},
-                          {processes, keyget(processes, Server, 1)}]
-                      end,
-                      Servers);
-        undefined ->
-            lists:map(fun(Family) -> [{name, Family}, {address, get_address(Family)}, {port, get_port()}, {family, Family}] end, [inet, inet6])
-    end.
+  case application:get_env(erldns, servers) of
+    {ok, Servers} ->
+      lists:map(
+        fun(Server) ->
+            [
+             {name, keyget(name, Server)},
+             {address, parse_address(keyget(address, Server))},
+             {port, keyget(port, Server)},
+             {family, keyget(family, Server)},
+             {processes, keyget(processes, Server, 1)}
+            ]
+        end, Servers);
+    undefined ->
+        lists:map(fun (Family) ->
+            [{name, Family},
+             {address, get_address(Family)},
+             {port, get_port()},
+             {family, Family}]
+        end, [inet, inet6])
+  end.
 
 -ifdef(TEST).
-
 get_servers_undefined_test() ->
-    ?assertEqual([[{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
-                  [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]],
-                 get_servers()).
+  ?assertEqual([
+    [{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
+    [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]
+  ], get_servers()).
 
 get_servers_empty_list_test() ->
-    application:set_env(erldns, servers, []),
-    ?assertEqual([], get_servers()).
+  application:set_env(erldns, servers, []),
+  ?assertEqual([], get_servers()).
+
 
 get_servers_single_server_test() ->
-    application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
-    ?assertEqual([[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}]], get_servers()).
+  application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
+  ?assertEqual([
+                [{name, example}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}]
+               ], get_servers()).
 
 get_servers_multiple_servers_test() ->
-    application:set_env(erldns,
-                        servers,
-                        [[{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
-                         [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]]),
-    ?assertEqual([[{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
-                  [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]],
-                 get_servers()).
+  application:set_env(erldns, servers, [
+                                        [{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
+                                        [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]
+                                       ]),
+  ?assertEqual([
+                [{name, example_inet}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}],
+                [{name, example_inet6}, {address, {0,0,0,0,0,0,0,1}}, {port, 8053}, {family, inet6}, {processes, 1}]
+               ], get_servers()).
 
 -endif.
 
@@ -108,161 +133,157 @@ get_servers_multiple_servers_test() ->
 %% IPv6 default: ::1
 -spec get_address(inet | inet6) -> inet:ip_address().
 get_address(inet) ->
-    case application:get_env(erldns, inet4) of
-        {ok, Address} ->
-            parse_address(Address);
-        _ ->
-            ?DEFAULT_IPV4_ADDRESS
-    end;
+  case application:get_env(erldns, inet4) of
+    {ok, Address} -> parse_address(Address);
+    _ -> ?DEFAULT_IPV4_ADDRESS
+  end;
 get_address(inet6) ->
-    case application:get_env(erldns, inet6) of
-        {ok, Address} ->
-            parse_address(Address);
-        _ ->
-            ?DEFAULT_IPV6_ADDRESS
-    end.
+  case application:get_env(erldns, inet6) of
+    {ok, Address} -> parse_address(Address);
+    _ -> ?DEFAULT_IPV6_ADDRESS
+  end.
 
 %% @doc The the port that the DNS server should listen on.
 %%
 %% Default: 53
 -spec get_port() -> inet:port_number().
 get_port() ->
-    case application:get_env(erldns, port) of
-        {ok, Port} ->
-            Port;
-        _ ->
-            ?DEFAULT_PORT
-    end.
+  case application:get_env(erldns, port) of
+    {ok, Port} -> Port;
+    _ -> ?DEFAULT_PORT
+  end.
 
 %% @doc Get the number of workers to run for handling DNS requests.
 %%
 %% Default: 10
 -spec get_num_workers() -> non_neg_integer().
 get_num_workers() ->
-    case application:get_env(erldns, num_workers) of
-        {ok, NumWorkers} ->
-            NumWorkers;
-        _ ->
-            ?DEFAULT_NUM_WORKERS
-    end.
+  case application:get_env(erldns, num_workers) of
+    {ok, NumWorkers} -> NumWorkers;
+    _ -> ?DEFAULT_NUM_WORKERS
+  end.
 
 -spec use_root_hints() -> boolean().
 use_root_hints() ->
-    case application:get_env(erldns, use_root_hints) of
-        {ok, Flag} ->
-            Flag;
-        _ ->
-            true
-    end.
+  case application:get_env(erldns, use_root_hints) of
+    {ok, Flag} -> Flag;
+    _ -> true
+  end.
 
 packet_cache() ->
-    application:get_env(erldns, packet_cache, []).
+  application:get_env(erldns, packet_cache, []).
 
 packet_cache_enabled() ->
-    keyget(enabled, packet_cache(), true).
+  keyget(enabled, packet_cache(), true).
 
 packet_cache_default_ttl() ->
-    keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
+  keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
 
 packet_cache_sweep_interval() ->
-    keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
+  keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
 
 packet_cache_ttl_overrides() ->
-    keyget(ttl_overrides, packet_cache(), []).
+  keyget(ttl_overrides, packet_cache(), []).
 
 keyget(Key, Data) ->
-    keyget(Key, Data, undefined).
+  keyget(Key, Data, undefined).
 
 keyget(Key, Data, Default) ->
-    case lists:keyfind(Key, 1, Data) of
-        false ->
-            Default;
-        {Key, Value} ->
-            Value
-    end.
+  case lists:keyfind(Key, 1, Data) of
+    false ->
+      Default;
+    {Key, Value} ->
+      Value
+  end.
+
 
 %% Zone server configuration
 %% TODO: remove as zone server client logic has been removed
 zone_server_env() ->
-    {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
-    ZoneServerEnv.
+  {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
+  ZoneServerEnv.
 
 zone_server_max_processes() ->
-    keyget(max_processes, zone_server_env(), 16).
+  keyget(max_processes, zone_server_env(), 16).
 
 zone_server_protocol() ->
-    keyget(protocol, zone_server_env(), "https").
+  keyget(protocol, zone_server_env(), "https").
 
 zone_server_host() ->
-    keyget(host, zone_server_env(), "localhost").
+  keyget(host, zone_server_env(), "localhost").
 
 zone_server_port() ->
-    keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
+  keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
 
 websocket_env() ->
-    keyget(websocket, zone_server_env(), []).
+  keyget(websocket, zone_server_env(), []).
 
 websocket_protocol() ->
-    keyget(protocol, websocket_env(), wss).
+  keyget(protocol, websocket_env(), wss).
 
 websocket_host() ->
-    keyget(host, websocket_env(), zone_server_host()).
+  keyget(host, websocket_env(), zone_server_host()).
 
 websocket_port() ->
-    keyget(port, websocket_env(), zone_server_port()).
+  keyget(port, websocket_env(), zone_server_port()).
 
 websocket_path() ->
-    keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
+  keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
 
 websocket_url() ->
-    atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
+  atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
 
 %% Storage configuration
 
 storage_type() ->
-    storage_get(type).
+  storage_get(type).
 
 storage_dir() ->
-    storage_get(dir).
+  storage_get(dir).
 
 storage_user() ->
-    storage_get(user).
+  storage_get(user).
 
 storage_pass() ->
-    storage_get(pass).
+  storage_get(pass).
 
 storage_host() ->
-    storage_get(host).
+  storage_get(host).
 
 storage_port() ->
-    storage_get(port).
+  storage_get(port).
 
 storage_env() ->
-    get_env(storage).
+  get_env(storage).
 
 storage_get(Key) ->
-    get_env_value(Key, storage).
+  get_env_value(Key, storage).
 
 % Private functions
 
 parse_address(Address) when is_list(Address) ->
-    {ok, Tuple} = inet_parse:address(Address),
-    Tuple;
-parse_address(Address) ->
-    Address.
+  {ok, Tuple} = inet_parse:address(Address),
+  Tuple;
+parse_address(Address) -> Address.
 
 get_env_value(Key, Name) ->
-    case lists:keyfind(Key, 1, get_env(Name)) of
-        false ->
-            undefined;
-        {Key, Value} ->
-            Value
-    end.
+  case lists:keyfind(Key, 1, get_env(Name)) of
+    false ->
+      undefined;
+    {Key, Value} ->
+      Value
+  end.
+
 
 get_env(storage) ->
-    case application:get_env(erldns, storage) of
-        undefined ->
-            [{type, erldns_storage_json}, {dir, undefined}, {user, undefined}, {pass, undefined}, {host, undefined}, {port, undefined}];
-        {ok, Env} ->
-            Env
-    end.
+  case application:get_env(erldns, storage) of
+    undefined ->
+      [{type, erldns_storage_json},
+       {dir, undefined},
+       {user, undefined},
+       {pass, undefined},
+       {host, undefined},
+       {port, undefined}];
+    {ok, Env} ->
+      Env
+  end.

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -42,7 +42,8 @@
          storage_host/0,
          storage_port/0,
          storage_dir/0]).
--export([keyget/2, keyget/3]).
+-export([keyget/2,
+         keyget/3]).
 
 -ifdef(TEST).
 

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -42,8 +42,7 @@
          storage_host/0,
          storage_port/0,
          storage_dir/0]).
--export([keyget/2,
-         keyget/3]).
+-export([keyget/2, keyget/3]).
 
 -ifdef(TEST).
 

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -31,7 +31,6 @@
          packet_cache_ttl_overrides/0
         ]).
 -export([
-         zone_delegates/0,
          zone_server_env/0,
          zone_server_max_processes/0,
          zone_server_protocol/0,
@@ -200,10 +199,6 @@ keyget(Key, Data, Default) ->
 
 %% Zone server configuration
 %% TODO: remove as zone server client logic has been removed
-
-zone_delegates() ->
-    application:get_env(erldns, zone_delegates, []).
-
 zone_server_env() ->
   {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
   ZoneServerEnv.

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -15,58 +15,44 @@
 %% @doc Provide application-wide configuration access.
 -module(erldns_config).
 
--export([
-         get_servers/0,
+-export([get_servers/0,
          get_address/1,
          get_port/0,
-         get_num_workers/0
-        ]).
--export([
-         use_root_hints/0
-        ]).
--export([
-         packet_cache_enabled/0,
+         get_num_workers/0]).
+-export([use_root_hints/0]).
+-export([packet_cache_enabled/0,
          packet_cache_default_ttl/0,
          packet_cache_sweep_interval/0,
-         packet_cache_ttl_overrides/0
-        ]).
--export([
-         zone_server_env/0,
+         packet_cache_ttl_overrides/0]).
+-export([zone_server_env/0,
          zone_server_max_processes/0,
          zone_server_protocol/0,
          zone_server_host/0,
-         zone_server_port/0
-        ]).
--export([
-         websocket_env/0,
+         zone_server_port/0]).
+-export([websocket_env/0,
          websocket_protocol/0,
          websocket_host/0,
          websocket_port/0,
          websocket_path/0,
-         websocket_url/0
-        ]).
-
--export([
-         storage_env/0,
+         websocket_url/0]).
+-export([storage_env/0,
          storage_type/0,
          storage_user/0,
          storage_pass/0,
          storage_host/0,
          storage_port/0,
-         storage_dir/0
-        ]).
-
--export([
-         keyget/2,
-         keyget/3
-        ]).
+         storage_dir/0]).
+-export([keyget/2,
+         keyget/3]).
 
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
--define(DEFAULT_IPV4_ADDRESS, {127,0,0,1}).
--define(DEFAULT_IPV6_ADDRESS, {0,0,0,0,0,0,0,1}).
+-define(DEFAULT_IPV4_ADDRESS, {127, 0, 0, 1}).
+-define(DEFAULT_IPV6_ADDRESS, {0, 0, 0, 0, 0, 0, 0, 1}).
 -define(DEFAULT_PORT, 53).
 -define(DEFAULT_NUM_WORKERS, 10).
 -define(DEFAULT_CACHE_TTL, 20).
@@ -75,54 +61,43 @@
 -define(DEFAULT_WEBSOCKET_PATH, "/ws").
 
 get_servers() ->
-  case application:get_env(erldns, servers) of
-    {ok, Servers} ->
-      lists:map(
-        fun(Server) ->
-            [
-             {name, keyget(name, Server)},
-             {address, parse_address(keyget(address, Server))},
-             {port, keyget(port, Server)},
-             {family, keyget(family, Server)},
-             {processes, keyget(processes, Server, 1)}
-            ]
-        end, Servers);
-    undefined ->
-        lists:map(fun (Family) ->
-            [{name, Family},
-             {address, get_address(Family)},
-             {port, get_port()},
-             {family, Family}]
-        end, [inet, inet6])
-  end.
+    case application:get_env(erldns, servers) of
+        {ok, Servers} ->
+            lists:map(fun(Server) ->
+                         [{name, keyget(name, Server)},
+                          {address, parse_address(keyget(address, Server))},
+                          {port, keyget(port, Server)},
+                          {family, keyget(family, Server)},
+                          {processes, keyget(processes, Server, 1)}]
+                      end,
+                      Servers);
+        undefined ->
+            lists:map(fun(Family) -> [{name, Family}, {address, get_address(Family)}, {port, get_port()}, {family, Family}] end, [inet, inet6])
+    end.
 
 -ifdef(TEST).
+
 get_servers_undefined_test() ->
-  ?assertEqual([
-    [{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
-    [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]
-  ], get_servers()).
+    ?assertEqual([[{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
+                  [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]],
+                 get_servers()).
 
 get_servers_empty_list_test() ->
-  application:set_env(erldns, servers, []),
-  ?assertEqual([], get_servers()).
-
+    application:set_env(erldns, servers, []),
+    ?assertEqual([], get_servers()).
 
 get_servers_single_server_test() ->
-  application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
-  ?assertEqual([
-                [{name, example}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}]
-               ], get_servers()).
+    application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
+    ?assertEqual([[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}]], get_servers()).
 
 get_servers_multiple_servers_test() ->
-  application:set_env(erldns, servers, [
-                                        [{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
-                                        [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]
-                                       ]),
-  ?assertEqual([
-                [{name, example_inet}, {address, {127,0,0,1}}, {port, 8053}, {family, inet}, {processes, 1}],
-                [{name, example_inet6}, {address, {0,0,0,0,0,0,0,1}}, {port, 8053}, {family, inet6}, {processes, 1}]
-               ], get_servers()).
+    application:set_env(erldns,
+                        servers,
+                        [[{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
+                         [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]]),
+    ?assertEqual([[{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
+                  [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]],
+                 get_servers()).
 
 -endif.
 
@@ -133,157 +108,161 @@ get_servers_multiple_servers_test() ->
 %% IPv6 default: ::1
 -spec get_address(inet | inet6) -> inet:ip_address().
 get_address(inet) ->
-  case application:get_env(erldns, inet4) of
-    {ok, Address} -> parse_address(Address);
-    _ -> ?DEFAULT_IPV4_ADDRESS
-  end;
+    case application:get_env(erldns, inet4) of
+        {ok, Address} ->
+            parse_address(Address);
+        _ ->
+            ?DEFAULT_IPV4_ADDRESS
+    end;
 get_address(inet6) ->
-  case application:get_env(erldns, inet6) of
-    {ok, Address} -> parse_address(Address);
-    _ -> ?DEFAULT_IPV6_ADDRESS
-  end.
+    case application:get_env(erldns, inet6) of
+        {ok, Address} ->
+            parse_address(Address);
+        _ ->
+            ?DEFAULT_IPV6_ADDRESS
+    end.
 
 %% @doc The the port that the DNS server should listen on.
 %%
 %% Default: 53
 -spec get_port() -> inet:port_number().
 get_port() ->
-  case application:get_env(erldns, port) of
-    {ok, Port} -> Port;
-    _ -> ?DEFAULT_PORT
-  end.
+    case application:get_env(erldns, port) of
+        {ok, Port} ->
+            Port;
+        _ ->
+            ?DEFAULT_PORT
+    end.
 
 %% @doc Get the number of workers to run for handling DNS requests.
 %%
 %% Default: 10
 -spec get_num_workers() -> non_neg_integer().
 get_num_workers() ->
-  case application:get_env(erldns, num_workers) of
-    {ok, NumWorkers} -> NumWorkers;
-    _ -> ?DEFAULT_NUM_WORKERS
-  end.
+    case application:get_env(erldns, num_workers) of
+        {ok, NumWorkers} ->
+            NumWorkers;
+        _ ->
+            ?DEFAULT_NUM_WORKERS
+    end.
 
 -spec use_root_hints() -> boolean().
 use_root_hints() ->
-  case application:get_env(erldns, use_root_hints) of
-    {ok, Flag} -> Flag;
-    _ -> true
-  end.
+    case application:get_env(erldns, use_root_hints) of
+        {ok, Flag} ->
+            Flag;
+        _ ->
+            true
+    end.
 
 packet_cache() ->
-  application:get_env(erldns, packet_cache, []).
+    application:get_env(erldns, packet_cache, []).
 
 packet_cache_enabled() ->
-  keyget(enabled, packet_cache(), true).
+    keyget(enabled, packet_cache(), true).
 
 packet_cache_default_ttl() ->
-  keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
+    keyget(default_ttl, packet_cache(), ?DEFAULT_CACHE_TTL).
 
 packet_cache_sweep_interval() ->
-  keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
+    keyget(sweep_interval, packet_cache(), ?DEFAULT_SWEEP_INTERVAL).
 
 packet_cache_ttl_overrides() ->
-  keyget(ttl_overrides, packet_cache(), []).
+    keyget(ttl_overrides, packet_cache(), []).
 
 keyget(Key, Data) ->
-  keyget(Key, Data, undefined).
+    keyget(Key, Data, undefined).
 
 keyget(Key, Data, Default) ->
-  case lists:keyfind(Key, 1, Data) of
-    false ->
-      Default;
-    {Key, Value} ->
-      Value
-  end.
-
+    case lists:keyfind(Key, 1, Data) of
+        false ->
+            Default;
+        {Key, Value} ->
+            Value
+    end.
 
 %% Zone server configuration
 %% TODO: remove as zone server client logic has been removed
 zone_server_env() ->
-  {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
-  ZoneServerEnv.
+    {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
+    ZoneServerEnv.
 
 zone_server_max_processes() ->
-  keyget(max_processes, zone_server_env(), 16).
+    keyget(max_processes, zone_server_env(), 16).
 
 zone_server_protocol() ->
-  keyget(protocol, zone_server_env(), "https").
+    keyget(protocol, zone_server_env(), "https").
 
 zone_server_host() ->
-  keyget(host, zone_server_env(), "localhost").
+    keyget(host, zone_server_env(), "localhost").
 
 zone_server_port() ->
-  keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
+    keyget(port, zone_server_env(), ?DEFAULT_ZONE_SERVER_PORT).
 
 websocket_env() ->
-  keyget(websocket, zone_server_env(), []).
+    keyget(websocket, zone_server_env(), []).
 
 websocket_protocol() ->
-  keyget(protocol, websocket_env(), wss).
+    keyget(protocol, websocket_env(), wss).
 
 websocket_host() ->
-  keyget(host, websocket_env(), zone_server_host()).
+    keyget(host, websocket_env(), zone_server_host()).
 
 websocket_port() ->
-  keyget(port, websocket_env(), zone_server_port()).
+    keyget(port, websocket_env(), zone_server_port()).
 
 websocket_path() ->
-  keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
+    keyget(path, websocket_env(), ?DEFAULT_WEBSOCKET_PATH).
 
 websocket_url() ->
-  atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
+    atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
 
 %% Storage configuration
 
 storage_type() ->
-  storage_get(type).
+    storage_get(type).
 
 storage_dir() ->
-  storage_get(dir).
+    storage_get(dir).
 
 storage_user() ->
-  storage_get(user).
+    storage_get(user).
 
 storage_pass() ->
-  storage_get(pass).
+    storage_get(pass).
 
 storage_host() ->
-  storage_get(host).
+    storage_get(host).
 
 storage_port() ->
-  storage_get(port).
+    storage_get(port).
 
 storage_env() ->
-  get_env(storage).
+    get_env(storage).
 
 storage_get(Key) ->
-  get_env_value(Key, storage).
+    get_env_value(Key, storage).
 
 % Private functions
 
 parse_address(Address) when is_list(Address) ->
-  {ok, Tuple} = inet_parse:address(Address),
-  Tuple;
-parse_address(Address) -> Address.
+    {ok, Tuple} = inet_parse:address(Address),
+    Tuple;
+parse_address(Address) ->
+    Address.
 
 get_env_value(Key, Name) ->
-  case lists:keyfind(Key, 1, get_env(Name)) of
-    false ->
-      undefined;
-    {Key, Value} ->
-      Value
-  end.
-
+    case lists:keyfind(Key, 1, get_env(Name)) of
+        false ->
+            undefined;
+        {Key, Value} ->
+            Value
+    end.
 
 get_env(storage) ->
-  case application:get_env(erldns, storage) of
-    undefined ->
-      [{type, erldns_storage_json},
-       {dir, undefined},
-       {user, undefined},
-       {pass, undefined},
-       {host, undefined},
-       {port, undefined}];
-    {ok, Env} ->
-      Env
-  end.
+    case application:get_env(erldns, storage) of
+        undefined ->
+            [{type, erldns_storage_json}, {dir, undefined}, {user, undefined}, {pass, undefined}, {host, undefined}, {port, undefined}];
+        {ok, Env} ->
+            Env
+    end.

--- a/src/erldns_decoder.erl
+++ b/src/erldns_decoder.erl
@@ -23,20 +23,18 @@
 %% @doc Decode the binary data into its Erlang representation.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an
+%% configuration, then this function should never throw an 
 %% exception.
--spec decode_message(dns:message_bin()) -> {dns:decode_error(), dns:message() | undefined, binary()} | dns:message().
+-spec decode_message(dns:message_bin()) -> {dns:decode_error(), dns:message() | 'undefined', binary()} | dns:message().
 decode_message(Bin) ->
-    case application:get_env(erldns, catch_exceptions) of
-        {ok, false} ->
-            dns:decode_message(Bin);
-        _ ->
-            try dns:decode_message(Bin) of
-                M ->
-                    M
-            catch
-                Exception:Reason ->
-                    erldns_events:notify({?MODULE, decode_message_error, {Exception, Reason, Bin}}),
-                    {formerr, Reason, Bin}
-            end
-    end.
+  case application:get_env(erldns, catch_exceptions) of
+    {ok, false} -> dns:decode_message(Bin);
+    _ ->
+      try dns:decode_message(Bin) of
+        M -> M
+      catch
+        Exception:Reason ->
+          erldns_events:notify({?MODULE, decode_message_error, {Exception, Reason, Bin}}),
+          {formerr, Reason, Bin}
+      end
+  end.

--- a/src/erldns_decoder.erl
+++ b/src/erldns_decoder.erl
@@ -23,18 +23,20 @@
 %% @doc Decode the binary data into its Erlang representation.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an 
+%% configuration, then this function should never throw an
 %% exception.
--spec decode_message(dns:message_bin()) -> {dns:decode_error(), dns:message() | 'undefined', binary()} | dns:message().
+-spec decode_message(dns:message_bin()) -> {dns:decode_error(), dns:message() | undefined, binary()} | dns:message().
 decode_message(Bin) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} -> dns:decode_message(Bin);
-    _ ->
-      try dns:decode_message(Bin) of
-        M -> M
-      catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, decode_message_error, {Exception, Reason, Bin}}),
-          {formerr, Reason, Bin}
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            dns:decode_message(Bin);
+        _ ->
+            try dns:decode_message(Bin) of
+                M ->
+                    M
+            catch
+                Exception:Reason ->
+                    erldns_events:notify({?MODULE, decode_message_error, {Exception, Reason, Bin}}),
+                    {formerr, Reason, Bin}
+            end
+    end.

--- a/src/erldns_decoder.erl
+++ b/src/erldns_decoder.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -16,132 +16,142 @@
 -module(erldns_dnssec).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([handle/4]).
--export([key_rrset_signer/2, zone_rrset_signer/2]).
+-export([key_rrset_signer/2,
+         zone_rrset_signer/2]).
 -export([rrsig_for_zone_rrset/2]).
 -export([maybe_sign_rrset/3]).
 
 -define(NEXT_DNAME_PART, <<"\000">>).
 
 %% @doc Given a zone and a set of records, return the RRSIG records.
--spec(rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()]).
+-spec rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()].
 rrsig_for_zone_rrset(Zone, RRs) ->
-  lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
+    lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
 
 %% @doc Return a function that can be used to sign the given records using the key signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the key signing key from each keyset.
--spec(key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
+-spec key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
 key_rrset_signer(ZoneName, RRs) ->
-  fun(Keyset) ->
-      Keytag = Keyset#keyset.key_signing_key_tag,
-      Alg = Keyset#keyset.key_signing_alg,
-      PrivateKey = Keyset#keyset.key_signing_key,
-      Inception = dns:unix_time(Keyset#keyset.inception),
-      Expiration = dns:unix_time(Keyset#keyset.valid_until),
+    fun(Keyset) ->
+       Keytag = Keyset#keyset.key_signing_key_tag,
+       Alg = Keyset#keyset.key_signing_alg,
+       PrivateKey = Keyset#keyset.key_signing_key,
+       Inception = dns:unix_time(Keyset#keyset.inception),
+       Expiration = dns:unix_time(Keyset#keyset.valid_until),
 
-      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
-  end.
+       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
+    end.
 
 %% @doc Return a function that can be used to sign the given records using the zone signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the zone signing key from each keyset.
--spec(zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
+-spec zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
 zone_rrset_signer(ZoneName, RRs) ->
-  fun(Keyset) ->
-      Keytag = Keyset#keyset.zone_signing_key_tag,
-      Alg = Keyset#keyset.zone_signing_alg,
-      PrivateKey = Keyset#keyset.zone_signing_key,
-      Inception = dns:unix_time(Keyset#keyset.inception),
-      Expiration = dns:unix_time(Keyset#keyset.valid_until),
+    fun(Keyset) ->
+       Keytag = Keyset#keyset.zone_signing_key_tag,
+       Alg = Keyset#keyset.zone_signing_alg,
+       PrivateKey = Keyset#keyset.zone_signing_key,
+       Inception = dns:unix_time(Keyset#keyset.inception),
+       Expiration = dns:unix_time(Keyset#keyset.valid_until),
 
-      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
-  end.
+       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
+    end.
 
 %% @doc This function will potentially sign the given RR set if the following
 %% conditions are true:
 %%
 %% - DNSSEC is requested
 %% - The zone is signed
--spec(maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()]).
+-spec maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()].
 maybe_sign_rrset(Message, Records, Zone) ->
-  case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets}  of
-    {true, []} ->
-      % DNSSEC requested, zone not signed
-      Records;
-    {true, _} ->
-      % DNSSEC requested, zone signed
-      Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
-    {false, _} ->
-      % DNSSEC not requested
-      Records
-  end.
+    case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets} of
+        {true, []} ->
+            % DNSSEC requested, zone not signed
+            Records;
+        {true, _} ->
+            % DNSSEC requested, zone signed
+            Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
+        {false, _} ->
+            % DNSSEC not requested
+            Records
+    end.
 
 %% @doc Apply DNSSEC records to the given message if the zone is signed
 %% and DNSSEC is requested.
--spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message()).
+-spec handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message().
 handle(Message, Zone, Qname, Qtype) ->
-  handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
-
+    handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
 
 %%% Internal functions
 
--spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message()).
+-spec handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message().
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequested = true, []) ->
-  % DNSSEC requested, zone unsigned
-  Message;
+    % DNSSEC requested, zone unsigned
+    Message;
 handle(Message, Zone, Qname, _Qtype, _DnssecRequested = true, _Keysets) ->
-  % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
-  Authority = lists:last(Zone#zone.authority),
-  Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
-  case Message#dns_message.answers of
-    [] ->
-      ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
-      ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
-      SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
+    % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
+    Authority = lists:last(Zone#zone.authority),
+    Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
+    case Message#dns_message.answers of
+        [] ->
+            ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
+            ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
+            SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
 
-      NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
-      NsecRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NSEC, ttl = Ttl, data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
-      NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
+            NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
+            NsecRecords =
+                [#dns_rr{name = Qname,
+                         type = ?DNS_TYPE_NSEC,
+                         ttl = Ttl,
+                         data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
+            NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
 
-      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords}, Zone));
-    _ ->
-      AnswerSignatures = find_rrsigs(Message#dns_message.answers),
-      AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
-      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, answers = Message#dns_message.answers ++ AnswerSignatures, authority = Message#dns_message.authority ++ AuthoritySignatures}, Zone))
-  end;
+            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
+                                                                             rc = ?DNS_RCODE_NOERROR,
+                                                                             authority =
+                                                                                 Message#dns_message.authority ++
+                                                                                     NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords},
+                                                         Zone));
+        _ ->
+            AnswerSignatures = find_rrsigs(Message#dns_message.answers),
+            AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
+            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
+                                                                             answers = Message#dns_message.answers ++ AnswerSignatures,
+                                                                             authority = Message#dns_message.authority ++ AuthoritySignatures},
+                                                         Zone))
+    end;
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequest = false, _) ->
-  Message.
+    Message.
 
 % @doc Find all RRSIG records that cover the records in the provided record list.
--spec(find_rrsigs([dns:rr()]) -> [dns:rr()]).
+-spec find_rrsigs([dns:rr()]) -> [dns:rr()].
 find_rrsigs(MessageRecords) ->
-  NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
-  lists:flatten(
-    lists:map(
-      fun({Name, Type}) ->
-          NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
-          lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
-      end, NamesAndTypes)).
+    NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
+    lists:flatten(lists:map(fun({Name, Type}) ->
+                               NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
+                               lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
+                            end,
+                            NamesAndTypes)).
 
--spec(sign_unsigned(dns:message(), erldns:zone()) -> dns:message()).
+-spec sign_unsigned(dns:message(), erldns:zone()) -> dns:message().
 sign_unsigned(Message, Zone) ->
-  UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
-  AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
-  Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
+    UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
+    AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
+    Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
 
--spec(find_unsigned_records([dns:rr()]) -> [dns:rr()]).
+-spec find_unsigned_records([dns:rr()]) -> [dns:rr()].
 find_unsigned_records(Records) ->
-  lists:filter(
-    fun(RR) ->
-        (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
-    end, Records).
+    lists:filter(fun(RR) ->
+                    (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
+                 end,
+                 Records).
 
 record_types_for_name(Name) ->
-  RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
-  TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
-  lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).
-
-
+    RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
+    TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
+    lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -16,7 +16,6 @@
 -module(erldns_dnssec).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([handle/4]).
@@ -27,126 +26,122 @@
 -define(NEXT_DNAME_PART, <<"\000">>).
 
 %% @doc Given a zone and a set of records, return the RRSIG records.
--spec rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()].
+-spec(rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()]).
 rrsig_for_zone_rrset(Zone, RRs) ->
-    lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
+  lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
 
 %% @doc Return a function that can be used to sign the given records using the key signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the key signing key from each keyset.
--spec key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
+-spec(key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
 key_rrset_signer(ZoneName, RRs) ->
-    fun(Keyset) ->
-       Keytag = Keyset#keyset.key_signing_key_tag,
-       Alg = Keyset#keyset.key_signing_alg,
-       PrivateKey = Keyset#keyset.key_signing_key,
-       Inception = dns:unix_time(Keyset#keyset.inception),
-       Expiration = dns:unix_time(Keyset#keyset.valid_until),
-       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
-    end.
+  fun(Keyset) ->
+      Keytag = Keyset#keyset.key_signing_key_tag,
+      Alg = Keyset#keyset.key_signing_alg,
+      PrivateKey = Keyset#keyset.key_signing_key,
+      Inception = dns:unix_time(Keyset#keyset.inception),
+      Expiration = dns:unix_time(Keyset#keyset.valid_until),
+
+      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
+  end.
 
 %% @doc Return a function that can be used to sign the given records using the zone signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the zone signing key from each keyset.
--spec zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
+-spec(zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
 zone_rrset_signer(ZoneName, RRs) ->
-    fun(Keyset) ->
-       Keytag = Keyset#keyset.zone_signing_key_tag,
-       Alg = Keyset#keyset.zone_signing_alg,
-       PrivateKey = Keyset#keyset.zone_signing_key,
-       Inception = dns:unix_time(Keyset#keyset.inception),
-       Expiration = dns:unix_time(Keyset#keyset.valid_until),
-       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
-    end.
+  fun(Keyset) ->
+      Keytag = Keyset#keyset.zone_signing_key_tag,
+      Alg = Keyset#keyset.zone_signing_alg,
+      PrivateKey = Keyset#keyset.zone_signing_key,
+      Inception = dns:unix_time(Keyset#keyset.inception),
+      Expiration = dns:unix_time(Keyset#keyset.valid_until),
+
+      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
+  end.
 
 %% @doc This function will potentially sign the given RR set if the following
 %% conditions are true:
 %%
 %% - DNSSEC is requested
 %% - The zone is signed
--spec maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()].
+-spec(maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()]).
 maybe_sign_rrset(Message, Records, Zone) ->
-    case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets} of
-        {true, []} ->
-            % DNSSEC requested, zone not signed
-            Records;
-        {true, _} ->
-            % DNSSEC requested, zone signed
-            Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
-        {false, _} ->
-            % DNSSEC not requested
-            Records
-    end.
+  case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets}  of
+    {true, []} ->
+      % DNSSEC requested, zone not signed
+      Records;
+    {true, _} ->
+      % DNSSEC requested, zone signed
+      Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
+    {false, _} ->
+      % DNSSEC not requested
+      Records
+  end.
 
 %% @doc Apply DNSSEC records to the given message if the zone is signed
 %% and DNSSEC is requested.
--spec handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message().
+-spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message()).
 handle(Message, Zone, Qname, Qtype) ->
-    handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
+  handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
+
 
 %%% Internal functions
 
--spec handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message().
+-spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message()).
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequested = true, []) ->
-    % DNSSEC requested, zone unsigned
-    Message;
+  % DNSSEC requested, zone unsigned
+  Message;
 handle(Message, Zone, Qname, _Qtype, _DnssecRequested = true, _Keysets) ->
-    % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
-    Authority = lists:last(Zone#zone.authority),
-    Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
-    case Message#dns_message.answers of
-        [] ->
-            ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
-            ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
-            SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
-            NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
-            NsecRecords =
-                [#dns_rr{name = Qname,
-                         type = ?DNS_TYPE_NSEC,
-                         ttl = Ttl,
-                         data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
-            NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
-            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
-                                                                             rc = ?DNS_RCODE_NOERROR,
-                                                                             authority =
-                                                                                 Message#dns_message.authority ++
-                                                                                     NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords},
-                                                         Zone));
-        _ ->
-            AnswerSignatures = find_rrsigs(Message#dns_message.answers),
-            AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
-            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
-                                                                             answers = Message#dns_message.answers ++ AnswerSignatures,
-                                                                             authority = Message#dns_message.authority ++ AuthoritySignatures},
-                                                         Zone))
-    end;
+  % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
+  Authority = lists:last(Zone#zone.authority),
+  Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
+  case Message#dns_message.answers of
+    [] ->
+      ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
+      ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
+      SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
+
+      NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
+      NsecRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NSEC, ttl = Ttl, data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
+      NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
+
+      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords}, Zone));
+    _ ->
+      AnswerSignatures = find_rrsigs(Message#dns_message.answers),
+      AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
+      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, answers = Message#dns_message.answers ++ AnswerSignatures, authority = Message#dns_message.authority ++ AuthoritySignatures}, Zone))
+  end;
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequest = false, _) ->
-    Message.
+  Message.
 
 % @doc Find all RRSIG records that cover the records in the provided record list.
--spec find_rrsigs([dns:rr()]) -> [dns:rr()].
+-spec(find_rrsigs([dns:rr()]) -> [dns:rr()]).
 find_rrsigs(MessageRecords) ->
-    NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
-    lists:flatten(lists:map(fun({Name, Type}) ->
-                               NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
-                               lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
-                            end,
-                            NamesAndTypes)).
+  NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
+  lists:flatten(
+    lists:map(
+      fun({Name, Type}) ->
+          NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
+          lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
+      end, NamesAndTypes)).
 
--spec sign_unsigned(dns:message(), erldns:zone()) -> dns:message().
+-spec(sign_unsigned(dns:message(), erldns:zone()) -> dns:message()).
 sign_unsigned(Message, Zone) ->
-    UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
-    AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
-    Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
+  UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
+  AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
+  Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
 
--spec find_unsigned_records([dns:rr()]) -> [dns:rr()].
+-spec(find_unsigned_records([dns:rr()]) -> [dns:rr()]).
 find_unsigned_records(Records) ->
-    lists:filter(fun(RR) ->
-                    (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
-                 end,
-                 Records).
+  lists:filter(
+    fun(RR) ->
+        (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
+    end, Records).
 
 record_types_for_name(Name) ->
-    RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
-    TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
-    lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).
+  RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
+  TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
+  lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).
+
+

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -20,8 +20,7 @@
 -include("erldns.hrl").
 
 -export([handle/4]).
--export([key_rrset_signer/2,
-         zone_rrset_signer/2]).
+-export([key_rrset_signer/2, zone_rrset_signer/2]).
 -export([rrsig_for_zone_rrset/2]).
 -export([maybe_sign_rrset/3]).
 

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -20,7 +20,8 @@
 -include("erldns.hrl").
 
 -export([handle/4]).
--export([key_rrset_signer/2, zone_rrset_signer/2]).
+-export([key_rrset_signer/2,
+         zone_rrset_signer/2]).
 -export([rrsig_for_zone_rrset/2]).
 -export([maybe_sign_rrset/3]).
 

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -16,6 +16,7 @@
 -module(erldns_dnssec).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([handle/4]).
@@ -26,122 +27,126 @@
 -define(NEXT_DNAME_PART, <<"\000">>).
 
 %% @doc Given a zone and a set of records, return the RRSIG records.
--spec(rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()]).
+-spec rrsig_for_zone_rrset(erldns:zone(), [dns:rr()]) -> [dns:rr()].
 rrsig_for_zone_rrset(Zone, RRs) ->
-  lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
+    lists:flatten(lists:map(zone_rrset_signer(Zone#zone.name, RRs), Zone#zone.keysets)).
 
 %% @doc Return a function that can be used to sign the given records using the key signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the key signing key from each keyset.
--spec(key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
+-spec key_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
 key_rrset_signer(ZoneName, RRs) ->
-  fun(Keyset) ->
-      Keytag = Keyset#keyset.key_signing_key_tag,
-      Alg = Keyset#keyset.key_signing_alg,
-      PrivateKey = Keyset#keyset.key_signing_key,
-      Inception = dns:unix_time(Keyset#keyset.inception),
-      Expiration = dns:unix_time(Keyset#keyset.valid_until),
-
-      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
-  end.
+    fun(Keyset) ->
+       Keytag = Keyset#keyset.key_signing_key_tag,
+       Alg = Keyset#keyset.key_signing_alg,
+       PrivateKey = Keyset#keyset.key_signing_key,
+       Inception = dns:unix_time(Keyset#keyset.inception),
+       Expiration = dns:unix_time(Keyset#keyset.valid_until),
+       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
+    end.
 
 %% @doc Return a function that can be used to sign the given records using the zone signing key.
 %% The function accepts a keyset, allowing the zone signing mechanism to iterate through available
 %% keysets, applying the zone signing key from each keyset.
--spec(zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()])).
+-spec zone_rrset_signer(dns:name(), [dns:rr()]) -> fun((erldns:keyset()) -> [dns:rr()]).
 zone_rrset_signer(ZoneName, RRs) ->
-  fun(Keyset) ->
-      Keytag = Keyset#keyset.zone_signing_key_tag,
-      Alg = Keyset#keyset.zone_signing_alg,
-      PrivateKey = Keyset#keyset.zone_signing_key,
-      Inception = dns:unix_time(Keyset#keyset.inception),
-      Expiration = dns:unix_time(Keyset#keyset.valid_until),
-
-      dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception},{expiration, Expiration}])
-  end.
+    fun(Keyset) ->
+       Keytag = Keyset#keyset.zone_signing_key_tag,
+       Alg = Keyset#keyset.zone_signing_alg,
+       PrivateKey = Keyset#keyset.zone_signing_key,
+       Inception = dns:unix_time(Keyset#keyset.inception),
+       Expiration = dns:unix_time(Keyset#keyset.valid_until),
+       dnssec:sign_rr(RRs, erldns:normalize_name(ZoneName), Keytag, Alg, PrivateKey, [{inception, Inception}, {expiration, Expiration}])
+    end.
 
 %% @doc This function will potentially sign the given RR set if the following
 %% conditions are true:
 %%
 %% - DNSSEC is requested
 %% - The zone is signed
--spec(maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()]).
+-spec maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()].
 maybe_sign_rrset(Message, Records, Zone) ->
-  case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets}  of
-    {true, []} ->
-      % DNSSEC requested, zone not signed
-      Records;
-    {true, _} ->
-      % DNSSEC requested, zone signed
-      Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
-    {false, _} ->
-      % DNSSEC not requested
-      Records
-  end.
+    case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets} of
+        {true, []} ->
+            % DNSSEC requested, zone not signed
+            Records;
+        {true, _} ->
+            % DNSSEC requested, zone signed
+            Records ++ erldns_dnssec:rrsig_for_zone_rrset(Zone, Records);
+        {false, _} ->
+            % DNSSEC not requested
+            Records
+    end.
 
 %% @doc Apply DNSSEC records to the given message if the zone is signed
 %% and DNSSEC is requested.
--spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message()).
+-spec handle(dns:message(), erldns:zone(), dns:name(), dns:type()) -> dns:message().
 handle(Message, Zone, Qname, Qtype) ->
-  handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
-
+    handle(Message, Zone, Qname, Qtype, proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets).
 
 %%% Internal functions
 
--spec(handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message()).
+-spec handle(dns:message(), erldns:zone(), dns:name(), dns:type(), boolean(), [erldns:keyset()]) -> dns:message().
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequested = true, []) ->
-  % DNSSEC requested, zone unsigned
-  Message;
+    % DNSSEC requested, zone unsigned
+    Message;
 handle(Message, Zone, Qname, _Qtype, _DnssecRequested = true, _Keysets) ->
-  % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
-  Authority = lists:last(Zone#zone.authority),
-  Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
-  case Message#dns_message.answers of
-    [] ->
-      ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
-      ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
-      SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
-
-      NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
-      NsecRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NSEC, ttl = Ttl, data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
-      NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
-
-      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords}, Zone));
-    _ ->
-      AnswerSignatures = find_rrsigs(Message#dns_message.answers),
-      AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
-      erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true, answers = Message#dns_message.answers ++ AnswerSignatures, authority = Message#dns_message.authority ++ AuthoritySignatures}, Zone))
-  end;
+    % lager:debug("DNSSEC requested (name: ~p)", [Zone#zone.name]),
+    Authority = lists:last(Zone#zone.authority),
+    Ttl = Authority#dns_rr.data#dns_rrdata_soa.minimum,
+    case Message#dns_message.answers of
+        [] ->
+            ApexRecords = erldns_zone_cache:get_records_by_name(Zone#zone.name),
+            ApexRRSigRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_RRSIG), ApexRecords),
+            SoaRRSigRecords = lists:filter(erldns_records:match_type_covered(?DNS_TYPE_SOA), ApexRRSigRecords),
+            NextDname = erldns:normalize_name(dns:labels_to_dname([?NEXT_DNAME_PART] ++ dns:dname_to_labels(Qname))),
+            NsecRecords =
+                [#dns_rr{name = Qname,
+                         type = ?DNS_TYPE_NSEC,
+                         ttl = Ttl,
+                         data = #dns_rrdata_nsec{next_dname = NextDname, types = record_types_for_name(Qname)}}],
+            NsecRRSigRecords = rrsig_for_zone_rrset(Zone, NsecRecords),
+            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
+                                                                             rc = ?DNS_RCODE_NOERROR,
+                                                                             authority =
+                                                                                 Message#dns_message.authority ++
+                                                                                     NsecRecords ++ SoaRRSigRecords ++ NsecRRSigRecords},
+                                                         Zone));
+        _ ->
+            AnswerSignatures = find_rrsigs(Message#dns_message.answers),
+            AuthoritySignatures = find_rrsigs(Message#dns_message.authority),
+            erldns_records:rewrite_soa_ttl(sign_unsigned(Message#dns_message{ad = true,
+                                                                             answers = Message#dns_message.answers ++ AnswerSignatures,
+                                                                             authority = Message#dns_message.authority ++ AuthoritySignatures},
+                                                         Zone))
+    end;
 handle(Message, _Zone, _Qname, _Qtype, _DnssecRequest = false, _) ->
-  Message.
+    Message.
 
 % @doc Find all RRSIG records that cover the records in the provided record list.
--spec(find_rrsigs([dns:rr()]) -> [dns:rr()]).
+-spec find_rrsigs([dns:rr()]) -> [dns:rr()].
 find_rrsigs(MessageRecords) ->
-  NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
-  lists:flatten(
-    lists:map(
-      fun({Name, Type}) ->
-          NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
-          lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
-      end, NamesAndTypes)).
+    NamesAndTypes = lists:usort(lists:map(fun(RR) -> {RR#dns_rr.name, RR#dns_rr.type} end, MessageRecords)),
+    lists:flatten(lists:map(fun({Name, Type}) ->
+                               NamedRRSigs = erldns_zone_cache:get_records_by_name_and_type(Name, ?DNS_TYPE_RRSIG),
+                               lists:filter(erldns_records:match_type_covered(Type), NamedRRSigs)
+                            end,
+                            NamesAndTypes)).
 
--spec(sign_unsigned(dns:message(), erldns:zone()) -> dns:message()).
+-spec sign_unsigned(dns:message(), erldns:zone()) -> dns:message().
 sign_unsigned(Message, Zone) ->
-  UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
-  AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
-  Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
+    UnsignedAnswers = find_unsigned_records(Message#dns_message.answers),
+    AnswerSignatures = erldns_dnssec:rrsig_for_zone_rrset(Zone, UnsignedAnswers),
+    Message#dns_message{answers = Message#dns_message.answers ++ AnswerSignatures}.
 
--spec(find_unsigned_records([dns:rr()]) -> [dns:rr()]).
+-spec find_unsigned_records([dns:rr()]) -> [dns:rr()].
 find_unsigned_records(Records) ->
-  lists:filter(
-    fun(RR) ->
-        (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
-    end, Records).
+    lists:filter(fun(RR) ->
+                    (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and (lists:filter(erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records) =:= [])
+                 end,
+                 Records).
 
 record_types_for_name(Name) ->
-  RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
-  TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
-  lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).
-
-
+    RecordsAtName = erldns_zone_cache:get_records_by_name(Name),
+    TypesCovered = lists:map(fun(RR) -> RR#dns_rr.type end, RecordsAtName),
+    lists:usort(TypesCovered ++ [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC]).

--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_edns.erl
+++ b/src/erldns_edns.erl
@@ -26,14 +26,14 @@
 %% * {dnssec, true}
 -spec get_opts(dns:message()) -> [proplists:property()].
 get_opts(Message) ->
-  get_opts(Message#dns_message.additional, []).
+    get_opts(Message#dns_message.additional, []).
 
--spec get_opts([dns:rr()|dns:optrr()], [proplists:property()]) -> [proplists:property()].
+-spec get_opts([dns:rr() | dns:optrr()], [proplists:property()]) -> [proplists:property()].
 get_opts([], Opts) ->
-  Opts;
-get_opts([RR|Rest], Opts) when is_record(RR, dns_rr) ->
-  get_opts(Rest, Opts);
-get_opts([RR|Rest], Opts) when is_record(RR, dns_optrr) and RR#dns_optrr.dnssec ->
-  get_opts(Rest, Opts ++ [{dnssec, true}]);
-get_opts([_RR|Rest], Opts) ->
-  get_opts(Rest, Opts).
+    Opts;
+get_opts([RR | Rest], Opts) when is_record(RR, dns_rr) ->
+    get_opts(Rest, Opts);
+get_opts([RR | Rest], Opts) when is_record(RR, dns_optrr) and RR#dns_optrr.dnssec ->
+    get_opts(Rest, Opts ++ [{dnssec, true}]);
+get_opts([_RR | Rest], Opts) ->
+    get_opts(Rest, Opts).

--- a/src/erldns_edns.erl
+++ b/src/erldns_edns.erl
@@ -26,14 +26,14 @@
 %% * {dnssec, true}
 -spec get_opts(dns:message()) -> [proplists:property()].
 get_opts(Message) ->
-    get_opts(Message#dns_message.additional, []).
+  get_opts(Message#dns_message.additional, []).
 
--spec get_opts([dns:rr() | dns:optrr()], [proplists:property()]) -> [proplists:property()].
+-spec get_opts([dns:rr()|dns:optrr()], [proplists:property()]) -> [proplists:property()].
 get_opts([], Opts) ->
-    Opts;
-get_opts([RR | Rest], Opts) when is_record(RR, dns_rr) ->
-    get_opts(Rest, Opts);
-get_opts([RR | Rest], Opts) when is_record(RR, dns_optrr) and RR#dns_optrr.dnssec ->
-    get_opts(Rest, Opts ++ [{dnssec, true}]);
-get_opts([_RR | Rest], Opts) ->
-    get_opts(Rest, Opts).
+  Opts;
+get_opts([RR|Rest], Opts) when is_record(RR, dns_rr) ->
+  get_opts(Rest, Opts);
+get_opts([RR|Rest], Opts) when is_record(RR, dns_optrr) and RR#dns_optrr.dnssec ->
+  get_opts(Rest, Opts ++ [{dnssec, true}]);
+get_opts([_RR|Rest], Opts) ->
+  get_opts(Rest, Opts).

--- a/src/erldns_edns.erl
+++ b/src/erldns_edns.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -18,8 +18,7 @@
 
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--export([encode_message/1,
-         encode_message/2]).
+-export([encode_message/1, encode_message/2]).
 
 %% @doc Encode the DNS message into its binary representation.
 %%

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -18,7 +18,8 @@
 
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--export([encode_message/1, encode_message/2]).
+-export([encode_message/1,
+         encode_message/2]).
 
 %% @doc Encode the DNS message into its binary representation.
 %%

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -23,65 +23,52 @@
 %% @doc Encode the DNS message into its binary representation.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an
+%% configuration, then this function should never throw an 
 %% exception.
 -spec encode_message(dns:message()) -> dns:message_bin().
 encode_message(Response) ->
-    case application:get_env(erldns, catch_exceptions) of
-        {ok, false} ->
-            dns:encode_message(Response);
-        _ ->
-            try dns:encode_message(Response) of
-                M ->
-                    M
-            catch
-                Exception:Reason ->
-                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
-                    encode_message(build_error_response(Response))
-            end
-    end.
+  case application:get_env(erldns, catch_exceptions) of
+    {ok, false} -> dns:encode_message(Response);
+    _ ->
+      try dns:encode_message(Response) of
+        M -> M
+      catch
+        Exception:Reason ->
+          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
+          encode_message(build_error_response(Response))
+      end
+  end.
 
 %% @doc Encode the DNS message into its binary representation. Use the
 %% Opts argument to pass in encoding options.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an
+%% configuration, then this function should never throw an 
 %% exception.
 -spec encode_message(dns:message(), [dns:encode_message_opt()]) ->
-                        {false, dns:message_bin()} |
-                        {true, dns:message_bin(), dns:message()} |
-                        {false, dns:message_bin(), dns:tsig_mac()} |
-                        {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
+  {false, dns:message_bin()} |
+  {true, dns:message_bin(), dns:message()} |
+  {false, dns:message_bin(), dns:tsig_mac()} |
+  {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
 encode_message(Response, Opts) ->
-    case application:get_env(erldns, catch_exceptions) of
-        {ok, false} ->
-            dns:encode_message(Response, Opts);
-        _ ->
-            try dns:encode_message(Response, Opts) of
-                M ->
-                    M
-            catch
-                Exception:Reason ->
-                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
-                    {false, encode_message(build_error_response(Response))}
-            end
-    end.
+  case application:get_env(erldns, catch_exceptions) of
+    {ok, false} -> dns:encode_message(Response, Opts);
+    _ ->
+      try dns:encode_message(Response, Opts) of
+        M -> M
+      catch
+        Exception:Reason ->
+          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
+          {false, encode_message(build_error_response(Response))}
+      end
+  end.
 
 % Private functions
 
 %% Populate a response with a servfail error
 build_error_response(Response) when is_record(Response, dns_message) ->
-    build_error_response(Response, ?DNS_RCODE_SERVFAIL);
+  build_error_response(Response, ?DNS_RCODE_SERVFAIL);
 build_error_response({_, Response}) ->
-    build_error_response(Response, ?DNS_RCODE_SERVFAIL).
-
+  build_error_response(Response, ?DNS_RCODE_SERVFAIL).
 build_error_response(Response, Rcode) ->
-    Response#dns_message{anc = 0,
-                         auc = 0,
-                         adc = 0,
-                         qr = true,
-                         aa = true,
-                         rc = Rcode,
-                         answers = [],
-                         authority = [],
-                         additional = []}.
+  Response#dns_message{anc = 0, auc = 0, adc = 0, qr = true, aa = true, rc = Rcode, answers=[], authority=[], additional=[]}.

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -23,52 +23,65 @@
 %% @doc Encode the DNS message into its binary representation.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an 
+%% configuration, then this function should never throw an
 %% exception.
 -spec encode_message(dns:message()) -> dns:message_bin().
 encode_message(Response) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} -> dns:encode_message(Response);
-    _ ->
-      try dns:encode_message(Response) of
-        M -> M
-      catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
-          encode_message(build_error_response(Response))
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            dns:encode_message(Response);
+        _ ->
+            try dns:encode_message(Response) of
+                M ->
+                    M
+            catch
+                Exception:Reason ->
+                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
+                    encode_message(build_error_response(Response))
+            end
+    end.
 
 %% @doc Encode the DNS message into its binary representation. Use the
 %% Opts argument to pass in encoding options.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an 
+%% configuration, then this function should never throw an
 %% exception.
 -spec encode_message(dns:message(), [dns:encode_message_opt()]) ->
-  {false, dns:message_bin()} |
-  {true, dns:message_bin(), dns:message()} |
-  {false, dns:message_bin(), dns:tsig_mac()} |
-  {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
+                        {false, dns:message_bin()} |
+                        {true, dns:message_bin(), dns:message()} |
+                        {false, dns:message_bin(), dns:tsig_mac()} |
+                        {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
 encode_message(Response, Opts) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} -> dns:encode_message(Response, Opts);
-    _ ->
-      try dns:encode_message(Response, Opts) of
-        M -> M
-      catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
-          {false, encode_message(build_error_response(Response))}
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            dns:encode_message(Response, Opts);
+        _ ->
+            try dns:encode_message(Response, Opts) of
+                M ->
+                    M
+            catch
+                Exception:Reason ->
+                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
+                    {false, encode_message(build_error_response(Response))}
+            end
+    end.
 
 % Private functions
 
 %% Populate a response with a servfail error
 build_error_response(Response) when is_record(Response, dns_message) ->
-  build_error_response(Response, ?DNS_RCODE_SERVFAIL);
+    build_error_response(Response, ?DNS_RCODE_SERVFAIL);
 build_error_response({_, Response}) ->
-  build_error_response(Response, ?DNS_RCODE_SERVFAIL).
+    build_error_response(Response, ?DNS_RCODE_SERVFAIL).
+
 build_error_response(Response, Rcode) ->
-  Response#dns_message{anc = 0, auc = 0, adc = 0, qr = true, aa = true, rc = Rcode, answers=[], authority=[], additional=[]}.
+    Response#dns_message{anc = 0,
+                         auc = 0,
+                         adc = 0,
+                         qr = true,
+                         aa = true,
+                         rc = Rcode,
+                         answers = [],
+                         authority = [],
+                         additional = []}.

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -18,57 +18,71 @@
 
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--export([encode_message/1, encode_message/2]).
+-export([encode_message/1,
+         encode_message/2]).
 
 %% @doc Encode the DNS message into its binary representation.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an 
+%% configuration, then this function should never throw an
 %% exception.
 -spec encode_message(dns:message()) -> dns:message_bin().
 encode_message(Response) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} -> dns:encode_message(Response);
-    _ ->
-      try dns:encode_message(Response) of
-        M -> M
-      catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
-          encode_message(build_error_response(Response))
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            dns:encode_message(Response);
+        _ ->
+            try dns:encode_message(Response) of
+                M ->
+                    M
+            catch
+                Exception:Reason ->
+                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response}}),
+                    encode_message(build_error_response(Response))
+            end
+    end.
 
 %% @doc Encode the DNS message into its binary representation. Use the
 %% Opts argument to pass in encoding options.
 %%
 %% Note that if the erldns catch_exceptions property is set in the
-%% configuration, then this function should never throw an 
+%% configuration, then this function should never throw an
 %% exception.
 -spec encode_message(dns:message(), [dns:encode_message_opt()]) ->
-  {false, dns:message_bin()} |
-  {true, dns:message_bin(), dns:message()} |
-  {false, dns:message_bin(), dns:tsig_mac()} |
-  {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
+                        {false, dns:message_bin()} |
+                        {true, dns:message_bin(), dns:message()} |
+                        {false, dns:message_bin(), dns:tsig_mac()} |
+                        {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
 encode_message(Response, Opts) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} -> dns:encode_message(Response, Opts);
-    _ ->
-      try dns:encode_message(Response, Opts) of
-        M -> M
-      catch
-        Exception:Reason ->
-          erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
-          {false, encode_message(build_error_response(Response))}
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            dns:encode_message(Response, Opts);
+        _ ->
+            try dns:encode_message(Response, Opts) of
+                M ->
+                    M
+            catch
+                Exception:Reason ->
+                    erldns_events:notify({?MODULE, encode_message_error, {Exception, Reason, Response, Opts}}),
+                    {false, encode_message(build_error_response(Response))}
+            end
+    end.
 
 % Private functions
 
 %% Populate a response with a servfail error
 build_error_response(Response) when is_record(Response, dns_message) ->
-  build_error_response(Response, ?DNS_RCODE_SERVFAIL);
+    build_error_response(Response, ?DNS_RCODE_SERVFAIL);
 build_error_response({_, Response}) ->
-  build_error_response(Response, ?DNS_RCODE_SERVFAIL).
+    build_error_response(Response, ?DNS_RCODE_SERVFAIL).
+
 build_error_response(Response, Rcode) ->
-  Response#dns_message{anc = 0, auc = 0, adc = 0, qr = true, aa = true, rc = Rcode, answers=[], authority=[], additional=[]}.
+    Response#dns_message{anc = 0,
+                         auc = 0,
+                         adc = 0,
+                         qr = true,
+                         aa = true,
+                         rc = Rcode,
+                         answers = [],
+                         authority = [],
+                         additional = []}.

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -17,138 +17,117 @@
 
 -behavior(gen_event).
 
--export([
-         init/1,
+-export([init/1,
          handle_event/2,
          handle_call/2,
          handle_info/2,
          code_change/3,
-         terminate/2
-        ]).
+         terminate/2]).
 
 -record(state, {servers_running = false}).
 
 init(_Args) ->
-  {ok, #state{}}.
+    {ok, #state{}}.
 
 handle_event({_M, start_servers}, State) ->
-  case State#state.servers_running of
-    false ->
-      % Start up the UDP and TCP servers
-      lager:info("Starting the UDP and TCP supervisor"),
-      supervisor:start_child(erldns_sup, #{
-                               id => erldns_sup,
-                               start => { erldns_server_sup, start_link, []},
-                               restart => permanent,
-                               shutdown => 5000,
-                               type => supervisor}),
-      erldns_events:notify({?MODULE, servers_started}),
-      {ok, State#state{servers_running = true}};
-    _ ->
-      erldns_events:notify({?MODULE, servers_already_started}),
-      {ok, State}
-  end;
-
+    case State#state.servers_running of
+        false ->
+            % Start up the UDP and TCP servers
+            lager:info("Starting the UDP and TCP supervisor"),
+            supervisor:start_child(erldns_sup,
+                                   #{id => erldns_sup,
+                                     start => {erldns_server_sup, start_link, []},
+                                     restart => permanent,
+                                     shutdown => 5000,
+                                     type => supervisor}),
+            erldns_events:notify({?MODULE, servers_started}),
+            {ok, State#state{servers_running = true}};
+        _ ->
+            erldns_events:notify({?MODULE, servers_already_started}),
+            {ok, State}
+    end;
 handle_event({_M, end_udp, [{host, _Host}]}, State) ->
-  folsom_metrics:notify({udp_request_meter, 1}),
-  folsom_metrics:notify({udp_request_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({udp_request_meter, 1}),
+    folsom_metrics:notify({udp_request_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M, end_tcp, [{host, _Host}]}, State) ->
-  folsom_metrics:notify({tcp_request_meter, 1}),
-  folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({tcp_request_meter, 1}),
+    folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M, udp_error, Reason}, State) ->
-  folsom_metrics:notify({udp_error_meter, 1}),
-  folsom_metrics:notify({udp_error_history, Reason}),
-  {ok, State};
-
+    folsom_metrics:notify({udp_error_meter, 1}),
+    folsom_metrics:notify({udp_error_history, Reason}),
+    {ok, State};
 handle_event({_M, tcp_error, Reason}, State) ->
-  folsom_metrics:notify({tcp_error_meter, 1}),
-  folsom_metrics:notify({tcp_error_history, Reason}),
-  {ok, State};
-
+    folsom_metrics:notify({tcp_error_meter, 1}),
+    folsom_metrics:notify({tcp_error_history, Reason}),
+    {ok, State};
 handle_event({_M, dnssec_request, _Host, _Qname}, State) ->
-  folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
-  folsom_metrics:notify(dnssec_request_meter, 1),
-  {ok, State};
-
+    folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
+    folsom_metrics:notify(dnssec_request_meter, 1),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = refused_response, _Questions}, State) ->
-  folsom_metrics:notify({refused_response_meter, 1}),
-  folsom_metrics:notify({refused_response_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({refused_response_meter, 1}),
+    folsom_metrics:notify({refused_response_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = empty_response, _Message}, State) ->
-  folsom_metrics:notify({empty_response_meter, 1}),
-  folsom_metrics:notify({empty_response_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({empty_response_meter, 1}),
+    folsom_metrics:notify({empty_response_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = resolve_error, {_Exception, _Reason, _Message, _Stacktrace}}, State) ->
-  folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
-  folsom_metrics:notify({erldns_handler_error_meter, 1}),
-  {ok, State};
-
+    folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
+    folsom_metrics:notify({erldns_handler_error_meter, 1}),
+    {ok, State};
 handle_event({M = erldns_zone_encoder, E = unsupported_rrdata_type, Data}, State) ->
-  lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-  {ok, State};
-
+    lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+    {ok, State};
 handle_event({M = erldns_zone_loader, E = read_file_error, Reason}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_loader, E = put_zone_error, {JsonZone, Reason}}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Reason}}, State) ->
-  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
-  {ok, State};
-
+    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Exception, Reason}}, State) ->
-  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Name, Type, Data, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)",
+                [M, E, Name, Type, Data, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = unsupported_record, Data}, State) ->
-  lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-  {ok, State};
-
+    lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+    {ok, State};
 handle_event({M = erldns_decoder, E = decode_message_error, {Exception, Reason, Bin}}, State) ->
-  lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
+    {ok, State};
 handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, Response}}, State) ->
-  lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
-  lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)", [M, E, Response, Opts,Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)",
+                [M, E, Response, Opts, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_storage, E = failed_zones_load, Reason}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+    {ok, State};
 handle_event({_M = erldns_worker, _E = timeout}, State) ->
-  folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
-  folsom_metrics:notify({worker_timeout_meter, 1}),
-  {ok, State};
-
+    folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
+    folsom_metrics:notify({worker_timeout_meter, 1}),
+    {ok, State};
 handle_event({M = erldns_worker, E = restart_failed, Error}, State) ->
-  lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
-  {ok, State};
-
+    lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
+    {ok, State};
 handle_event(_Event, State) ->
-  {ok, State}.
+    {ok, State}.
 
 handle_call(_Message, State) ->
-  {ok, ok, State}.
+    {ok, ok, State}.
 
 handle_info(_Message, State) ->
-  {ok, State}.
+    {ok, State}.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -17,133 +17,112 @@
 
 -behavior(gen_event).
 
--export([
-         init/1,
+-export([init/1,
          handle_event/2,
          handle_call/2,
          handle_info/2,
          code_change/3,
-         terminate/2
-        ]).
+         terminate/2]).
 
 -record(state, {servers_running = false}).
 
 init(_Args) ->
-  {ok, #state{}}.
+    {ok, #state{}}.
 
 handle_event({_M, start_servers}, State) ->
-  case State#state.servers_running of
-    false ->
-      % Start up the UDP and TCP servers
-      lager:info("Starting the UDP and TCP supervisor"),
-      erldns_server_sup:start_link(),
-      erldns_events:notify({?MODULE, servers_started}),
-      {ok, State#state{servers_running = true}};
-    _ ->
-      erldns_events:notify({?MODULE, servers_already_started}),
-      {ok, State}
-  end;
-
+    case State#state.servers_running of
+        false ->
+            % Start up the UDP and TCP servers
+            lager:info("Starting the UDP and TCP supervisor"),
+            erldns_server_sup:start_link(),
+            erldns_events:notify({?MODULE, servers_started}),
+            {ok, State#state{servers_running = true}};
+        _ ->
+            erldns_events:notify({?MODULE, servers_already_started}),
+            {ok, State}
+    end;
 handle_event({_M, end_udp, [{host, _Host}]}, State) ->
-  folsom_metrics:notify({udp_request_meter, 1}),
-  folsom_metrics:notify({udp_request_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({udp_request_meter, 1}),
+    folsom_metrics:notify({udp_request_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M, end_tcp, [{host, _Host}]}, State) ->
-  folsom_metrics:notify({tcp_request_meter, 1}),
-  folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({tcp_request_meter, 1}),
+    folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M, udp_error, Reason}, State) ->
-  folsom_metrics:notify({udp_error_meter, 1}),
-  folsom_metrics:notify({udp_error_history, Reason}),
-  {ok, State};
-
+    folsom_metrics:notify({udp_error_meter, 1}),
+    folsom_metrics:notify({udp_error_history, Reason}),
+    {ok, State};
 handle_event({_M, tcp_error, Reason}, State) ->
-  folsom_metrics:notify({tcp_error_meter, 1}),
-  folsom_metrics:notify({tcp_error_history, Reason}),
-  {ok, State};
-
+    folsom_metrics:notify({tcp_error_meter, 1}),
+    folsom_metrics:notify({tcp_error_history, Reason}),
+    {ok, State};
 handle_event({_M, dnssec_request, _Host, _Qname}, State) ->
-  folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
-  folsom_metrics:notify(dnssec_request_meter, 1),
-  {ok, State};
-
+    folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
+    folsom_metrics:notify(dnssec_request_meter, 1),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = refused_response, _Questions}, State) ->
-  folsom_metrics:notify({refused_response_meter, 1}),
-  folsom_metrics:notify({refused_response_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({refused_response_meter, 1}),
+    folsom_metrics:notify({refused_response_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = empty_response, _Message}, State) ->
-  folsom_metrics:notify({empty_response_meter, 1}),
-  folsom_metrics:notify({empty_response_counter, {inc, 1}}),
-  {ok, State};
-
+    folsom_metrics:notify({empty_response_meter, 1}),
+    folsom_metrics:notify({empty_response_counter, {inc, 1}}),
+    {ok, State};
 handle_event({_M = erldns_handler, _E = resolve_error, {_Exception, _Reason, _Message, _Stacktrace}}, State) ->
-  folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
-  folsom_metrics:notify({erldns_handler_error_meter, 1}),
-  {ok, State};
-
+    folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
+    folsom_metrics:notify({erldns_handler_error_meter, 1}),
+    {ok, State};
 handle_event({M = erldns_zone_encoder, E = unsupported_rrdata_type, Data}, State) ->
-  lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-  {ok, State};
-
+    lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+    {ok, State};
 handle_event({M = erldns_zone_loader, E = read_file_error, Reason}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_loader, E = put_zone_error, {JsonZone, Reason}}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Reason}}, State) ->
-  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
-  {ok, State};
-
+    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Exception, Reason}}, State) ->
-  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Name, Type, Data, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)",
+                [M, E, Name, Type, Data, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_zone_parser, E = unsupported_record, Data}, State) ->
-  lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-  {ok, State};
-
+    lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+    {ok, State};
 handle_event({M = erldns_decoder, E = decode_message_error, {Exception, Reason, Bin}}, State) ->
-  lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
+    {ok, State};
 handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, Response}}, State) ->
-  lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
-  lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)", [M, E, Response, Opts,Exception, Reason]),
-  {ok, State};
-
+    lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)",
+                [M, E, Response, Opts, Exception, Reason]),
+    {ok, State};
 handle_event({M = erldns_storage, E = failed_zones_load, Reason}, State) ->
-  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-  {ok, State};
-
+    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+    {ok, State};
 handle_event({_M = erldns_worker, _E = timeout}, State) ->
-  folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
-  folsom_metrics:notify({worker_timeout_meter, 1}),
-  {ok, State};
-
+    folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
+    folsom_metrics:notify({worker_timeout_meter, 1}),
+    {ok, State};
 handle_event({M = erldns_worker, E = restart_failed, Error}, State) ->
-  lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
-  {ok, State};
-
+    lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
+    {ok, State};
 handle_event(_Event, State) ->
-  {ok, State}.
+    {ok, State}.
 
 handle_call(_Message, State) ->
-  {ok, ok, State}.
+    {ok, ok, State}.
 
 handle_info(_Message, State) ->
-  {ok, State}.
+    {ok, State}.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -17,112 +17,133 @@
 
 -behavior(gen_event).
 
--export([init/1,
+-export([
+         init/1,
          handle_event/2,
          handle_call/2,
          handle_info/2,
          code_change/3,
-         terminate/2]).
+         terminate/2
+        ]).
 
 -record(state, {servers_running = false}).
 
 init(_Args) ->
-    {ok, #state{}}.
+  {ok, #state{}}.
 
 handle_event({_M, start_servers}, State) ->
-    case State#state.servers_running of
-        false ->
-            % Start up the UDP and TCP servers
-            lager:info("Starting the UDP and TCP supervisor"),
-            erldns_server_sup:start_link(),
-            erldns_events:notify({?MODULE, servers_started}),
-            {ok, State#state{servers_running = true}};
-        _ ->
-            erldns_events:notify({?MODULE, servers_already_started}),
-            {ok, State}
-    end;
+  case State#state.servers_running of
+    false ->
+      % Start up the UDP and TCP servers
+      lager:info("Starting the UDP and TCP supervisor"),
+      erldns_server_sup:start_link(),
+      erldns_events:notify({?MODULE, servers_started}),
+      {ok, State#state{servers_running = true}};
+    _ ->
+      erldns_events:notify({?MODULE, servers_already_started}),
+      {ok, State}
+  end;
+
 handle_event({_M, end_udp, [{host, _Host}]}, State) ->
-    folsom_metrics:notify({udp_request_meter, 1}),
-    folsom_metrics:notify({udp_request_counter, {inc, 1}}),
-    {ok, State};
+  folsom_metrics:notify({udp_request_meter, 1}),
+  folsom_metrics:notify({udp_request_counter, {inc, 1}}),
+  {ok, State};
+
 handle_event({_M, end_tcp, [{host, _Host}]}, State) ->
-    folsom_metrics:notify({tcp_request_meter, 1}),
-    folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
-    {ok, State};
+  folsom_metrics:notify({tcp_request_meter, 1}),
+  folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
+  {ok, State};
+
 handle_event({_M, udp_error, Reason}, State) ->
-    folsom_metrics:notify({udp_error_meter, 1}),
-    folsom_metrics:notify({udp_error_history, Reason}),
-    {ok, State};
+  folsom_metrics:notify({udp_error_meter, 1}),
+  folsom_metrics:notify({udp_error_history, Reason}),
+  {ok, State};
+
 handle_event({_M, tcp_error, Reason}, State) ->
-    folsom_metrics:notify({tcp_error_meter, 1}),
-    folsom_metrics:notify({tcp_error_history, Reason}),
-    {ok, State};
+  folsom_metrics:notify({tcp_error_meter, 1}),
+  folsom_metrics:notify({tcp_error_history, Reason}),
+  {ok, State};
+
 handle_event({_M, dnssec_request, _Host, _Qname}, State) ->
-    folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
-    folsom_metrics:notify(dnssec_request_meter, 1),
-    {ok, State};
+  folsom_metrics:notify(dnssec_request_counter, {inc, 1}),
+  folsom_metrics:notify(dnssec_request_meter, 1),
+  {ok, State};
+
 handle_event({_M = erldns_handler, _E = refused_response, _Questions}, State) ->
-    folsom_metrics:notify({refused_response_meter, 1}),
-    folsom_metrics:notify({refused_response_counter, {inc, 1}}),
-    {ok, State};
+  folsom_metrics:notify({refused_response_meter, 1}),
+  folsom_metrics:notify({refused_response_counter, {inc, 1}}),
+  {ok, State};
+
 handle_event({_M = erldns_handler, _E = empty_response, _Message}, State) ->
-    folsom_metrics:notify({empty_response_meter, 1}),
-    folsom_metrics:notify({empty_response_counter, {inc, 1}}),
-    {ok, State};
+  folsom_metrics:notify({empty_response_meter, 1}),
+  folsom_metrics:notify({empty_response_counter, {inc, 1}}),
+  {ok, State};
+
 handle_event({_M = erldns_handler, _E = resolve_error, {_Exception, _Reason, _Message, _Stacktrace}}, State) ->
-    folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
-    folsom_metrics:notify({erldns_handler_error_meter, 1}),
-    {ok, State};
+  folsom_metrics:notify({erldns_handler_error_counter, {inc, 1}}),
+  folsom_metrics:notify({erldns_handler_error_meter, 1}),
+  {ok, State};
+
 handle_event({M = erldns_zone_encoder, E = unsupported_rrdata_type, Data}, State) ->
-    lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-    {ok, State};
+  lager:info("Unable to encode rrdata (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+  {ok, State};
+
 handle_event({M = erldns_zone_loader, E = read_file_error, Reason}, State) ->
-    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-    {ok, State};
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+  {ok, State};
+
 handle_event({M = erldns_zone_loader, E = put_zone_error, {JsonZone, Reason}}, State) ->
-    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
-    {ok, State};
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p, json: ~p)", [M, E, Reason, JsonZone]),
+  {ok, State};
+
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Reason}}, State) ->
-    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
-    {ok, State};
+  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
+  {ok, State};
+
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Exception, Reason}}, State) ->
-    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)",
-                [M, E, Name, Type, Data, Exception, Reason]),
-    {ok, State};
+  lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Name, Type, Data, Exception, Reason]),
+  {ok, State};
+
 handle_event({M = erldns_zone_parser, E = unsupported_record, Data}, State) ->
-    lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
-    {ok, State};
+  lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
+  {ok, State};
+
 handle_event({M = erldns_decoder, E = decode_message_error, {Exception, Reason, Bin}}, State) ->
-    lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
-    {ok, State};
+  lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
+  {ok, State};
+
 handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, Response}}, State) ->
-    lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
-    {ok, State};
+  lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
+  {ok, State};
+
 handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
-    lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)",
-                [M, E, Response, Opts, Exception, Reason]),
-    {ok, State};
+  lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)", [M, E, Response, Opts,Exception, Reason]),
+  {ok, State};
+
 handle_event({M = erldns_storage, E = failed_zones_load, Reason}, State) ->
-    lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
-    {ok, State};
+  lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),
+  {ok, State};
+
 handle_event({_M = erldns_worker, _E = timeout}, State) ->
-    folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
-    folsom_metrics:notify({worker_timeout_meter, 1}),
-    {ok, State};
+  folsom_metrics:notify({worker_timeout_counter, {inc, 1}}),
+  folsom_metrics:notify({worker_timeout_meter, 1}),
+  {ok, State};
+
 handle_event({M = erldns_worker, E = restart_failed, Error}, State) ->
-    lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
-    {ok, State};
+  lager:error("Restart failed (module: ~p, event: ~p, error: ~p)", [M, E, Error]),
+  {ok, State};
+
 handle_event(_Event, State) ->
-    {ok, State}.
+  {ok, State}.
 
 handle_call(_Message, State) ->
-    {ok, ok, State}.
+  {ok, ok, State}.
 
 handle_info(_Message, State) ->
-    {ok, State}.
+  {ok, State}.
 
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 terminate(_Reason, _State) ->
-    ok.
+  ok.

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -36,7 +36,13 @@ handle_event({_M, start_servers}, State) ->
     false ->
       % Start up the UDP and TCP servers
       lager:info("Starting the UDP and TCP supervisor"),
-      erldns_server_sup:start_link(),
+      supervisor:start_child(erldns_sup, #{
+                               id => erldns_sup,
+                               start => { erldns_server_sup, start_link, []},
+                               restart => permanent,
+                               shutdown => 5000,
+                               type => supervisor,
+                               modules => [erldns_sup]}),
       erldns_events:notify({?MODULE, servers_started}),
       {ok, State#state{servers_running = true}};
     _ ->

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -41,8 +41,7 @@ handle_event({_M, start_servers}, State) ->
                                start => { erldns_server_sup, start_link, []},
                                restart => permanent,
                                shutdown => 5000,
-                               type => supervisor,
-                               modules => [erldns_sup]}),
+                               type => supervisor}),
       erldns_events:notify({?MODULE, servers_started}),
       {ok, State#state{servers_running = true}};
     _ ->

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_events.erl
+++ b/src/erldns_events.erl
@@ -15,27 +15,24 @@
 %% @doc Public API for erldns event handler registration and notification.
 -module(erldns_events).
 
--export([start_link/0,
-         notify/1,
-         add_handler/1,
-         add_handler/2]).
+-export([start_link/0, notify/1, add_handler/1, add_handler/2]).
 
 %% @doc Start the event process.
 -spec start_link() -> any().
 start_link() ->
-    gen_event:start_link({local, ?MODULE}).
+  gen_event:start_link({local, ?MODULE}).
 
 %% @doc Fire an event.
 -spec notify(any()) -> any().
 notify(Event) ->
-    gen_event:notify(?MODULE, Event).
+  gen_event:notify(?MODULE, Event).
 
 %% @doc Add an event handler.
 -spec add_handler(module()) -> any().
 add_handler(Module) ->
-    add_handler(Module, []).
+  add_handler(Module, []).
 
 %% @doc Add an event handler with arguments.
 -spec add_handler(module(), [term()]) -> any().
 add_handler(Module, Args) ->
-    gen_event:add_handler(?MODULE, Module, Args).
+  gen_event:add_handler(?MODULE, Module, Args).

--- a/src/erldns_events.erl
+++ b/src/erldns_events.erl
@@ -15,24 +15,27 @@
 %% @doc Public API for erldns event handler registration and notification.
 -module(erldns_events).
 
--export([start_link/0, notify/1, add_handler/1, add_handler/2]).
+-export([start_link/0,
+         notify/1,
+         add_handler/1,
+         add_handler/2]).
 
 %% @doc Start the event process.
 -spec start_link() -> any().
 start_link() ->
-  gen_event:start_link({local, ?MODULE}).
+    gen_event:start_link({local, ?MODULE}).
 
 %% @doc Fire an event.
 -spec notify(any()) -> any().
 notify(Event) ->
-  gen_event:notify(?MODULE, Event).
+    gen_event:notify(?MODULE, Event).
 
 %% @doc Add an event handler.
 -spec add_handler(module()) -> any().
 add_handler(Module) ->
-  add_handler(Module, []).
+    add_handler(Module, []).
 
 %% @doc Add an event handler with arguments.
 -spec add_handler(module(), [term()]) -> any().
 add_handler(Module, Args) ->
-  gen_event:add_handler(?MODULE, Module, Args).
+    gen_event:add_handler(?MODULE, Module, Args).

--- a/src/erldns_events.erl
+++ b/src/erldns_events.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -20,23 +20,25 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -define(DEFAULT_HANDLER_VERSION, 1).
 
--export([start_link/0, register_handler/2, register_handler/3, get_handlers/0, get_versioned_handlers/0, handle/2]).
-
+-export([start_link/0,
+         register_handler/2,
+         register_handler/3,
+         get_handlers/0,
+         get_versioned_handlers/0,
+         handle/2]).
 -export([do_handle/2]).
-
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
-
+         code_change/3]).
 % Internal API
 -export([handle_message/2]).
 
@@ -45,67 +47,70 @@
 %% @doc Start the handler registry process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Register a record handler.
 -spec register_handler([dns:type()], module()) -> ok.
 register_handler(RecordTypes, Module) ->
-  register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
+    register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
 
 %% @doc Register a record handler with version.
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
-  gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
+    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
 
-%% @doc Get all registered handlers along with the DNS types they handle 
+%% @doc Get all registered handlers along with the DNS types they handle
 -spec get_handlers() -> [{module(), [dns:type()]}].
 get_handlers() ->
-  Handlers  = gen_server:call(?MODULE, {get_handlers}),
-  % return only Version 1 handlers 
-  % strip version information for Version handlers 
-  [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
+    Handlers = gen_server:call(?MODULE, {get_handlers}),
+    % return only Version 1 handlers
+    % strip version information for Version handlers
+    [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
 
 %% @doc Get all registered handlers along with the DNS types they handle and associated versions
 -spec get_versioned_handlers() -> [{module(), [dns:type()], integer()}].
 get_versioned_handlers() ->
-  gen_server:call(?MODULE, {get_handlers}).
+    gen_server:call(?MODULE, {get_handlers}).
 
 % gen_server callbacks
 
 init([]) ->
-  {ok, #state{handlers=[]}}.
+    {ok, #state{handlers = []}}.
 
 handle_call({register_handler, RecordTypes, Module}, _, State) ->
-  lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
-  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
+    lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
+    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
 handle_call({register_handler, RecordTypes, Module, Version}, _, State) ->
-  lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
-  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
+    lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
+    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
 handle_call({get_handlers}, _, State) ->
-  {reply, State#state.handlers, State}.
+    {reply, State#state.handlers, State}.
 
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_, _) ->
-  erldns_storage:delete_table(handler_registry),
-  ok.
+    erldns_storage:delete_table(handler_registry),
+    ok.
+
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% If the message has trailing garbage just throw the garbage away and continue
 %% trying to process the message.
 handle({trailing_garbage, Message, _}, Context) ->
-  handle(Message, Context);
+    handle(Message, Context);
 %% Handle the message, checking to see if it is throttled.
 handle(Message, Context = {_, Host}) when is_record(Message, dns_message) ->
-  handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
+    handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
 %% The message was bad so just return it.
 %% TODO: consider just throwing away the message
 handle(Message, {_, Host}) ->
-  lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
-  Message.
+    lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
+    Message.
 
 %% We throttle ANY queries to discourage use of our authoritative name servers
 %% for reflection attacks.
@@ -113,107 +118,114 @@ handle(Message, {_, Host}) ->
 %% Note: this should probably be changed to return the original packet without
 %% any answer data and with TC bit set to 1.
 handle(Message, Host, {throttled, Host, _ReqCount}) ->
-  folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
-  folsom_metrics:notify({request_throttled_meter, 1}),
-  Message#dns_message{tc = true, aa = true, rc = ?DNS_RCODE_NOERROR};
-
+    folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
+    folsom_metrics:notify({request_throttled_meter, 1}),
+    Message#dns_message{tc = true,
+                        aa = true,
+                        rc = ?DNS_RCODE_NOERROR};
 %% Message was not throttled, so handle it, then do EDNS handling, optionally
 %% append the SOA record if it is a zone transfer and complete the response
 %% by filling out count-related header fields.
 handle(Message, Host, _) ->
-  erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
-  Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
-  erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
-  Response.
+    erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
+    Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
+    erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
+    Response.
 
 do_handle(Message, Host) ->
-  NewMessage = handle_message(Message, Host),
-  complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
+    NewMessage = handle_message(Message, Host),
+    complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
 
 %% Handle the message by hitting the packet cache and either
 %% using the cached packet or continuing with the lookup process.
 %%
 %% If the cache is missed, then the SOA (Start of Authority) is discovered here.
 handle_message(Message, Host) ->
-  case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
-    {ok, CachedResponse} ->
-      erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
-      CachedResponse#dns_message{id=Message#dns_message.id};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
-      handle_packet_cache_miss(Message, get_authority(Message), Host) % SOA lookup
-  end.
+    case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
+        {ok, CachedResponse} ->
+            erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
+            CachedResponse#dns_message{id = Message#dns_message.id};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
+            handle_packet_cache_miss(Message,
+                                     get_authority(Message),
+                                     Host) % SOA lookup
+    end.
 
 %% If the packet is not in the cache and we are not authoritative (because there
 %% is no SOA record for this zone), then answer immediately setting the AA flag to false.
 %% If erldns is configured to use root hints then those will be added to the response.
--spec(handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
+-spec handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
 handle_packet_cache_miss(Message, [], _Host) ->
-  case erldns_config:use_root_hints() of
-    true ->
-      {Authority, Additional} = erldns_records:root_hints(),
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED, authority = Authority, additional = Additional};
-    _ ->
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
-  end;
-
+    case erldns_config:use_root_hints() of
+        true ->
+            {Authority, Additional} = erldns_records:root_hints(),
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_REFUSED,
+                                authority = Authority,
+                                additional = Additional};
+        _ ->
+            Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
+    end;
 %% The packet is not in the cache yet we are authoritative, so try to resolve
 %% the request. This is the point the request moves on to the erldns_resolver
 %% module.
 handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-  safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
+    safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
 
--spec(safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
+-spec safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
 safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} ->
-      Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
-      maybe_cache_packet(Response, Response#dns_message.aa);
-    _ ->
-      try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
-        Response -> maybe_cache_packet(Response, Response#dns_message.aa)
-      catch
-        Exception:Reason:Stacktrace ->
-          lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: ~p)", [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
-          erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
-          Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
+            maybe_cache_packet(Response, Response#dns_message.aa);
+        _ ->
+            try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
+                Response ->
+                    maybe_cache_packet(Response, Response#dns_message.aa)
+            catch
+                Exception:Reason:Stacktrace ->
+                    lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: "
+                                "~p)",
+                                [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
+                    erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
+                    Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
+            end
+    end.
 
 %% We are authoritative so cache the packet and return the message.
 maybe_cache_packet(Message, true) ->
-  erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
-  Message;
-
+    erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
+    Message;
 %% We are not authoritative so just return the message.
 maybe_cache_packet(Message, false) ->
-  Message.
+    Message.
 
 %% Get the SOA authority for the current query.
 get_authority(MessageOrName) ->
-  case erldns_zone_cache:get_authority(MessageOrName) of
-    {ok, Authority} -> Authority;
-    {error, _} -> []
-  end.
+    case erldns_zone_cache:get_authority(MessageOrName) of
+        {ok, Authority} ->
+            Authority;
+        {error, _} ->
+            []
+    end.
 
 %% Update the message counts and set the QR flag to true.
 complete_response(Message) ->
-  notify_empty_response(Message#dns_message{
-    anc = length(Message#dns_message.answers),
-    auc = length(Message#dns_message.authority),
-    adc = length(Message#dns_message.additional),
-    qr = true
-   }).
+    notify_empty_response(Message#dns_message{anc = length(Message#dns_message.answers),
+                                              auc = length(Message#dns_message.authority),
+                                              adc = length(Message#dns_message.additional),
+                                              qr = true}).
 
 notify_empty_response(Message) ->
-  case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
-    {?DNS_RCODE_REFUSED, _} ->
-      erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
-      Message;
-    {_, 0} ->
-      lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
-      erldns_events:notify({?MODULE, empty_response, Message}),
-      Message;
-    _ ->
-      Message
-  end.
+    case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
+        {?DNS_RCODE_REFUSED, _} ->
+            erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
+            Message;
+        {_, 0} ->
+            lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
+            erldns_events:notify({?MODULE, empty_response, Message}),
+            Message;
+        _ ->
+            Message
+    end.

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -20,23 +20,25 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -define(DEFAULT_HANDLER_VERSION, 1).
 
--export([start_link/0, register_handler/2, register_handler/3, get_handlers/0, get_versioned_handlers/0, handle/2]).
-
+-export([start_link/0,
+         register_handler/2,
+         register_handler/3,
+         get_handlers/0,
+         get_versioned_handlers/0,
+         handle/2]).
 -export([do_handle/2]).
-
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
-
+         code_change/3]).
 % Internal API
 -export([handle_message/2]).
 
@@ -45,67 +47,70 @@
 %% @doc Start the handler registry process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Register a record handler.
 -spec register_handler([dns:type()], module()) -> ok.
 register_handler(RecordTypes, Module) ->
-  register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
+    register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
 
 %% @doc Register a record handler with version.
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
-  gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
+    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
 
-%% @doc Get all registered handlers along with the DNS types they handle 
+%% @doc Get all registered handlers along with the DNS types they handle
 -spec get_handlers() -> [{module(), [dns:type()]}].
 get_handlers() ->
-  Handlers  = gen_server:call(?MODULE, {get_handlers}),
-  % return only Version 1 handlers 
-  % strip version information for Version handlers 
-  [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
+    Handlers = gen_server:call(?MODULE, {get_handlers}),
+    % return only Version 1 handlers
+    % strip version information for Version handlers
+    [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
 
 %% @doc Get all registered handlers along with the DNS types they handle and associated versions
 -spec get_versioned_handlers() -> [{module(), [dns:type()], integer()}].
 get_versioned_handlers() ->
-  gen_server:call(?MODULE, {get_handlers}).
+    gen_server:call(?MODULE, {get_handlers}).
 
 % gen_server callbacks
 
 init([]) ->
-  {ok, #state{handlers=[]}}.
+    {ok, #state{handlers = []}}.
 
 handle_call({register_handler, RecordTypes, Module}, _, State) ->
-  lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
-  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
+    lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
+    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
 handle_call({register_handler, RecordTypes, Module, Version}, _, State) ->
-  lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
-  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
+    lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
+    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
 handle_call({get_handlers}, _, State) ->
-  {reply, State#state.handlers, State}.
+    {reply, State#state.handlers, State}.
 
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_, _) ->
-  erldns_storage:delete_table(handler_registry),
-  ok.
+    erldns_storage:delete_table(handler_registry),
+    ok.
+
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% If the message has trailing garbage just throw the garbage away and continue
 %% trying to process the message.
 handle({trailing_garbage, Message, _}, Context) ->
-  handle(Message, Context);
+    handle(Message, Context);
 %% Handle the message, checking to see if it is throttled.
 handle(Message, Context = {_, Host}) when is_record(Message, dns_message) ->
-  handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
+    handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
 %% The message was bad so just return it.
 %% TODO: consider just throwing away the message
 handle(Message, {_, Host}) ->
-  lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
-  Message.
+    lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
+    Message.
 
 %% We throttle ANY queries to discourage use of our authoritative name servers
 %% for reflection attacks.
@@ -113,107 +118,112 @@ handle(Message, {_, Host}) ->
 %% Note: this should probably be changed to return the original packet without
 %% any answer data and with TC bit set to 1.
 handle(Message, Host, {throttled, Host, _ReqCount}) ->
-  folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
-  folsom_metrics:notify({request_throttled_meter, 1}),
-  Message#dns_message{tc = true, aa = true, rc = ?DNS_RCODE_NOERROR};
-
+    folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
+    folsom_metrics:notify({request_throttled_meter, 1}),
+    Message#dns_message{tc = true,
+                        aa = true,
+                        rc = ?DNS_RCODE_NOERROR};
 %% Message was not throttled, so handle it, then do EDNS handling, optionally
 %% append the SOA record if it is a zone transfer and complete the response
 %% by filling out count-related header fields.
 handle(Message, Host, _) ->
-  erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
-  Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
-  erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
-  Response.
+    erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
+    Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
+    erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
+    Response.
 
 do_handle(Message, Host) ->
-  NewMessage = handle_message(Message, Host),
-  complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
+    NewMessage = handle_message(Message, Host),
+    complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
 
 %% Handle the message by hitting the packet cache and either
 %% using the cached packet or continuing with the lookup process.
 %%
 %% If the cache is missed, then the SOA (Start of Authority) is discovered here.
 handle_message(Message, Host) ->
-  case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
-    {ok, CachedResponse} ->
-      erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
-      CachedResponse#dns_message{id=Message#dns_message.id};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
-      handle_packet_cache_miss(Message, get_authority(Message), Host) % SOA lookup
-  end.
+    case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
+        {ok, CachedResponse} ->
+            erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
+            CachedResponse#dns_message{id = Message#dns_message.id};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
+            handle_packet_cache_miss(Message, get_authority(Message), Host) % SOA lookup
+    end.
 
 %% If the packet is not in the cache and we are not authoritative (because there
 %% is no SOA record for this zone), then answer immediately setting the AA flag to false.
 %% If erldns is configured to use root hints then those will be added to the response.
--spec(handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
+-spec handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
 handle_packet_cache_miss(Message, [], _Host) ->
-  case erldns_config:use_root_hints() of
-    true ->
-      {Authority, Additional} = erldns_records:root_hints(),
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED, authority = Authority, additional = Additional};
-    _ ->
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
-  end;
-
+    case erldns_config:use_root_hints() of
+        true ->
+            {Authority, Additional} = erldns_records:root_hints(),
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_REFUSED,
+                                authority = Authority,
+                                additional = Additional};
+        _ ->
+            Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
+    end;
 %% The packet is not in the cache yet we are authoritative, so try to resolve
 %% the request. This is the point the request moves on to the erldns_resolver
 %% module.
 handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-  safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
+    safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
 
--spec(safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
+-spec safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
 safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-  case application:get_env(erldns, catch_exceptions) of
-    {ok, false} ->
-      Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
-      maybe_cache_packet(Response, Response#dns_message.aa);
-    _ ->
-      try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
-        Response -> maybe_cache_packet(Response, Response#dns_message.aa)
-      catch
-        Exception:Reason:Stacktrace ->
-          lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: ~p)", [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
-          erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
-          Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
-      end
-  end.
+    case application:get_env(erldns, catch_exceptions) of
+        {ok, false} ->
+            Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
+            maybe_cache_packet(Response, Response#dns_message.aa);
+        _ ->
+            try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
+                Response ->
+                    maybe_cache_packet(Response, Response#dns_message.aa)
+            catch
+                Exception:Reason:Stacktrace ->
+                    lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: "
+                                "~p)",
+                                [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
+                    erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
+                    Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
+            end
+    end.
 
 %% We are authoritative so cache the packet and return the message.
 maybe_cache_packet(Message, true) ->
-  erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
-  Message;
-
+    erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
+    Message;
 %% We are not authoritative so just return the message.
 maybe_cache_packet(Message, false) ->
-  Message.
+    Message.
 
 %% Get the SOA authority for the current query.
 get_authority(MessageOrName) ->
-  case erldns_zone_cache:get_authority(MessageOrName) of
-    {ok, Authority} -> Authority;
-    {error, _} -> []
-  end.
+    case erldns_zone_cache:get_authority(MessageOrName) of
+        {ok, Authority} ->
+            Authority;
+        {error, _} ->
+            []
+    end.
 
 %% Update the message counts and set the QR flag to true.
 complete_response(Message) ->
-  notify_empty_response(Message#dns_message{
-    anc = length(Message#dns_message.answers),
-    auc = length(Message#dns_message.authority),
-    adc = length(Message#dns_message.additional),
-    qr = true
-   }).
+    notify_empty_response(Message#dns_message{anc = length(Message#dns_message.answers),
+                                              auc = length(Message#dns_message.authority),
+                                              adc = length(Message#dns_message.additional),
+                                              qr = true}).
 
 notify_empty_response(Message) ->
-  case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
-    {?DNS_RCODE_REFUSED, _} ->
-      erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
-      Message;
-    {_, 0} ->
-      lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
-      erldns_events:notify({?MODULE, empty_response, Message}),
-      Message;
-    _ ->
-      Message
-  end.
+    case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
+        {?DNS_RCODE_REFUSED, _} ->
+            erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
+            Message;
+        {_, 0} ->
+            lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
+            erldns_events:notify({?MODULE, empty_response, Message}),
+            Message;
+        _ ->
+            Message
+    end.

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -20,25 +20,23 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -define(DEFAULT_HANDLER_VERSION, 1).
 
--export([start_link/0,
-         register_handler/2,
-         register_handler/3,
-         get_handlers/0,
-         get_versioned_handlers/0,
-         handle/2]).
+-export([start_link/0, register_handler/2, register_handler/3, get_handlers/0, get_versioned_handlers/0, handle/2]).
+
 -export([do_handle/2]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
+
 % Internal API
 -export([handle_message/2]).
 
@@ -47,70 +45,67 @@
 %% @doc Start the handler registry process.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Register a record handler.
 -spec register_handler([dns:type()], module()) -> ok.
 register_handler(RecordTypes, Module) ->
-    register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
+  register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
 
 %% @doc Register a record handler with version.
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
-    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
+  gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
 
-%% @doc Get all registered handlers along with the DNS types they handle
+%% @doc Get all registered handlers along with the DNS types they handle 
 -spec get_handlers() -> [{module(), [dns:type()]}].
 get_handlers() ->
-    Handlers = gen_server:call(?MODULE, {get_handlers}),
-    % return only Version 1 handlers
-    % strip version information for Version handlers
-    [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
+  Handlers  = gen_server:call(?MODULE, {get_handlers}),
+  % return only Version 1 handlers 
+  % strip version information for Version handlers 
+  [erlang:delete_element(3, X) || X <- Handlers, element(3, X) =:= ?DEFAULT_HANDLER_VERSION].
 
 %% @doc Get all registered handlers along with the DNS types they handle and associated versions
 -spec get_versioned_handlers() -> [{module(), [dns:type()], integer()}].
 get_versioned_handlers() ->
-    gen_server:call(?MODULE, {get_handlers}).
+  gen_server:call(?MODULE, {get_handlers}).
 
 % gen_server callbacks
 
 init([]) ->
-    {ok, #state{handlers = []}}.
+  {ok, #state{handlers=[]}}.
 
 handle_call({register_handler, RecordTypes, Module}, _, State) ->
-    lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
-    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
+  lager:info("Registered handler (module: ~p, types: ~p)", [Module, RecordTypes]),
+  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, 1}]}};
 handle_call({register_handler, RecordTypes, Module, Version}, _, State) ->
-    lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
-    {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
+  lager:info("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
+  {reply, ok, State#state{handlers = State#state.handlers ++ [{Module, RecordTypes, Version}]}};
 handle_call({get_handlers}, _, State) ->
-    {reply, State#state.handlers, State}.
+  {reply, State#state.handlers, State}.
 
 handle_cast(_, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 handle_info(_, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 terminate(_, _) ->
-    erldns_storage:delete_table(handler_registry),
-    ok.
-
+  erldns_storage:delete_table(handler_registry),
+  ok.
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% If the message has trailing garbage just throw the garbage away and continue
 %% trying to process the message.
 handle({trailing_garbage, Message, _}, Context) ->
-    handle(Message, Context);
+  handle(Message, Context);
 %% Handle the message, checking to see if it is throttled.
 handle(Message, Context = {_, Host}) when is_record(Message, dns_message) ->
-    handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
+  handle(Message, Host, erldns_query_throttle:throttle(Message, Context));
 %% The message was bad so just return it.
 %% TODO: consider just throwing away the message
 handle(Message, {_, Host}) ->
-    lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
-    Message.
+  lager:error("Received a bad message (module: ~p, event: ~p, message: ~p, host: ~p)", [?MODULE, bad_message, Message, Host]),
+  Message.
 
 %% We throttle ANY queries to discourage use of our authoritative name servers
 %% for reflection attacks.
@@ -118,114 +113,107 @@ handle(Message, {_, Host}) ->
 %% Note: this should probably be changed to return the original packet without
 %% any answer data and with TC bit set to 1.
 handle(Message, Host, {throttled, Host, _ReqCount}) ->
-    folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
-    folsom_metrics:notify({request_throttled_meter, 1}),
-    Message#dns_message{tc = true,
-                        aa = true,
-                        rc = ?DNS_RCODE_NOERROR};
+  folsom_metrics:notify({request_throttled_counter, {inc, 1}}),
+  folsom_metrics:notify({request_throttled_meter, 1}),
+  Message#dns_message{tc = true, aa = true, rc = ?DNS_RCODE_NOERROR};
+
 %% Message was not throttled, so handle it, then do EDNS handling, optionally
 %% append the SOA record if it is a zone transfer and complete the response
 %% by filling out count-related header fields.
 handle(Message, Host, _) ->
-    erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
-    Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
-    erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
-    Response.
+  erldns_events:notify({?MODULE, start_handle, [{host, Host}, {message, Message}]}),
+  Response = folsom_metrics:histogram_timed_update(request_handled_histogram, ?MODULE, do_handle, [Message, Host]),
+  erldns_events:notify({?MODULE, end_handle, [{host, Host}, {message, Message}, {response, Response}]}),
+  Response.
 
 do_handle(Message, Host) ->
-    NewMessage = handle_message(Message, Host),
-    complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
+  NewMessage = handle_message(Message, Host),
+  complete_response(erldns_axfr:optionally_append_soa(NewMessage)).
 
 %% Handle the message by hitting the packet cache and either
 %% using the cached packet or continuing with the lookup process.
 %%
 %% If the cache is missed, then the SOA (Start of Authority) is discovered here.
 handle_message(Message, Host) ->
-    case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
-        {ok, CachedResponse} ->
-            erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
-            CachedResponse#dns_message{id = Message#dns_message.id};
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
-            handle_packet_cache_miss(Message,
-                                     get_authority(Message),
-                                     Host) % SOA lookup
-    end.
+  case erldns_packet_cache:get({Message#dns_message.questions, Message#dns_message.additional}, Host) of
+    {ok, CachedResponse} ->
+      erldns_events:notify({?MODULE, packet_cache_hit, [{host, Host}, {message, Message}]}),
+      CachedResponse#dns_message{id=Message#dns_message.id};
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, packet_cache_miss, [{reason, Reason}, {host, Host}, {message, Message}]}),
+      handle_packet_cache_miss(Message, get_authority(Message), Host) % SOA lookup
+  end.
 
 %% If the packet is not in the cache and we are not authoritative (because there
 %% is no SOA record for this zone), then answer immediately setting the AA flag to false.
 %% If erldns is configured to use root hints then those will be added to the response.
--spec handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
+-spec(handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
 handle_packet_cache_miss(Message, [], _Host) ->
-    case erldns_config:use_root_hints() of
-        true ->
-            {Authority, Additional} = erldns_records:root_hints(),
-            Message#dns_message{aa = false,
-                                rc = ?DNS_RCODE_REFUSED,
-                                authority = Authority,
-                                additional = Additional};
-        _ ->
-            Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
-    end;
+  case erldns_config:use_root_hints() of
+    true ->
+      {Authority, Additional} = erldns_records:root_hints(),
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED, authority = Authority, additional = Additional};
+    _ ->
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED}
+  end;
+
 %% The packet is not in the cache yet we are authoritative, so try to resolve
 %% the request. This is the point the request moves on to the erldns_resolver
 %% module.
 handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-    safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
+  safe_handle_packet_cache_miss(Message#dns_message{ra = false}, AuthorityRecords, Host).
 
--spec safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message().
+-spec(safe_handle_packet_cache_miss(Message :: dns:message(), AuthorityRecords :: dns:authority(), Host :: dns:ip()) -> dns:message()).
 safe_handle_packet_cache_miss(Message, AuthorityRecords, Host) ->
-    case application:get_env(erldns, catch_exceptions) of
-        {ok, false} ->
-            Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
-            maybe_cache_packet(Response, Response#dns_message.aa);
-        _ ->
-            try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
-                Response ->
-                    maybe_cache_packet(Response, Response#dns_message.aa)
-            catch
-                Exception:Reason:Stacktrace ->
-                    lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: "
-                                "~p)",
-                                [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
-                    erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
-                    Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
-            end
-    end.
+  case application:get_env(erldns, catch_exceptions) of
+    {ok, false} ->
+      Response = erldns_resolver:resolve(Message, AuthorityRecords, Host),
+      maybe_cache_packet(Response, Response#dns_message.aa);
+    _ ->
+      try erldns_resolver:resolve(Message, AuthorityRecords, Host) of
+        Response -> maybe_cache_packet(Response, Response#dns_message.aa)
+      catch
+        Exception:Reason:Stacktrace ->
+          lager:error("Error answering request (module: ~p, event: ~p, exception: ~p, reason: ~p, message: ~p, stacktrace: ~p)", [?MODULE, resolve_error, Exception, Reason, Message, Stacktrace]),
+          erldns_events:notify({?MODULE, resolve_error, {Exception, Reason, Message, Stacktrace}}),
+          Message#dns_message{aa = false, rc = ?DNS_RCODE_SERVFAIL}
+      end
+  end.
 
 %% We are authoritative so cache the packet and return the message.
 maybe_cache_packet(Message, true) ->
-    erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
-    Message;
+  erldns_packet_cache:put({Message#dns_message.questions, Message#dns_message.additional}, Message),
+  Message;
+
 %% We are not authoritative so just return the message.
 maybe_cache_packet(Message, false) ->
-    Message.
+  Message.
 
 %% Get the SOA authority for the current query.
 get_authority(MessageOrName) ->
-    case erldns_zone_cache:get_authority(MessageOrName) of
-        {ok, Authority} ->
-            Authority;
-        {error, _} ->
-            []
-    end.
+  case erldns_zone_cache:get_authority(MessageOrName) of
+    {ok, Authority} -> Authority;
+    {error, _} -> []
+  end.
 
 %% Update the message counts and set the QR flag to true.
 complete_response(Message) ->
-    notify_empty_response(Message#dns_message{anc = length(Message#dns_message.answers),
-                                              auc = length(Message#dns_message.authority),
-                                              adc = length(Message#dns_message.additional),
-                                              qr = true}).
+  notify_empty_response(Message#dns_message{
+    anc = length(Message#dns_message.answers),
+    auc = length(Message#dns_message.authority),
+    adc = length(Message#dns_message.additional),
+    qr = true
+   }).
 
 notify_empty_response(Message) ->
-    case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
-        {?DNS_RCODE_REFUSED, _} ->
-            erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
-            Message;
-        {_, 0} ->
-            lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
-            erldns_events:notify({?MODULE, empty_response, Message}),
-            Message;
-        _ ->
-            Message
-    end.
+  case {Message#dns_message.rc, Message#dns_message.anc + Message#dns_message.auc + Message#dns_message.adc} of
+    {?DNS_RCODE_REFUSED, _} ->
+      erldns_events:notify({?MODULE, refused_response, Message#dns_message.questions}),
+      Message;
+    {_, 0} ->
+      lager:info("Empty response (module: ~p, event: ~p, message: ~p)", [?MODULE, empty_response, Message]),
+      erldns_events:notify({?MODULE, empty_response, Message}),
+      Message;
+    _ ->
+      Message
+  end.

--- a/src/erldns_packet_cache.erl
+++ b/src/erldns_packet_cache.erl
@@ -21,117 +21,116 @@
 -behavior(gen_server).
 
 % API
--export([start_link/0,
-         get/1,
-         get/2,
-         put/2,
-         sweep/0,
-         clear/0,
-         stop/0]).
+-export([start_link/0, get/1, get/2, put/2, sweep/0, clear/0, stop/0]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -define(SERVER, ?MODULE).
 
--record(state, {ttl :: non_neg_integer(), ttl_overrides :: [{binary(), non_neg_integer()}], tref :: timer:tref()}).
+-record(state, {
+          ttl :: non_neg_integer(),
+          ttl_overrides :: [{binary(), non_neg_integer()}],
+          tref :: timer:tref()
+         }).
 
 % Public API
 
 %% @doc Start the cache.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Try to retrieve a cached response for the given question.
 -spec get(dns:question() | {dns:question(), [dns:rr()]}) -> {ok, dns:message()} | {error, cache_expired} | {error, cache_miss}.
 get(Key) ->
-    get(Key, unknown).
+  get(Key, unknown).
 
 %% @doc Try to retrieve a cached response for the given question sent
 %% by the given host.
 -spec get(dns:question() | {dns:question(), [dns:rr()]}, dns:ip()) -> {ok, dns:message()} | {error, cache_expired} | {error, cache_miss}.
 get(Key, _Host) ->
-    case erldns_storage:select(packet_cache, Key) of
-        [{Key, {Response, ExpiresAt}}] ->
-            case timestamp() > ExpiresAt of
-                true ->
-                    folsom_metrics:notify(cache_expired_meter, 1),
-                    {error, cache_expired};
-                false ->
-                    folsom_metrics:notify(cache_hit_meter, 1),
-                    {ok, Response}
-            end;
-        _ ->
-            folsom_metrics:notify(cache_miss_meter, 1),
-            {error, cache_miss}
-    end.
+  case erldns_storage:select(packet_cache, Key) of
+    [{Key, {Response, ExpiresAt}}] ->
+      case timestamp() > ExpiresAt of
+        true ->
+          folsom_metrics:notify(cache_expired_meter, 1),
+          {error, cache_expired};
+        false ->
+          folsom_metrics:notify(cache_hit_meter, 1),
+          {ok, Response}
+      end;
+    _ ->
+      folsom_metrics:notify(cache_miss_meter, 1),
+      {error, cache_miss}
+  end.
 
 %% @doc Put the response in the cache for the given question.
 -spec put(dns:question() | {dns:question(), [dns:rr()]}, dns:message()) -> ok.
 put(Key, Response) ->
-    case erldns_config:packet_cache_enabled() of
-        true ->
-            gen_server:call(?SERVER, {set_packet, [Key, Response]});
-        _ ->
-            ok
-    end.
+  case erldns_config:packet_cache_enabled() of
+    true ->
+      gen_server:call(?SERVER, {set_packet, [Key, Response]});
+    _ ->
+      ok
+  end.
 
 %% @doc Remove all old cached packets from the cache.
 -spec sweep() -> any().
 sweep() ->
-    gen_server:cast(?SERVER, sweep).
+  gen_server:cast(?SERVER, sweep).
 
 %% @doc Clean the cache
 -spec clear() -> any().
 clear() ->
-    gen_server:cast(?SERVER, clear).
+  gen_server:cast(?SERVER, clear).
 
 %% @doc Stop the cache
 -spec stop() -> any().
 stop() ->
-    gen_server:call(?SERVER, stop).
+  gen_server:call(?SERVER, stop).
 
 %% Gen server hooks
 -spec init([non_neg_integer()]) -> {ok, #state{}}.
 init([]) ->
-    init([erldns_config:packet_cache_default_ttl()]);
+  init([erldns_config:packet_cache_default_ttl()]);
 init([TTL]) ->
-    erldns_storage:create(packet_cache),
-    {ok, Tref} = timer:apply_interval(erldns_config:packet_cache_sweep_interval(), ?MODULE, sweep, []),
-    {ok,
-     #state{ttl = TTL,
-            ttl_overrides = erldns_config:packet_cache_ttl_overrides(),
-            tref = Tref}}.
+  erldns_storage:create(packet_cache),
+  {ok, Tref} = timer:apply_interval(erldns_config:packet_cache_sweep_interval(), ?MODULE, sweep, []),
+  {ok, #state{ttl = TTL, ttl_overrides = erldns_config:packet_cache_ttl_overrides(), tref = Tref}}.
 
 handle_call({set_packet, [Key, Response]}, _From, State) ->
-    erldns_storage:insert(packet_cache, {Key, {Response, timestamp() + State#state.ttl}}),
-    {reply, ok, State};
+  erldns_storage:insert(packet_cache, {Key, {Response, timestamp() + State#state.ttl}}),
+  {reply, ok, State};
+
 handle_call(stop, _From, State) ->
-    {stop, normal, ok, State}.
+  {stop, normal, ok, State}.
 
 handle_cast(sweep, State) ->
-    Keys = erldns_storage:select(packet_cache, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - 10}], ['$1']}], infinite),
-    lists:foreach(fun(K) -> erldns_storage:delete(packet_cache, K) end, Keys),
-    {noreply, State};
+  Keys = erldns_storage:select(packet_cache, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - 10}], ['$1']}], infinite),
+  lists:foreach(fun(K) -> erldns_storage:delete(packet_cache, K) end, Keys),
+  {noreply, State};
+
 handle_cast(clear, State) ->
-    erldns_storage:empty_table(packet_cache),
-    {noreply, State}.
+  erldns_storage:empty_table(packet_cache),
+  {noreply, State}.
 
 handle_info(_Message, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_Reason, _State) ->
-    erldns_storage:delete_table(packet_cache),
-    ok.
+  erldns_storage:delete_table(packet_cache),
+  ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 timestamp() ->
-    {TM, TS, _} = os:timestamp(),
-    TM * 1000000 + TS.
+  {TM, TS, _} = os:timestamp(),
+  (TM * 1000000) + TS.

--- a/src/erldns_packet_cache.erl
+++ b/src/erldns_packet_cache.erl
@@ -21,116 +21,117 @@
 -behavior(gen_server).
 
 % API
--export([start_link/0, get/1, get/2, put/2, sweep/0, clear/0, stop/0]).
-
+-export([start_link/0,
+         get/1,
+         get/2,
+         put/2,
+         sweep/0,
+         clear/0,
+         stop/0]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 
--record(state, {
-          ttl :: non_neg_integer(),
-          ttl_overrides :: [{binary(), non_neg_integer()}],
-          tref :: timer:tref()
-         }).
+-record(state, {ttl :: non_neg_integer(), ttl_overrides :: [{binary(), non_neg_integer()}], tref :: timer:tref()}).
 
 % Public API
 
 %% @doc Start the cache.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Try to retrieve a cached response for the given question.
 -spec get(dns:question() | {dns:question(), [dns:rr()]}) -> {ok, dns:message()} | {error, cache_expired} | {error, cache_miss}.
 get(Key) ->
-  get(Key, unknown).
+    get(Key, unknown).
 
 %% @doc Try to retrieve a cached response for the given question sent
 %% by the given host.
 -spec get(dns:question() | {dns:question(), [dns:rr()]}, dns:ip()) -> {ok, dns:message()} | {error, cache_expired} | {error, cache_miss}.
 get(Key, _Host) ->
-  case erldns_storage:select(packet_cache, Key) of
-    [{Key, {Response, ExpiresAt}}] ->
-      case timestamp() > ExpiresAt of
-        true ->
-          folsom_metrics:notify(cache_expired_meter, 1),
-          {error, cache_expired};
-        false ->
-          folsom_metrics:notify(cache_hit_meter, 1),
-          {ok, Response}
-      end;
-    _ ->
-      folsom_metrics:notify(cache_miss_meter, 1),
-      {error, cache_miss}
-  end.
+    case erldns_storage:select(packet_cache, Key) of
+        [{Key, {Response, ExpiresAt}}] ->
+            case timestamp() > ExpiresAt of
+                true ->
+                    folsom_metrics:notify(cache_expired_meter, 1),
+                    {error, cache_expired};
+                false ->
+                    folsom_metrics:notify(cache_hit_meter, 1),
+                    {ok, Response}
+            end;
+        _ ->
+            folsom_metrics:notify(cache_miss_meter, 1),
+            {error, cache_miss}
+    end.
 
 %% @doc Put the response in the cache for the given question.
 -spec put(dns:question() | {dns:question(), [dns:rr()]}, dns:message()) -> ok.
 put(Key, Response) ->
-  case erldns_config:packet_cache_enabled() of
-    true ->
-      gen_server:call(?SERVER, {set_packet, [Key, Response]});
-    _ ->
-      ok
-  end.
+    case erldns_config:packet_cache_enabled() of
+        true ->
+            gen_server:call(?SERVER, {set_packet, [Key, Response]});
+        _ ->
+            ok
+    end.
 
 %% @doc Remove all old cached packets from the cache.
 -spec sweep() -> any().
 sweep() ->
-  gen_server:cast(?SERVER, sweep).
+    gen_server:cast(?SERVER, sweep).
 
 %% @doc Clean the cache
 -spec clear() -> any().
 clear() ->
-  gen_server:cast(?SERVER, clear).
+    gen_server:cast(?SERVER, clear).
 
 %% @doc Stop the cache
 -spec stop() -> any().
 stop() ->
-  gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop).
 
 %% Gen server hooks
 -spec init([non_neg_integer()]) -> {ok, #state{}}.
 init([]) ->
-  init([erldns_config:packet_cache_default_ttl()]);
+    init([erldns_config:packet_cache_default_ttl()]);
 init([TTL]) ->
-  erldns_storage:create(packet_cache),
-  {ok, Tref} = timer:apply_interval(erldns_config:packet_cache_sweep_interval(), ?MODULE, sweep, []),
-  {ok, #state{ttl = TTL, ttl_overrides = erldns_config:packet_cache_ttl_overrides(), tref = Tref}}.
+    erldns_storage:create(packet_cache),
+    {ok, Tref} = timer:apply_interval(erldns_config:packet_cache_sweep_interval(), ?MODULE, sweep, []),
+    {ok,
+     #state{ttl = TTL,
+            ttl_overrides = erldns_config:packet_cache_ttl_overrides(),
+            tref = Tref}}.
 
 handle_call({set_packet, [Key, Response]}, _From, State) ->
-  erldns_storage:insert(packet_cache, {Key, {Response, timestamp() + State#state.ttl}}),
-  {reply, ok, State};
-
+    erldns_storage:insert(packet_cache, {Key, {Response, timestamp() + State#state.ttl}}),
+    {reply, ok, State};
 handle_call(stop, _From, State) ->
-  {stop, normal, ok, State}.
+    {stop, normal, ok, State}.
 
 handle_cast(sweep, State) ->
-  Keys = erldns_storage:select(packet_cache, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - 10}], ['$1']}], infinite),
-  lists:foreach(fun(K) -> erldns_storage:delete(packet_cache, K) end, Keys),
-  {noreply, State};
-
+    Keys = erldns_storage:select(packet_cache, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - 10}], ['$1']}], infinite),
+    lists:foreach(fun(K) -> erldns_storage:delete(packet_cache, K) end, Keys),
+    {noreply, State};
 handle_cast(clear, State) ->
-  erldns_storage:empty_table(packet_cache),
-  {noreply, State}.
+    erldns_storage:empty_table(packet_cache),
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  erldns_storage:delete_table(packet_cache),
-  ok.
+    erldns_storage:delete_table(packet_cache),
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 timestamp() ->
-  {TM, TS, _} = os:timestamp(),
-  (TM * 1000000) + TS.
+    {TM, TS, _} = os:timestamp(),
+    TM * 1000000 + TS.

--- a/src/erldns_packet_cache.erl
+++ b/src/erldns_packet_cache.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -22,19 +22,21 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
 %% API
--export([start_link/0, throttle/2, sweep/0, stop/0]).
-
+-export([start_link/0,
+         throttle/2,
+         sweep/0,
+         stop/0]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 %% Types
 -export_type([throttle_result/0, throttle_hit_count/0]).
+
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.
 
@@ -48,92 +50,99 @@
 %% @doc Start the query throttle process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Throttle the given message if necessary.
--spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) ->
-  ok | throttle_result().
--if(not(ENABLED)).
+-spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) -> ok | throttle_result().
+-if(not ENABLED).
+
 throttle(_Message, {_, _Host}) ->
     %% lager:debug("Throttle not enabled"),
     ok.
+
 -else.
+
 throttle(_Message, {tcp, _Host}) ->
-  ok;
+    ok;
 throttle(Message, {_, Host}) ->
     case lists:filter(fun(Q) -> Q#dns_query.type =:= ?DNS_TYPE_ANY end, Message#dns_message.questions) of
-        [] -> ok;
-        _ -> record_request(maybe_throttle(Host))
+        [] ->
+            ok;
+        _ ->
+            record_request(maybe_throttle(Host))
     end.
 
 %% Internal
--spec(maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result()).
+-spec maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result().
 maybe_throttle(Host) ->
-  case erldns_storage:select(host_throttle, Host) of
-    [{_, {ReqCount, LastRequestAt}}] ->
-      case is_throttled(Host, ReqCount, LastRequestAt) of
-        {true, NewReqCount} -> {throttled, Host, NewReqCount};
-        {false, NewReqCount} -> {ok, Host, NewReqCount}
-      end;
-    [] ->
-      {ok, Host, 1}
-  end.
+    case erldns_storage:select(host_throttle, Host) of
+        [{_, {ReqCount, LastRequestAt}}] ->
+            case is_throttled(Host, ReqCount, LastRequestAt) of
+                {true, NewReqCount} ->
+                    {throttled, Host, NewReqCount};
+                {false, NewReqCount} ->
+                    {ok, Host, NewReqCount}
+            end;
+        [] ->
+            {ok, Host, 1}
+    end.
 
--spec(record_request(throttle_result()) -> throttle_result()).
+-spec record_request(throttle_result()) -> throttle_result().
 record_request(Res = {_ThrottleResponse, Host, ReqCount}) ->
-  erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
-  Res.
+    erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
+    Res.
 
-is_throttled({127,0,0,1}, ReqCount, _) -> {false, ReqCount + 1};
+is_throttled({127, 0, 0, 1}, ReqCount, _) ->
+    {false, ReqCount + 1};
 is_throttled(Host, ReqCount, LastRequestAt) ->
-  ExceedsLimit = ReqCount >= ?LIMIT,
-  Expired = timestamp() - LastRequestAt > ?EXPIRATION,
-  case Expired of
-    true ->
-      erldns_storage:delete(host_throttle, Host),
-      {false, 1};
-    false ->
-      {ExceedsLimit, ReqCount + 1}
-  end.
+    ExceedsLimit = ReqCount >= ?LIMIT,
+    Expired = timestamp() - LastRequestAt > ?EXPIRATION,
+    case Expired of
+        true ->
+            erldns_storage:delete(host_throttle, Host),
+            {false, 1};
+        false ->
+            {ExceedsLimit, ReqCount + 1}
+    end.
+
 -endif.
 
 %% @doc Sweep the query throttle table for expired host records.
 -spec sweep() -> any().
 sweep() ->
-  gen_server:cast(?MODULE, sweep).
+    gen_server:cast(?MODULE, sweep).
 
 %% @doc Stop the query throttle process normally.
 -spec stop() -> any().
 stop() ->
-  gen_server:call(?MODULE, stop).
-
+    gen_server:call(?MODULE, stop).
 
 % Gen server hooks
 init([]) ->
-  erldns_storage:create(host_throttle),
-  {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
-  {ok, #state{tref = Tref}}.
+    erldns_storage:create(host_throttle),
+    {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
+    {ok, #state{tref = Tref}}.
 
 handle_call(stop, _From, State) ->
-  {stop, normal, ok, State}.
+    {stop, normal, ok, State}.
 
 handle_cast(sweep, State) ->
-  Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
-  lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
-  {noreply, State}.
+    Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
+    lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  erldns_storage:delete_table(host_throttle),
-  ok.
+    erldns_storage:delete_table(host_throttle),
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% Internal API
 
 timestamp() ->
-  {TM, TS, _} = os:timestamp(),
-  (TM * 1000000) + TS.
+    {TM, TS, _} = os:timestamp(),
+    TM * 1000000 + TS.

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -22,21 +22,19 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
 %% API
--export([start_link/0,
-         throttle/2,
-         sweep/0,
-         stop/0]).
+-export([start_link/0, throttle/2, sweep/0, stop/0]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 %% Types
 -export_type([throttle_result/0, throttle_hit_count/0]).
-
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.
 
@@ -50,99 +48,92 @@
 %% @doc Start the query throttle process.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Throttle the given message if necessary.
--spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) -> ok | throttle_result().
--if(not ENABLED).
-
+-spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) ->
+  ok | throttle_result().
+-if(not(ENABLED)).
 throttle(_Message, {_, _Host}) ->
     %% lager:debug("Throttle not enabled"),
     ok.
-
 -else.
-
 throttle(_Message, {tcp, _Host}) ->
-    ok;
+  ok;
 throttle(Message, {_, Host}) ->
     case lists:filter(fun(Q) -> Q#dns_query.type =:= ?DNS_TYPE_ANY end, Message#dns_message.questions) of
-        [] ->
-            ok;
-        _ ->
-            record_request(maybe_throttle(Host))
+        [] -> ok;
+        _ -> record_request(maybe_throttle(Host))
     end.
 
 %% Internal
--spec maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result().
+-spec(maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result()).
 maybe_throttle(Host) ->
-    case erldns_storage:select(host_throttle, Host) of
-        [{_, {ReqCount, LastRequestAt}}] ->
-            case is_throttled(Host, ReqCount, LastRequestAt) of
-                {true, NewReqCount} ->
-                    {throttled, Host, NewReqCount};
-                {false, NewReqCount} ->
-                    {ok, Host, NewReqCount}
-            end;
-        [] ->
-            {ok, Host, 1}
-    end.
+  case erldns_storage:select(host_throttle, Host) of
+    [{_, {ReqCount, LastRequestAt}}] ->
+      case is_throttled(Host, ReqCount, LastRequestAt) of
+        {true, NewReqCount} -> {throttled, Host, NewReqCount};
+        {false, NewReqCount} -> {ok, Host, NewReqCount}
+      end;
+    [] ->
+      {ok, Host, 1}
+  end.
 
--spec record_request(throttle_result()) -> throttle_result().
+-spec(record_request(throttle_result()) -> throttle_result()).
 record_request(Res = {_ThrottleResponse, Host, ReqCount}) ->
-    erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
-    Res.
+  erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
+  Res.
 
-is_throttled({127, 0, 0, 1}, ReqCount, _) ->
-    {false, ReqCount + 1};
+is_throttled({127,0,0,1}, ReqCount, _) -> {false, ReqCount + 1};
 is_throttled(Host, ReqCount, LastRequestAt) ->
-    ExceedsLimit = ReqCount >= ?LIMIT,
-    Expired = timestamp() - LastRequestAt > ?EXPIRATION,
-    case Expired of
-        true ->
-            erldns_storage:delete(host_throttle, Host),
-            {false, 1};
-        false ->
-            {ExceedsLimit, ReqCount + 1}
-    end.
-
+  ExceedsLimit = ReqCount >= ?LIMIT,
+  Expired = timestamp() - LastRequestAt > ?EXPIRATION,
+  case Expired of
+    true ->
+      erldns_storage:delete(host_throttle, Host),
+      {false, 1};
+    false ->
+      {ExceedsLimit, ReqCount + 1}
+  end.
 -endif.
 
 %% @doc Sweep the query throttle table for expired host records.
 -spec sweep() -> any().
 sweep() ->
-    gen_server:cast(?MODULE, sweep).
+  gen_server:cast(?MODULE, sweep).
 
 %% @doc Stop the query throttle process normally.
 -spec stop() -> any().
 stop() ->
-    gen_server:call(?MODULE, stop).
+  gen_server:call(?MODULE, stop).
+
 
 % Gen server hooks
 init([]) ->
-    erldns_storage:create(host_throttle),
-    {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
-    {ok, #state{tref = Tref}}.
+  erldns_storage:create(host_throttle),
+  {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
+  {ok, #state{tref = Tref}}.
 
 handle_call(stop, _From, State) ->
-    {stop, normal, ok, State}.
+  {stop, normal, ok, State}.
 
 handle_cast(sweep, State) ->
-    Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
-    lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
-    {noreply, State}.
+  Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
+  lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
+  {noreply, State}.
 
 handle_info(_Message, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_Reason, _State) ->
-    erldns_storage:delete_table(host_throttle),
-    ok.
+  erldns_storage:delete_table(host_throttle),
+  ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% Internal API
 
 timestamp() ->
-    {TM, TS, _} = os:timestamp(),
-    TM * 1000000 + TS.
+  {TM, TS, _} = os:timestamp(),
+  (TM * 1000000) + TS.

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -35,7 +35,8 @@
          code_change/3]).
 
 %% Types
--export_type([throttle_result/0, throttle_hit_count/0]).
+-export_type([throttle_result/0,
+              throttle_hit_count/0]).
 
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -22,19 +22,22 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
 %% API
--export([start_link/0, throttle/2, sweep/0, stop/0]).
-
+-export([start_link/0,
+         throttle/2,
+         sweep/0,
+         stop/0]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 %% Types
--export_type([throttle_result/0, throttle_hit_count/0]).
+-export_type([throttle_result/0,
+              throttle_hit_count/0]).
+
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.
 
@@ -48,92 +51,99 @@
 %% @doc Start the query throttle process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Throttle the given message if necessary.
--spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) ->
-  ok | throttle_result().
--if(not(ENABLED)).
+-spec throttle(dns:message(), Context :: {term(), Host :: inet:ip_address() | inet:hostname()}) -> ok | throttle_result().
+-if(not ENABLED).
+
 throttle(_Message, {_, _Host}) ->
     %% lager:debug("Throttle not enabled"),
     ok.
+
 -else.
+
 throttle(_Message, {tcp, _Host}) ->
-  ok;
+    ok;
 throttle(Message, {_, Host}) ->
     case lists:filter(fun(Q) -> Q#dns_query.type =:= ?DNS_TYPE_ANY end, Message#dns_message.questions) of
-        [] -> ok;
-        _ -> record_request(maybe_throttle(Host))
+        [] ->
+            ok;
+        _ ->
+            record_request(maybe_throttle(Host))
     end.
 
 %% Internal
--spec(maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result()).
+-spec maybe_throttle(inet:ip_address() | inet:hostname()) -> throttle_result().
 maybe_throttle(Host) ->
-  case erldns_storage:select(host_throttle, Host) of
-    [{_, {ReqCount, LastRequestAt}}] ->
-      case is_throttled(Host, ReqCount, LastRequestAt) of
-        {true, NewReqCount} -> {throttled, Host, NewReqCount};
-        {false, NewReqCount} -> {ok, Host, NewReqCount}
-      end;
-    [] ->
-      {ok, Host, 1}
-  end.
+    case erldns_storage:select(host_throttle, Host) of
+        [{_, {ReqCount, LastRequestAt}}] ->
+            case is_throttled(Host, ReqCount, LastRequestAt) of
+                {true, NewReqCount} ->
+                    {throttled, Host, NewReqCount};
+                {false, NewReqCount} ->
+                    {ok, Host, NewReqCount}
+            end;
+        [] ->
+            {ok, Host, 1}
+    end.
 
--spec(record_request(throttle_result()) -> throttle_result()).
+-spec record_request(throttle_result()) -> throttle_result().
 record_request(Res = {_ThrottleResponse, Host, ReqCount}) ->
-  erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
-  Res.
+    erldns_storage:insert(host_throttle, {Host, {ReqCount, timestamp()}}),
+    Res.
 
-is_throttled({127,0,0,1}, ReqCount, _) -> {false, ReqCount + 1};
+is_throttled({127, 0, 0, 1}, ReqCount, _) ->
+    {false, ReqCount + 1};
 is_throttled(Host, ReqCount, LastRequestAt) ->
-  ExceedsLimit = ReqCount >= ?LIMIT,
-  Expired = timestamp() - LastRequestAt > ?EXPIRATION,
-  case Expired of
-    true ->
-      erldns_storage:delete(host_throttle, Host),
-      {false, 1};
-    false ->
-      {ExceedsLimit, ReqCount + 1}
-  end.
+    ExceedsLimit = ReqCount >= ?LIMIT,
+    Expired = timestamp() - LastRequestAt > ?EXPIRATION,
+    case Expired of
+        true ->
+            erldns_storage:delete(host_throttle, Host),
+            {false, 1};
+        false ->
+            {ExceedsLimit, ReqCount + 1}
+    end.
+
 -endif.
 
 %% @doc Sweep the query throttle table for expired host records.
 -spec sweep() -> any().
 sweep() ->
-  gen_server:cast(?MODULE, sweep).
+    gen_server:cast(?MODULE, sweep).
 
 %% @doc Stop the query throttle process normally.
 -spec stop() -> any().
 stop() ->
-  gen_server:call(?MODULE, stop).
-
+    gen_server:call(?MODULE, stop).
 
 % Gen server hooks
 init([]) ->
-  erldns_storage:create(host_throttle),
-  {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
-  {ok, #state{tref = Tref}}.
+    erldns_storage:create(host_throttle),
+    {ok, Tref} = timer:apply_interval(?SWEEP_INTERVAL, ?MODULE, sweep, []),
+    {ok, #state{tref = Tref}}.
 
 handle_call(stop, _From, State) ->
-  {stop, normal, ok, State}.
+    {stop, normal, ok, State}.
 
 handle_cast(sweep, State) ->
-  Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
-  lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
-  {noreply, State}.
+    Keys = erldns_storage:select(host_throttle, [{{'$1', {'_', '$2'}}, [{'<', '$2', timestamp() - ?EXPIRATION}], ['$1']}], infinite),
+    lists:foreach(fun(K) -> erldns_storage:delete(host_throttle, K) end, Keys),
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  erldns_storage:delete_table(host_throttle),
-  ok.
+    erldns_storage:delete_table(host_throttle),
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% Internal API
 
 timestamp() ->
-  {TM, TS, _} = os:timestamp(),
-  (TM * 1000000) + TS.
+    {TM, TS, _} = os:timestamp(),
+    TM * 1000000 + TS.

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -35,8 +35,7 @@
          code_change/3]).
 
 %% Types
--export_type([throttle_result/0,
-              throttle_hit_count/0]).
+-export_type([throttle_result/0, throttle_hit_count/0]).
 
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -16,36 +16,30 @@
 -module(erldns_records).
 
 -include("erldns.hrl").
+
 -include_lib("dns_erlang/include/dns.hrl").
+
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 % Wildcard functions
--export([
-         optionally_convert_wildcard/2,
-         wildcard_qname/1
-        ]).
-
+-export([optionally_convert_wildcard/2,
+         wildcard_qname/1]).
 % SOA TTL functions
--export([
-         minimum_soa_ttl/2,
-         rewrite_soa_ttl/1
-        ]).
-
+-export([minimum_soa_ttl/2,
+         rewrite_soa_ttl/1]).
 % Matcher functions
--export([
-         match_name/1,
+-export([match_name/1,
          match_type/1,
          match_name_and_type/2,
          match_types/1,
          match_wildcard/0,
          match_delegation/1,
-         match_type_covered/1
-        ]).
-
--export([
-         default_ttl/1,
+         match_type_covered/1]).
+-export([default_ttl/1,
          default_priority/1,
          name_type/1,
          root_hints/0,
@@ -54,275 +48,390 @@
 %% @doc If given Name is a wildcard name then the original qname needs to be returned in its place.
 -spec optionally_convert_wildcard(dns:dname(), dns:dname()) -> dns:dname().
 optionally_convert_wildcard(Name, Qname) ->
-  [Head|_] = dns:dname_to_labels(Name),
-  case Head of
-    <<"*">> -> Qname;
-    _ -> Name
-  end.
+    [Head | _] = dns:dname_to_labels(Name),
+    case Head of
+        <<"*">> ->
+            Qname;
+        _ ->
+            Name
+    end.
 
 %% @doc Get a wildcard variation of a Qname. Replaces the leading abel with an asterisk for wildcard lookup.
 -spec wildcard_qname(dns:dname()) -> dns:dname().
 wildcard_qname(Qname) ->
-  [_|Rest] = dns:dname_to_labels(Qname),
-  dns:labels_to_dname([<<"*">>] ++ Rest).
+    [_ | Rest] = dns:dname_to_labels(Qname),
+    dns:labels_to_dname([<<"*">>] ++ Rest).
 
 %% @doc Return the TTL value or 3600 if it is undefined.
 -spec default_ttl(integer() | undefined) -> integer().
 default_ttl(TTL) ->
-  case TTL of
-    undefined -> 3600;
-    Value -> Value
-  end.
+    case TTL of
+        undefined ->
+            3600;
+        Value ->
+            Value
+    end.
 
 %% @doc Return the Priority value or 0 if it is undefined.
 -spec default_priority(integer() | undefined) -> integer().
 default_priority(Priority) ->
-  case Priority of
-    undefined -> 0;
-    Value -> Value
-  end.
+    case Priority of
+        undefined ->
+            0;
+        Value ->
+            Value
+    end.
 
 %% @doc Applies a minimum TTL based on the SOA minumum value.
 %%
 %% The first argument is the Record that is being updated.
 %% The second argument is the SOA RR Data.
 -spec minimum_soa_ttl(dns:dns_rr(), dns:dns_rrdata_soa()) -> dns:dns_rr().
-minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) -> Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
-minimum_soa_ttl(Record, _) -> Record.
+minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) ->
+    Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
+minimum_soa_ttl(Record, _) ->
+    Record.
 
 %% @doc According to RFC 2308 the TTL for the SOA record in an NXDOMAIN response
 %% must be set to the value of the minimum field in the SOA content.
 -spec rewrite_soa_ttl(dns:message()) -> dns:message().
-rewrite_soa_ttl(Message) -> rewrite_soa_ttl(Message, Message#dns_message.authority, []).
+rewrite_soa_ttl(Message) ->
+    rewrite_soa_ttl(Message, Message#dns_message.authority, []).
 
-rewrite_soa_ttl(Message, [], NewAuthority) -> Message#dns_message{authority = NewAuthority};
-rewrite_soa_ttl(Message, [R|Rest], NewAuthority) -> rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
-
+rewrite_soa_ttl(Message, [], NewAuthority) ->
+    Message#dns_message{authority = NewAuthority};
+rewrite_soa_ttl(Message, [R | Rest], NewAuthority) ->
+    rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
 
 %% Various matching functions.
 
 -spec match_name(dns:name()) -> fun((dns:rr()) -> boolean()).
 match_name(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.name =:= Name
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.name =:= Name end.
 
 -spec match_type(dns:type()) -> fun((dns:rr()) -> boolean()).
 match_type(Type) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.type =:= Type
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.type =:= Type end.
 
 -spec match_name_and_type(dns:name(), dns:type()) -> fun((dns:rr()) -> boolean()).
 match_name_and_type(Name, Type) ->
-  fun(R) when is_record(R, dns_rr) ->
-      (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type)
-  end.
+    fun(R) when is_record(R, dns_rr) -> (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type) end.
 
 -spec match_types([dns:type()]) -> fun((dns:rr()) -> boolean()).
 match_types(Types) ->
-  fun(R) when is_record(R, dns_rr) ->
-      lists:any(fun(T) -> R#dns_rr.type =:= T end, Types)
-  end.
+    fun(R) when is_record(R, dns_rr) -> lists:any(fun(T) -> R#dns_rr.type =:= T end, Types) end.
 
 -spec match_wildcard() -> fun((dns:rr()) -> boolean()).
 match_wildcard() ->
-  fun(R) when is_record(R, dns_rr) ->
-      lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name))
-  end.
+    fun(R) when is_record(R, dns_rr) -> lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name)) end.
 
 -spec match_wildcard_label() -> fun((binary()) -> boolean()).
 match_wildcard_label() ->
-  fun(L) ->
-      L =:= <<"*">>
-  end.
+    fun(L) -> L =:= <<"*">> end.
 
 -spec match_delegation(dns:dname()) -> fun((dns:rr()) -> boolean()).
 match_delegation(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.data =:= #dns_rrdata_ns{dname=Name}
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.data =:= #dns_rrdata_ns{dname = Name} end.
 
--spec(match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean())).
+-spec match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean()).
 match_type_covered(Qtype) ->
-  fun(RRSig) ->
-      RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype
-  end.
-
+    fun(RRSig) -> RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype end.
 
 %% Replacement functions.
 
 replace_name(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr{name = Name}
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr{name = Name} end.
 
 %% @doc Returns the type value given a binary string.
--spec name_type(binary()) -> dns:type() | 'undefined'.
+-spec name_type(binary()) -> dns:type() | undefined.
 name_type(Type) when is_binary(Type) ->
-  case Type of
-    ?DNS_TYPE_A_BSTR -> ?DNS_TYPE_A_NUMBER;
-    ?DNS_TYPE_NS_BSTR -> ?DNS_TYPE_NS_NUMBER;
-    ?DNS_TYPE_MD_BSTR -> ?DNS_TYPE_MD_NUMBER;
-    ?DNS_TYPE_MF_BSTR -> ?DNS_TYPE_MF_NUMBER;
-    ?DNS_TYPE_CNAME_BSTR -> ?DNS_TYPE_CNAME_NUMBER;
-    ?DNS_TYPE_SOA_BSTR -> ?DNS_TYPE_SOA_NUMBER;
-    ?DNS_TYPE_MB_BSTR -> ?DNS_TYPE_MB_NUMBER;
-    ?DNS_TYPE_MG_BSTR -> ?DNS_TYPE_MG_NUMBER;
-    ?DNS_TYPE_MR_BSTR -> ?DNS_TYPE_MR_NUMBER;
-    ?DNS_TYPE_NULL_BSTR -> ?DNS_TYPE_NULL_NUMBER;
-    ?DNS_TYPE_WKS_BSTR -> ?DNS_TYPE_WKS_NUMBER;
-    ?DNS_TYPE_PTR_BSTR -> ?DNS_TYPE_PTR_NUMBER;
-    ?DNS_TYPE_HINFO_BSTR -> ?DNS_TYPE_HINFO_NUMBER;
-    ?DNS_TYPE_MINFO_BSTR -> ?DNS_TYPE_MINFO_NUMBER;
-    ?DNS_TYPE_MX_BSTR -> ?DNS_TYPE_MX_NUMBER;
-    ?DNS_TYPE_TXT_BSTR -> ?DNS_TYPE_TXT_NUMBER;
-    ?DNS_TYPE_RP_BSTR -> ?DNS_TYPE_RP_NUMBER;
-    ?DNS_TYPE_AFSDB_BSTR -> ?DNS_TYPE_AFSDB_NUMBER;
-    ?DNS_TYPE_X25_BSTR -> ?DNS_TYPE_X25_NUMBER;
-    ?DNS_TYPE_ISDN_BSTR -> ?DNS_TYPE_ISDN_NUMBER;
-    ?DNS_TYPE_RT_BSTR -> ?DNS_TYPE_RT_NUMBER;
-    ?DNS_TYPE_NSAP_BSTR -> ?DNS_TYPE_NSAP_NUMBER;
-    ?DNS_TYPE_SIG_BSTR -> ?DNS_TYPE_SIG_NUMBER;
-    ?DNS_TYPE_KEY_BSTR -> ?DNS_TYPE_KEY_NUMBER;
-    ?DNS_TYPE_PX_BSTR -> ?DNS_TYPE_PX_NUMBER;
-    ?DNS_TYPE_GPOS_BSTR -> ?DNS_TYPE_GPOS_NUMBER;
-    ?DNS_TYPE_AAAA_BSTR -> ?DNS_TYPE_AAAA_NUMBER;
-    ?DNS_TYPE_LOC_BSTR -> ?DNS_TYPE_LOC_NUMBER;
-    ?DNS_TYPE_NXT_BSTR -> ?DNS_TYPE_NXT_NUMBER;
-    ?DNS_TYPE_EID_BSTR -> ?DNS_TYPE_EID_NUMBER;
-    ?DNS_TYPE_NIMLOC_BSTR -> ?DNS_TYPE_NIMLOC_NUMBER;
-    ?DNS_TYPE_SRV_BSTR -> ?DNS_TYPE_SRV_NUMBER;
-    ?DNS_TYPE_ATMA_BSTR -> ?DNS_TYPE_ATMA_NUMBER;
-    ?DNS_TYPE_NAPTR_BSTR -> ?DNS_TYPE_NAPTR_NUMBER;
-    ?DNS_TYPE_KX_BSTR -> ?DNS_TYPE_KX_NUMBER;
-    ?DNS_TYPE_CERT_BSTR -> ?DNS_TYPE_CERT_NUMBER;
-    ?DNS_TYPE_DNAME_BSTR -> ?DNS_TYPE_DNAME_NUMBER;
-    ?DNS_TYPE_SINK_BSTR -> ?DNS_TYPE_SINK_NUMBER;
-    ?DNS_TYPE_OPT_BSTR -> ?DNS_TYPE_OPT_NUMBER;
-    ?DNS_TYPE_APL_BSTR -> ?DNS_TYPE_APL_NUMBER;
-    ?DNS_TYPE_DS_BSTR -> ?DNS_TYPE_DS_NUMBER;
-    ?DNS_TYPE_CDS_BSTR -> ?DNS_TYPE_CDS_NUMBER;
-    ?DNS_TYPE_SSHFP_BSTR -> ?DNS_TYPE_SSHFP_NUMBER;
-    ?DNS_TYPE_IPSECKEY_BSTR -> ?DNS_TYPE_IPSECKEY_NUMBER;
-    ?DNS_TYPE_RRSIG_BSTR -> ?DNS_TYPE_RRSIG_NUMBER;
-    ?DNS_TYPE_NSEC_BSTR -> ?DNS_TYPE_NSEC_NUMBER;
-    ?DNS_TYPE_DNSKEY_BSTR -> ?DNS_TYPE_DNSKEY_NUMBER;
-    ?DNS_TYPE_CDNSKEY_BSTR -> ?DNS_TYPE_CDNSKEY_NUMBER;
-    ?DNS_TYPE_NSEC3_BSTR -> ?DNS_TYPE_NSEC3_NUMBER;
-    ?DNS_TYPE_NSEC3PARAM_BSTR -> ?DNS_TYPE_NSEC3PARAM_NUMBER;
-    ?DNS_TYPE_DHCID_BSTR -> ?DNS_TYPE_DHCID_NUMBER;
-    ?DNS_TYPE_HIP_BSTR -> ?DNS_TYPE_HIP_NUMBER;
-    ?DNS_TYPE_NINFO_BSTR -> ?DNS_TYPE_NINFO_NUMBER;
-    ?DNS_TYPE_RKEY_BSTR -> ?DNS_TYPE_RKEY_NUMBER;
-    ?DNS_TYPE_TALINK_BSTR -> ?DNS_TYPE_TALINK_NUMBER;
-    ?DNS_TYPE_SPF_BSTR -> ?DNS_TYPE_SPF_NUMBER;
-    ?DNS_TYPE_UINFO_BSTR -> ?DNS_TYPE_UINFO_NUMBER;
-    ?DNS_TYPE_UID_BSTR -> ?DNS_TYPE_UID_NUMBER;
-    ?DNS_TYPE_GID_BSTR -> ?DNS_TYPE_GID_NUMBER;
-    ?DNS_TYPE_UNSPEC_BSTR -> ?DNS_TYPE_UNSPEC_NUMBER;
-    ?DNS_TYPE_TKEY_BSTR -> ?DNS_TYPE_TKEY_NUMBER;
-    ?DNS_TYPE_TSIG_BSTR -> ?DNS_TYPE_TSIG_NUMBER;
-    ?DNS_TYPE_IXFR_BSTR -> ?DNS_TYPE_IXFR_NUMBER;
-    ?DNS_TYPE_AXFR_BSTR -> ?DNS_TYPE_AXFR_NUMBER;
-    ?DNS_TYPE_MAILB_BSTR -> ?DNS_TYPE_MAILB_NUMBER;
-    ?DNS_TYPE_MAILA_BSTR -> ?DNS_TYPE_MAILA_NUMBER;
-    ?DNS_TYPE_ANY_BSTR -> ?DNS_TYPE_ANY_NUMBER;
-    ?DNS_TYPE_CAA_BSTR -> ?DNS_TYPE_CAA_NUMBER;
-    ?DNS_TYPE_DLV_BSTR -> ?DNS_TYPE_DLV_NUMBER;
-    _ -> undefined
-  end.
+    case Type of
+        ?DNS_TYPE_A_BSTR ->
+            ?DNS_TYPE_A_NUMBER;
+        ?DNS_TYPE_NS_BSTR ->
+            ?DNS_TYPE_NS_NUMBER;
+        ?DNS_TYPE_MD_BSTR ->
+            ?DNS_TYPE_MD_NUMBER;
+        ?DNS_TYPE_MF_BSTR ->
+            ?DNS_TYPE_MF_NUMBER;
+        ?DNS_TYPE_CNAME_BSTR ->
+            ?DNS_TYPE_CNAME_NUMBER;
+        ?DNS_TYPE_SOA_BSTR ->
+            ?DNS_TYPE_SOA_NUMBER;
+        ?DNS_TYPE_MB_BSTR ->
+            ?DNS_TYPE_MB_NUMBER;
+        ?DNS_TYPE_MG_BSTR ->
+            ?DNS_TYPE_MG_NUMBER;
+        ?DNS_TYPE_MR_BSTR ->
+            ?DNS_TYPE_MR_NUMBER;
+        ?DNS_TYPE_NULL_BSTR ->
+            ?DNS_TYPE_NULL_NUMBER;
+        ?DNS_TYPE_WKS_BSTR ->
+            ?DNS_TYPE_WKS_NUMBER;
+        ?DNS_TYPE_PTR_BSTR ->
+            ?DNS_TYPE_PTR_NUMBER;
+        ?DNS_TYPE_HINFO_BSTR ->
+            ?DNS_TYPE_HINFO_NUMBER;
+        ?DNS_TYPE_MINFO_BSTR ->
+            ?DNS_TYPE_MINFO_NUMBER;
+        ?DNS_TYPE_MX_BSTR ->
+            ?DNS_TYPE_MX_NUMBER;
+        ?DNS_TYPE_TXT_BSTR ->
+            ?DNS_TYPE_TXT_NUMBER;
+        ?DNS_TYPE_RP_BSTR ->
+            ?DNS_TYPE_RP_NUMBER;
+        ?DNS_TYPE_AFSDB_BSTR ->
+            ?DNS_TYPE_AFSDB_NUMBER;
+        ?DNS_TYPE_X25_BSTR ->
+            ?DNS_TYPE_X25_NUMBER;
+        ?DNS_TYPE_ISDN_BSTR ->
+            ?DNS_TYPE_ISDN_NUMBER;
+        ?DNS_TYPE_RT_BSTR ->
+            ?DNS_TYPE_RT_NUMBER;
+        ?DNS_TYPE_NSAP_BSTR ->
+            ?DNS_TYPE_NSAP_NUMBER;
+        ?DNS_TYPE_SIG_BSTR ->
+            ?DNS_TYPE_SIG_NUMBER;
+        ?DNS_TYPE_KEY_BSTR ->
+            ?DNS_TYPE_KEY_NUMBER;
+        ?DNS_TYPE_PX_BSTR ->
+            ?DNS_TYPE_PX_NUMBER;
+        ?DNS_TYPE_GPOS_BSTR ->
+            ?DNS_TYPE_GPOS_NUMBER;
+        ?DNS_TYPE_AAAA_BSTR ->
+            ?DNS_TYPE_AAAA_NUMBER;
+        ?DNS_TYPE_LOC_BSTR ->
+            ?DNS_TYPE_LOC_NUMBER;
+        ?DNS_TYPE_NXT_BSTR ->
+            ?DNS_TYPE_NXT_NUMBER;
+        ?DNS_TYPE_EID_BSTR ->
+            ?DNS_TYPE_EID_NUMBER;
+        ?DNS_TYPE_NIMLOC_BSTR ->
+            ?DNS_TYPE_NIMLOC_NUMBER;
+        ?DNS_TYPE_SRV_BSTR ->
+            ?DNS_TYPE_SRV_NUMBER;
+        ?DNS_TYPE_ATMA_BSTR ->
+            ?DNS_TYPE_ATMA_NUMBER;
+        ?DNS_TYPE_NAPTR_BSTR ->
+            ?DNS_TYPE_NAPTR_NUMBER;
+        ?DNS_TYPE_KX_BSTR ->
+            ?DNS_TYPE_KX_NUMBER;
+        ?DNS_TYPE_CERT_BSTR ->
+            ?DNS_TYPE_CERT_NUMBER;
+        ?DNS_TYPE_DNAME_BSTR ->
+            ?DNS_TYPE_DNAME_NUMBER;
+        ?DNS_TYPE_SINK_BSTR ->
+            ?DNS_TYPE_SINK_NUMBER;
+        ?DNS_TYPE_OPT_BSTR ->
+            ?DNS_TYPE_OPT_NUMBER;
+        ?DNS_TYPE_APL_BSTR ->
+            ?DNS_TYPE_APL_NUMBER;
+        ?DNS_TYPE_DS_BSTR ->
+            ?DNS_TYPE_DS_NUMBER;
+        ?DNS_TYPE_CDS_BSTR ->
+            ?DNS_TYPE_CDS_NUMBER;
+        ?DNS_TYPE_SSHFP_BSTR ->
+            ?DNS_TYPE_SSHFP_NUMBER;
+        ?DNS_TYPE_IPSECKEY_BSTR ->
+            ?DNS_TYPE_IPSECKEY_NUMBER;
+        ?DNS_TYPE_RRSIG_BSTR ->
+            ?DNS_TYPE_RRSIG_NUMBER;
+        ?DNS_TYPE_NSEC_BSTR ->
+            ?DNS_TYPE_NSEC_NUMBER;
+        ?DNS_TYPE_DNSKEY_BSTR ->
+            ?DNS_TYPE_DNSKEY_NUMBER;
+        ?DNS_TYPE_CDNSKEY_BSTR ->
+            ?DNS_TYPE_CDNSKEY_NUMBER;
+        ?DNS_TYPE_NSEC3_BSTR ->
+            ?DNS_TYPE_NSEC3_NUMBER;
+        ?DNS_TYPE_NSEC3PARAM_BSTR ->
+            ?DNS_TYPE_NSEC3PARAM_NUMBER;
+        ?DNS_TYPE_DHCID_BSTR ->
+            ?DNS_TYPE_DHCID_NUMBER;
+        ?DNS_TYPE_HIP_BSTR ->
+            ?DNS_TYPE_HIP_NUMBER;
+        ?DNS_TYPE_NINFO_BSTR ->
+            ?DNS_TYPE_NINFO_NUMBER;
+        ?DNS_TYPE_RKEY_BSTR ->
+            ?DNS_TYPE_RKEY_NUMBER;
+        ?DNS_TYPE_TALINK_BSTR ->
+            ?DNS_TYPE_TALINK_NUMBER;
+        ?DNS_TYPE_SPF_BSTR ->
+            ?DNS_TYPE_SPF_NUMBER;
+        ?DNS_TYPE_UINFO_BSTR ->
+            ?DNS_TYPE_UINFO_NUMBER;
+        ?DNS_TYPE_UID_BSTR ->
+            ?DNS_TYPE_UID_NUMBER;
+        ?DNS_TYPE_GID_BSTR ->
+            ?DNS_TYPE_GID_NUMBER;
+        ?DNS_TYPE_UNSPEC_BSTR ->
+            ?DNS_TYPE_UNSPEC_NUMBER;
+        ?DNS_TYPE_TKEY_BSTR ->
+            ?DNS_TYPE_TKEY_NUMBER;
+        ?DNS_TYPE_TSIG_BSTR ->
+            ?DNS_TYPE_TSIG_NUMBER;
+        ?DNS_TYPE_IXFR_BSTR ->
+            ?DNS_TYPE_IXFR_NUMBER;
+        ?DNS_TYPE_AXFR_BSTR ->
+            ?DNS_TYPE_AXFR_NUMBER;
+        ?DNS_TYPE_MAILB_BSTR ->
+            ?DNS_TYPE_MAILB_NUMBER;
+        ?DNS_TYPE_MAILA_BSTR ->
+            ?DNS_TYPE_MAILA_NUMBER;
+        ?DNS_TYPE_ANY_BSTR ->
+            ?DNS_TYPE_ANY_NUMBER;
+        ?DNS_TYPE_CAA_BSTR ->
+            ?DNS_TYPE_CAA_NUMBER;
+        ?DNS_TYPE_DLV_BSTR ->
+            ?DNS_TYPE_DLV_NUMBER;
+        _ ->
+            undefined
+    end.
 
--spec(root_hints() -> {[dns:rr()], [dns:rr()]}).
+-spec root_hints() -> {[dns:rr()], [dns:rr()]}.
 root_hints() ->
-  {
-   [
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}
-   ],
-   [
-    #dns_rr{name = <<"a.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,41,0,4}}},
-    #dns_rr{name = <<"b.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,228,79,201}}},
-    #dns_rr{name = <<"c.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,33,4,12}}},
-    #dns_rr{name = <<"d.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,8,10,90}}},
-    #dns_rr{name = <<"e.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,203,230,10}}},
-    #dns_rr{name = <<"f.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,5,5,241}}},
-    #dns_rr{name = <<"g.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,112,36,4}}},
-    #dns_rr{name = <<"h.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,63,2,53}}},
-    #dns_rr{name = <<"i.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,36,148,17}}},
-    #dns_rr{name = <<"j.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,58,128,30}}},
-    #dns_rr{name = <<"k.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {193,0,14,129}}},
-    #dns_rr{name = <<"l.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,32,64,12}}},
-    #dns_rr{name = <<"m.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {202,12,27,33}}}
-   ]
-  }.
-
-
+    {[#dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}],
+     [#dns_rr{name = <<"a.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {198, 41, 0, 4}}},
+      #dns_rr{name = <<"b.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 228, 79, 201}}},
+      #dns_rr{name = <<"c.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 33, 4, 12}}},
+      #dns_rr{name = <<"d.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {128, 8, 10, 90}}},
+      #dns_rr{name = <<"e.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 203, 230, 10}}},
+      #dns_rr{name = <<"f.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 5, 5, 241}}},
+      #dns_rr{name = <<"g.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 112, 36, 4}}},
+      #dns_rr{name = <<"h.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {128, 63, 2, 53}}},
+      #dns_rr{name = <<"i.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 36, 148, 17}}},
+      #dns_rr{name = <<"j.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 58, 128, 30}}},
+      #dns_rr{name = <<"k.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {193, 0, 14, 129}}},
+      #dns_rr{name = <<"l.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {198, 32, 64, 12}}},
+      #dns_rr{name = <<"m.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {202, 12, 27, 33}}}]}.
 
 -ifdef(TEST).
 
 wildcard_qname_test_() ->
-  ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
+    ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
 
 minimum_soa_ttl_test_() ->
-  [
-   ?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
-   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
-   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))
-  ].
+    [?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
+     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
+     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))].
 
 replace_name_test_() ->
-  [
-   ?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
-   ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))
-  ].
+    [?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
+     ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))].
 
 match_name_test_() ->
-  [
-   ?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
-   ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))
-  ].
+    [?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
+     ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))].
 
 match_type_test_() ->
-  [
-   ?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))
-  ].
+    [?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))].
 
 match_types_test_() ->
-  [
-   ?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))
-  ].
+    [?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))].
 
 match_wildcard_test_() ->
-  [
-   ?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
-   ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))
-  ].
+    [?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
+     ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))].
 
 match_delegation_test_() ->
-  [
-   ?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
-   ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))
-  ].
+    [?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
+     ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))].
 
 match_wildcard_label_test_() ->
-  [
-   ?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
-   ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))
-  ].
+    [?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
+     ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))].
 
 -endif.

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -16,36 +16,28 @@
 -module(erldns_records).
 
 -include("erldns.hrl").
+
 -include_lib("dns_erlang/include/dns.hrl").
+
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 % Wildcard functions
--export([
-         optionally_convert_wildcard/2,
-         wildcard_qname/1
-        ]).
-
+-export([optionally_convert_wildcard/2, wildcard_qname/1]).
 % SOA TTL functions
--export([
-         minimum_soa_ttl/2,
-         rewrite_soa_ttl/1
-        ]).
-
+-export([minimum_soa_ttl/2, rewrite_soa_ttl/1]).
 % Matcher functions
--export([
-         match_name/1,
+-export([match_name/1,
          match_type/1,
          match_name_and_type/2,
          match_types/1,
          match_wildcard/0,
          match_delegation/1,
-         match_type_covered/1
-        ]).
-
--export([
-         default_ttl/1,
+         match_type_covered/1]).
+-export([default_ttl/1,
          default_priority/1,
          name_type/1,
          root_hints/0,
@@ -54,275 +46,390 @@
 %% @doc If given Name is a wildcard name then the original qname needs to be returned in its place.
 -spec optionally_convert_wildcard(dns:dname(), dns:dname()) -> dns:dname().
 optionally_convert_wildcard(Name, Qname) ->
-  [Head|_] = dns:dname_to_labels(Name),
-  case Head of
-    <<"*">> -> Qname;
-    _ -> Name
-  end.
+    [Head | _] = dns:dname_to_labels(Name),
+    case Head of
+        <<"*">> ->
+            Qname;
+        _ ->
+            Name
+    end.
 
 %% @doc Get a wildcard variation of a Qname. Replaces the leading abel with an asterisk for wildcard lookup.
 -spec wildcard_qname(dns:dname()) -> dns:dname().
 wildcard_qname(Qname) ->
-  [_|Rest] = dns:dname_to_labels(Qname),
-  dns:labels_to_dname([<<"*">>] ++ Rest).
+    [_ | Rest] = dns:dname_to_labels(Qname),
+    dns:labels_to_dname([<<"*">>] ++ Rest).
 
 %% @doc Return the TTL value or 3600 if it is undefined.
 -spec default_ttl(integer() | undefined) -> integer().
 default_ttl(TTL) ->
-  case TTL of
-    undefined -> 3600;
-    Value -> Value
-  end.
+    case TTL of
+        undefined ->
+            3600;
+        Value ->
+            Value
+    end.
 
 %% @doc Return the Priority value or 0 if it is undefined.
 -spec default_priority(integer() | undefined) -> integer().
 default_priority(Priority) ->
-  case Priority of
-    undefined -> 0;
-    Value -> Value
-  end.
+    case Priority of
+        undefined ->
+            0;
+        Value ->
+            Value
+    end.
 
 %% @doc Applies a minimum TTL based on the SOA minumum value.
 %%
 %% The first argument is the Record that is being updated.
 %% The second argument is the SOA RR Data.
 -spec minimum_soa_ttl(dns:dns_rr(), dns:dns_rrdata_soa()) -> dns:dns_rr().
-minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) -> Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
-minimum_soa_ttl(Record, _) -> Record.
+minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) ->
+    Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
+minimum_soa_ttl(Record, _) ->
+    Record.
 
 %% @doc According to RFC 2308 the TTL for the SOA record in an NXDOMAIN response
 %% must be set to the value of the minimum field in the SOA content.
 -spec rewrite_soa_ttl(dns:message()) -> dns:message().
-rewrite_soa_ttl(Message) -> rewrite_soa_ttl(Message, Message#dns_message.authority, []).
+rewrite_soa_ttl(Message) ->
+    rewrite_soa_ttl(Message, Message#dns_message.authority, []).
 
-rewrite_soa_ttl(Message, [], NewAuthority) -> Message#dns_message{authority = NewAuthority};
-rewrite_soa_ttl(Message, [R|Rest], NewAuthority) -> rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
-
+rewrite_soa_ttl(Message, [], NewAuthority) ->
+    Message#dns_message{authority = NewAuthority};
+rewrite_soa_ttl(Message, [R | Rest], NewAuthority) ->
+    rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
 
 %% Various matching functions.
 
 -spec match_name(dns:name()) -> fun((dns:rr()) -> boolean()).
 match_name(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.name =:= Name
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.name =:= Name end.
 
 -spec match_type(dns:type()) -> fun((dns:rr()) -> boolean()).
 match_type(Type) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.type =:= Type
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.type =:= Type end.
 
 -spec match_name_and_type(dns:name(), dns:type()) -> fun((dns:rr()) -> boolean()).
 match_name_and_type(Name, Type) ->
-  fun(R) when is_record(R, dns_rr) ->
-      (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type)
-  end.
+    fun(R) when is_record(R, dns_rr) -> (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type) end.
 
 -spec match_types([dns:type()]) -> fun((dns:rr()) -> boolean()).
 match_types(Types) ->
-  fun(R) when is_record(R, dns_rr) ->
-      lists:any(fun(T) -> R#dns_rr.type =:= T end, Types)
-  end.
+    fun(R) when is_record(R, dns_rr) -> lists:any(fun(T) -> R#dns_rr.type =:= T end, Types) end.
 
 -spec match_wildcard() -> fun((dns:rr()) -> boolean()).
 match_wildcard() ->
-  fun(R) when is_record(R, dns_rr) ->
-      lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name))
-  end.
+    fun(R) when is_record(R, dns_rr) -> lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name)) end.
 
 -spec match_wildcard_label() -> fun((binary()) -> boolean()).
 match_wildcard_label() ->
-  fun(L) ->
-      L =:= <<"*">>
-  end.
+    fun(L) -> L =:= <<"*">> end.
 
 -spec match_delegation(dns:dname()) -> fun((dns:rr()) -> boolean()).
 match_delegation(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr.data =:= #dns_rrdata_ns{dname=Name}
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr.data =:= #dns_rrdata_ns{dname = Name} end.
 
--spec(match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean())).
+-spec match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean()).
 match_type_covered(Qtype) ->
-  fun(RRSig) ->
-      RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype
-  end.
-
+    fun(RRSig) -> RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype end.
 
 %% Replacement functions.
 
 replace_name(Name) ->
-  fun(R) when is_record(R, dns_rr) ->
-      R#dns_rr{name = Name}
-  end.
+    fun(R) when is_record(R, dns_rr) -> R#dns_rr{name = Name} end.
 
 %% @doc Returns the type value given a binary string.
--spec name_type(binary()) -> dns:type() | 'undefined'.
+-spec name_type(binary()) -> dns:type() | undefined.
 name_type(Type) when is_binary(Type) ->
-  case Type of
-    ?DNS_TYPE_A_BSTR -> ?DNS_TYPE_A_NUMBER;
-    ?DNS_TYPE_NS_BSTR -> ?DNS_TYPE_NS_NUMBER;
-    ?DNS_TYPE_MD_BSTR -> ?DNS_TYPE_MD_NUMBER;
-    ?DNS_TYPE_MF_BSTR -> ?DNS_TYPE_MF_NUMBER;
-    ?DNS_TYPE_CNAME_BSTR -> ?DNS_TYPE_CNAME_NUMBER;
-    ?DNS_TYPE_SOA_BSTR -> ?DNS_TYPE_SOA_NUMBER;
-    ?DNS_TYPE_MB_BSTR -> ?DNS_TYPE_MB_NUMBER;
-    ?DNS_TYPE_MG_BSTR -> ?DNS_TYPE_MG_NUMBER;
-    ?DNS_TYPE_MR_BSTR -> ?DNS_TYPE_MR_NUMBER;
-    ?DNS_TYPE_NULL_BSTR -> ?DNS_TYPE_NULL_NUMBER;
-    ?DNS_TYPE_WKS_BSTR -> ?DNS_TYPE_WKS_NUMBER;
-    ?DNS_TYPE_PTR_BSTR -> ?DNS_TYPE_PTR_NUMBER;
-    ?DNS_TYPE_HINFO_BSTR -> ?DNS_TYPE_HINFO_NUMBER;
-    ?DNS_TYPE_MINFO_BSTR -> ?DNS_TYPE_MINFO_NUMBER;
-    ?DNS_TYPE_MX_BSTR -> ?DNS_TYPE_MX_NUMBER;
-    ?DNS_TYPE_TXT_BSTR -> ?DNS_TYPE_TXT_NUMBER;
-    ?DNS_TYPE_RP_BSTR -> ?DNS_TYPE_RP_NUMBER;
-    ?DNS_TYPE_AFSDB_BSTR -> ?DNS_TYPE_AFSDB_NUMBER;
-    ?DNS_TYPE_X25_BSTR -> ?DNS_TYPE_X25_NUMBER;
-    ?DNS_TYPE_ISDN_BSTR -> ?DNS_TYPE_ISDN_NUMBER;
-    ?DNS_TYPE_RT_BSTR -> ?DNS_TYPE_RT_NUMBER;
-    ?DNS_TYPE_NSAP_BSTR -> ?DNS_TYPE_NSAP_NUMBER;
-    ?DNS_TYPE_SIG_BSTR -> ?DNS_TYPE_SIG_NUMBER;
-    ?DNS_TYPE_KEY_BSTR -> ?DNS_TYPE_KEY_NUMBER;
-    ?DNS_TYPE_PX_BSTR -> ?DNS_TYPE_PX_NUMBER;
-    ?DNS_TYPE_GPOS_BSTR -> ?DNS_TYPE_GPOS_NUMBER;
-    ?DNS_TYPE_AAAA_BSTR -> ?DNS_TYPE_AAAA_NUMBER;
-    ?DNS_TYPE_LOC_BSTR -> ?DNS_TYPE_LOC_NUMBER;
-    ?DNS_TYPE_NXT_BSTR -> ?DNS_TYPE_NXT_NUMBER;
-    ?DNS_TYPE_EID_BSTR -> ?DNS_TYPE_EID_NUMBER;
-    ?DNS_TYPE_NIMLOC_BSTR -> ?DNS_TYPE_NIMLOC_NUMBER;
-    ?DNS_TYPE_SRV_BSTR -> ?DNS_TYPE_SRV_NUMBER;
-    ?DNS_TYPE_ATMA_BSTR -> ?DNS_TYPE_ATMA_NUMBER;
-    ?DNS_TYPE_NAPTR_BSTR -> ?DNS_TYPE_NAPTR_NUMBER;
-    ?DNS_TYPE_KX_BSTR -> ?DNS_TYPE_KX_NUMBER;
-    ?DNS_TYPE_CERT_BSTR -> ?DNS_TYPE_CERT_NUMBER;
-    ?DNS_TYPE_DNAME_BSTR -> ?DNS_TYPE_DNAME_NUMBER;
-    ?DNS_TYPE_SINK_BSTR -> ?DNS_TYPE_SINK_NUMBER;
-    ?DNS_TYPE_OPT_BSTR -> ?DNS_TYPE_OPT_NUMBER;
-    ?DNS_TYPE_APL_BSTR -> ?DNS_TYPE_APL_NUMBER;
-    ?DNS_TYPE_DS_BSTR -> ?DNS_TYPE_DS_NUMBER;
-    ?DNS_TYPE_CDS_BSTR -> ?DNS_TYPE_CDS_NUMBER;
-    ?DNS_TYPE_SSHFP_BSTR -> ?DNS_TYPE_SSHFP_NUMBER;
-    ?DNS_TYPE_IPSECKEY_BSTR -> ?DNS_TYPE_IPSECKEY_NUMBER;
-    ?DNS_TYPE_RRSIG_BSTR -> ?DNS_TYPE_RRSIG_NUMBER;
-    ?DNS_TYPE_NSEC_BSTR -> ?DNS_TYPE_NSEC_NUMBER;
-    ?DNS_TYPE_DNSKEY_BSTR -> ?DNS_TYPE_DNSKEY_NUMBER;
-    ?DNS_TYPE_CDNSKEY_BSTR -> ?DNS_TYPE_CDNSKEY_NUMBER;
-    ?DNS_TYPE_NSEC3_BSTR -> ?DNS_TYPE_NSEC3_NUMBER;
-    ?DNS_TYPE_NSEC3PARAM_BSTR -> ?DNS_TYPE_NSEC3PARAM_NUMBER;
-    ?DNS_TYPE_DHCID_BSTR -> ?DNS_TYPE_DHCID_NUMBER;
-    ?DNS_TYPE_HIP_BSTR -> ?DNS_TYPE_HIP_NUMBER;
-    ?DNS_TYPE_NINFO_BSTR -> ?DNS_TYPE_NINFO_NUMBER;
-    ?DNS_TYPE_RKEY_BSTR -> ?DNS_TYPE_RKEY_NUMBER;
-    ?DNS_TYPE_TALINK_BSTR -> ?DNS_TYPE_TALINK_NUMBER;
-    ?DNS_TYPE_SPF_BSTR -> ?DNS_TYPE_SPF_NUMBER;
-    ?DNS_TYPE_UINFO_BSTR -> ?DNS_TYPE_UINFO_NUMBER;
-    ?DNS_TYPE_UID_BSTR -> ?DNS_TYPE_UID_NUMBER;
-    ?DNS_TYPE_GID_BSTR -> ?DNS_TYPE_GID_NUMBER;
-    ?DNS_TYPE_UNSPEC_BSTR -> ?DNS_TYPE_UNSPEC_NUMBER;
-    ?DNS_TYPE_TKEY_BSTR -> ?DNS_TYPE_TKEY_NUMBER;
-    ?DNS_TYPE_TSIG_BSTR -> ?DNS_TYPE_TSIG_NUMBER;
-    ?DNS_TYPE_IXFR_BSTR -> ?DNS_TYPE_IXFR_NUMBER;
-    ?DNS_TYPE_AXFR_BSTR -> ?DNS_TYPE_AXFR_NUMBER;
-    ?DNS_TYPE_MAILB_BSTR -> ?DNS_TYPE_MAILB_NUMBER;
-    ?DNS_TYPE_MAILA_BSTR -> ?DNS_TYPE_MAILA_NUMBER;
-    ?DNS_TYPE_ANY_BSTR -> ?DNS_TYPE_ANY_NUMBER;
-    ?DNS_TYPE_CAA_BSTR -> ?DNS_TYPE_CAA_NUMBER;
-    ?DNS_TYPE_DLV_BSTR -> ?DNS_TYPE_DLV_NUMBER;
-    _ -> undefined
-  end.
+    case Type of
+        ?DNS_TYPE_A_BSTR ->
+            ?DNS_TYPE_A_NUMBER;
+        ?DNS_TYPE_NS_BSTR ->
+            ?DNS_TYPE_NS_NUMBER;
+        ?DNS_TYPE_MD_BSTR ->
+            ?DNS_TYPE_MD_NUMBER;
+        ?DNS_TYPE_MF_BSTR ->
+            ?DNS_TYPE_MF_NUMBER;
+        ?DNS_TYPE_CNAME_BSTR ->
+            ?DNS_TYPE_CNAME_NUMBER;
+        ?DNS_TYPE_SOA_BSTR ->
+            ?DNS_TYPE_SOA_NUMBER;
+        ?DNS_TYPE_MB_BSTR ->
+            ?DNS_TYPE_MB_NUMBER;
+        ?DNS_TYPE_MG_BSTR ->
+            ?DNS_TYPE_MG_NUMBER;
+        ?DNS_TYPE_MR_BSTR ->
+            ?DNS_TYPE_MR_NUMBER;
+        ?DNS_TYPE_NULL_BSTR ->
+            ?DNS_TYPE_NULL_NUMBER;
+        ?DNS_TYPE_WKS_BSTR ->
+            ?DNS_TYPE_WKS_NUMBER;
+        ?DNS_TYPE_PTR_BSTR ->
+            ?DNS_TYPE_PTR_NUMBER;
+        ?DNS_TYPE_HINFO_BSTR ->
+            ?DNS_TYPE_HINFO_NUMBER;
+        ?DNS_TYPE_MINFO_BSTR ->
+            ?DNS_TYPE_MINFO_NUMBER;
+        ?DNS_TYPE_MX_BSTR ->
+            ?DNS_TYPE_MX_NUMBER;
+        ?DNS_TYPE_TXT_BSTR ->
+            ?DNS_TYPE_TXT_NUMBER;
+        ?DNS_TYPE_RP_BSTR ->
+            ?DNS_TYPE_RP_NUMBER;
+        ?DNS_TYPE_AFSDB_BSTR ->
+            ?DNS_TYPE_AFSDB_NUMBER;
+        ?DNS_TYPE_X25_BSTR ->
+            ?DNS_TYPE_X25_NUMBER;
+        ?DNS_TYPE_ISDN_BSTR ->
+            ?DNS_TYPE_ISDN_NUMBER;
+        ?DNS_TYPE_RT_BSTR ->
+            ?DNS_TYPE_RT_NUMBER;
+        ?DNS_TYPE_NSAP_BSTR ->
+            ?DNS_TYPE_NSAP_NUMBER;
+        ?DNS_TYPE_SIG_BSTR ->
+            ?DNS_TYPE_SIG_NUMBER;
+        ?DNS_TYPE_KEY_BSTR ->
+            ?DNS_TYPE_KEY_NUMBER;
+        ?DNS_TYPE_PX_BSTR ->
+            ?DNS_TYPE_PX_NUMBER;
+        ?DNS_TYPE_GPOS_BSTR ->
+            ?DNS_TYPE_GPOS_NUMBER;
+        ?DNS_TYPE_AAAA_BSTR ->
+            ?DNS_TYPE_AAAA_NUMBER;
+        ?DNS_TYPE_LOC_BSTR ->
+            ?DNS_TYPE_LOC_NUMBER;
+        ?DNS_TYPE_NXT_BSTR ->
+            ?DNS_TYPE_NXT_NUMBER;
+        ?DNS_TYPE_EID_BSTR ->
+            ?DNS_TYPE_EID_NUMBER;
+        ?DNS_TYPE_NIMLOC_BSTR ->
+            ?DNS_TYPE_NIMLOC_NUMBER;
+        ?DNS_TYPE_SRV_BSTR ->
+            ?DNS_TYPE_SRV_NUMBER;
+        ?DNS_TYPE_ATMA_BSTR ->
+            ?DNS_TYPE_ATMA_NUMBER;
+        ?DNS_TYPE_NAPTR_BSTR ->
+            ?DNS_TYPE_NAPTR_NUMBER;
+        ?DNS_TYPE_KX_BSTR ->
+            ?DNS_TYPE_KX_NUMBER;
+        ?DNS_TYPE_CERT_BSTR ->
+            ?DNS_TYPE_CERT_NUMBER;
+        ?DNS_TYPE_DNAME_BSTR ->
+            ?DNS_TYPE_DNAME_NUMBER;
+        ?DNS_TYPE_SINK_BSTR ->
+            ?DNS_TYPE_SINK_NUMBER;
+        ?DNS_TYPE_OPT_BSTR ->
+            ?DNS_TYPE_OPT_NUMBER;
+        ?DNS_TYPE_APL_BSTR ->
+            ?DNS_TYPE_APL_NUMBER;
+        ?DNS_TYPE_DS_BSTR ->
+            ?DNS_TYPE_DS_NUMBER;
+        ?DNS_TYPE_CDS_BSTR ->
+            ?DNS_TYPE_CDS_NUMBER;
+        ?DNS_TYPE_SSHFP_BSTR ->
+            ?DNS_TYPE_SSHFP_NUMBER;
+        ?DNS_TYPE_IPSECKEY_BSTR ->
+            ?DNS_TYPE_IPSECKEY_NUMBER;
+        ?DNS_TYPE_RRSIG_BSTR ->
+            ?DNS_TYPE_RRSIG_NUMBER;
+        ?DNS_TYPE_NSEC_BSTR ->
+            ?DNS_TYPE_NSEC_NUMBER;
+        ?DNS_TYPE_DNSKEY_BSTR ->
+            ?DNS_TYPE_DNSKEY_NUMBER;
+        ?DNS_TYPE_CDNSKEY_BSTR ->
+            ?DNS_TYPE_CDNSKEY_NUMBER;
+        ?DNS_TYPE_NSEC3_BSTR ->
+            ?DNS_TYPE_NSEC3_NUMBER;
+        ?DNS_TYPE_NSEC3PARAM_BSTR ->
+            ?DNS_TYPE_NSEC3PARAM_NUMBER;
+        ?DNS_TYPE_DHCID_BSTR ->
+            ?DNS_TYPE_DHCID_NUMBER;
+        ?DNS_TYPE_HIP_BSTR ->
+            ?DNS_TYPE_HIP_NUMBER;
+        ?DNS_TYPE_NINFO_BSTR ->
+            ?DNS_TYPE_NINFO_NUMBER;
+        ?DNS_TYPE_RKEY_BSTR ->
+            ?DNS_TYPE_RKEY_NUMBER;
+        ?DNS_TYPE_TALINK_BSTR ->
+            ?DNS_TYPE_TALINK_NUMBER;
+        ?DNS_TYPE_SPF_BSTR ->
+            ?DNS_TYPE_SPF_NUMBER;
+        ?DNS_TYPE_UINFO_BSTR ->
+            ?DNS_TYPE_UINFO_NUMBER;
+        ?DNS_TYPE_UID_BSTR ->
+            ?DNS_TYPE_UID_NUMBER;
+        ?DNS_TYPE_GID_BSTR ->
+            ?DNS_TYPE_GID_NUMBER;
+        ?DNS_TYPE_UNSPEC_BSTR ->
+            ?DNS_TYPE_UNSPEC_NUMBER;
+        ?DNS_TYPE_TKEY_BSTR ->
+            ?DNS_TYPE_TKEY_NUMBER;
+        ?DNS_TYPE_TSIG_BSTR ->
+            ?DNS_TYPE_TSIG_NUMBER;
+        ?DNS_TYPE_IXFR_BSTR ->
+            ?DNS_TYPE_IXFR_NUMBER;
+        ?DNS_TYPE_AXFR_BSTR ->
+            ?DNS_TYPE_AXFR_NUMBER;
+        ?DNS_TYPE_MAILB_BSTR ->
+            ?DNS_TYPE_MAILB_NUMBER;
+        ?DNS_TYPE_MAILA_BSTR ->
+            ?DNS_TYPE_MAILA_NUMBER;
+        ?DNS_TYPE_ANY_BSTR ->
+            ?DNS_TYPE_ANY_NUMBER;
+        ?DNS_TYPE_CAA_BSTR ->
+            ?DNS_TYPE_CAA_NUMBER;
+        ?DNS_TYPE_DLV_BSTR ->
+            ?DNS_TYPE_DLV_NUMBER;
+        _ ->
+            undefined
+    end.
 
--spec(root_hints() -> {[dns:rr()], [dns:rr()]}).
+-spec root_hints() -> {[dns:rr()], [dns:rr()]}.
 root_hints() ->
-  {
-   [
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
-    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}
-   ],
-   [
-    #dns_rr{name = <<"a.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,41,0,4}}},
-    #dns_rr{name = <<"b.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,228,79,201}}},
-    #dns_rr{name = <<"c.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,33,4,12}}},
-    #dns_rr{name = <<"d.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,8,10,90}}},
-    #dns_rr{name = <<"e.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,203,230,10}}},
-    #dns_rr{name = <<"f.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,5,5,241}}},
-    #dns_rr{name = <<"g.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,112,36,4}}},
-    #dns_rr{name = <<"h.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,63,2,53}}},
-    #dns_rr{name = <<"i.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,36,148,17}}},
-    #dns_rr{name = <<"j.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,58,128,30}}},
-    #dns_rr{name = <<"k.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {193,0,14,129}}},
-    #dns_rr{name = <<"l.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,32,64,12}}},
-    #dns_rr{name = <<"m.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {202,12,27,33}}}
-   ]
-  }.
-
-
+    {[#dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
+      #dns_rr{name = <<"">>,
+              type = ?DNS_TYPE_NS,
+              ttl = 518400,
+              data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}],
+     [#dns_rr{name = <<"a.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {198, 41, 0, 4}}},
+      #dns_rr{name = <<"b.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 228, 79, 201}}},
+      #dns_rr{name = <<"c.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 33, 4, 12}}},
+      #dns_rr{name = <<"d.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {128, 8, 10, 90}}},
+      #dns_rr{name = <<"e.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 203, 230, 10}}},
+      #dns_rr{name = <<"f.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 5, 5, 241}}},
+      #dns_rr{name = <<"g.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 112, 36, 4}}},
+      #dns_rr{name = <<"h.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {128, 63, 2, 53}}},
+      #dns_rr{name = <<"i.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 36, 148, 17}}},
+      #dns_rr{name = <<"j.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {192, 58, 128, 30}}},
+      #dns_rr{name = <<"k.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {193, 0, 14, 129}}},
+      #dns_rr{name = <<"l.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {198, 32, 64, 12}}},
+      #dns_rr{name = <<"m.root-servers.net">>,
+              type = ?DNS_TYPE_A,
+              ttl = 3600000,
+              data = #dns_rrdata_a{ip = {202, 12, 27, 33}}}]}.
 
 -ifdef(TEST).
 
 wildcard_qname_test_() ->
-  ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
+    ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
 
 minimum_soa_ttl_test_() ->
-  [
-   ?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
-   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
-   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))
-  ].
+    [?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
+     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
+     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))].
 
 replace_name_test_() ->
-  [
-   ?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
-   ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))
-  ].
+    [?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
+     ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))].
 
 match_name_test_() ->
-  [
-   ?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
-   ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))
-  ].
+    [?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
+     ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))].
 
 match_type_test_() ->
-  [
-   ?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))
-  ].
+    [?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))].
 
 match_types_test_() ->
-  [
-   ?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
-   ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))
-  ].
+    [?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
+     ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))].
 
 match_wildcard_test_() ->
-  [
-   ?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
-   ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))
-  ].
+    [?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
+     ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))].
 
 match_delegation_test_() ->
-  [
-   ?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
-   ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))
-  ].
+    [?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
+     ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))].
 
 match_wildcard_label_test_() ->
-  [
-   ?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
-   ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))
-  ].
+    [?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
+     ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))].
 
 -endif.

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -27,8 +27,6 @@
          wildcard_qname/1
         ]).
 
-
-
 % SOA TTL functions
 -export([
          minimum_soa_ttl/2,

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -26,9 +26,11 @@
 -endif.
 
 % Wildcard functions
--export([optionally_convert_wildcard/2, wildcard_qname/1]).
+-export([optionally_convert_wildcard/2,
+         wildcard_qname/1]).
 % SOA TTL functions
--export([minimum_soa_ttl/2, rewrite_soa_ttl/1]).
+-export([minimum_soa_ttl/2,
+         rewrite_soa_ttl/1]).
 % Matcher functions
 -export([match_name/1,
          match_type/1,

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -26,11 +26,9 @@
 -endif.
 
 % Wildcard functions
--export([optionally_convert_wildcard/2,
-         wildcard_qname/1]).
+-export([optionally_convert_wildcard/2, wildcard_qname/1]).
 % SOA TTL functions
--export([minimum_soa_ttl/2,
-         rewrite_soa_ttl/1]).
+-export([minimum_soa_ttl/2, rewrite_soa_ttl/1]).
 % Matcher functions
 -export([match_name/1,
          match_type/1,

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -16,28 +16,36 @@
 -module(erldns_records).
 
 -include("erldns.hrl").
-
 -include_lib("dns_erlang/include/dns.hrl").
-
 -ifdef(TEST).
-
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
 % Wildcard functions
--export([optionally_convert_wildcard/2, wildcard_qname/1]).
+-export([
+         optionally_convert_wildcard/2,
+         wildcard_qname/1
+        ]).
+
 % SOA TTL functions
--export([minimum_soa_ttl/2, rewrite_soa_ttl/1]).
+-export([
+         minimum_soa_ttl/2,
+         rewrite_soa_ttl/1
+        ]).
+
 % Matcher functions
--export([match_name/1,
+-export([
+         match_name/1,
          match_type/1,
          match_name_and_type/2,
          match_types/1,
          match_wildcard/0,
          match_delegation/1,
-         match_type_covered/1]).
--export([default_ttl/1,
+         match_type_covered/1
+        ]).
+
+-export([
+         default_ttl/1,
          default_priority/1,
          name_type/1,
          root_hints/0,
@@ -46,390 +54,275 @@
 %% @doc If given Name is a wildcard name then the original qname needs to be returned in its place.
 -spec optionally_convert_wildcard(dns:dname(), dns:dname()) -> dns:dname().
 optionally_convert_wildcard(Name, Qname) ->
-    [Head | _] = dns:dname_to_labels(Name),
-    case Head of
-        <<"*">> ->
-            Qname;
-        _ ->
-            Name
-    end.
+  [Head|_] = dns:dname_to_labels(Name),
+  case Head of
+    <<"*">> -> Qname;
+    _ -> Name
+  end.
 
 %% @doc Get a wildcard variation of a Qname. Replaces the leading abel with an asterisk for wildcard lookup.
 -spec wildcard_qname(dns:dname()) -> dns:dname().
 wildcard_qname(Qname) ->
-    [_ | Rest] = dns:dname_to_labels(Qname),
-    dns:labels_to_dname([<<"*">>] ++ Rest).
+  [_|Rest] = dns:dname_to_labels(Qname),
+  dns:labels_to_dname([<<"*">>] ++ Rest).
 
 %% @doc Return the TTL value or 3600 if it is undefined.
 -spec default_ttl(integer() | undefined) -> integer().
 default_ttl(TTL) ->
-    case TTL of
-        undefined ->
-            3600;
-        Value ->
-            Value
-    end.
+  case TTL of
+    undefined -> 3600;
+    Value -> Value
+  end.
 
 %% @doc Return the Priority value or 0 if it is undefined.
 -spec default_priority(integer() | undefined) -> integer().
 default_priority(Priority) ->
-    case Priority of
-        undefined ->
-            0;
-        Value ->
-            Value
-    end.
+  case Priority of
+    undefined -> 0;
+    Value -> Value
+  end.
 
 %% @doc Applies a minimum TTL based on the SOA minumum value.
 %%
 %% The first argument is the Record that is being updated.
 %% The second argument is the SOA RR Data.
 -spec minimum_soa_ttl(dns:dns_rr(), dns:dns_rrdata_soa()) -> dns:dns_rr().
-minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) ->
-    Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
-minimum_soa_ttl(Record, _) ->
-    Record.
+minimum_soa_ttl(Record, Data) when is_record(Data, dns_rrdata_soa) -> Record#dns_rr{ttl = erlang:min(Data#dns_rrdata_soa.minimum, Record#dns_rr.ttl)};
+minimum_soa_ttl(Record, _) -> Record.
 
 %% @doc According to RFC 2308 the TTL for the SOA record in an NXDOMAIN response
 %% must be set to the value of the minimum field in the SOA content.
 -spec rewrite_soa_ttl(dns:message()) -> dns:message().
-rewrite_soa_ttl(Message) ->
-    rewrite_soa_ttl(Message, Message#dns_message.authority, []).
+rewrite_soa_ttl(Message) -> rewrite_soa_ttl(Message, Message#dns_message.authority, []).
 
-rewrite_soa_ttl(Message, [], NewAuthority) ->
-    Message#dns_message{authority = NewAuthority};
-rewrite_soa_ttl(Message, [R | Rest], NewAuthority) ->
-    rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
+rewrite_soa_ttl(Message, [], NewAuthority) -> Message#dns_message{authority = NewAuthority};
+rewrite_soa_ttl(Message, [R|Rest], NewAuthority) -> rewrite_soa_ttl(Message, Rest, NewAuthority ++ [minimum_soa_ttl(R, R#dns_rr.data)]).
+
 
 %% Various matching functions.
 
 -spec match_name(dns:name()) -> fun((dns:rr()) -> boolean()).
 match_name(Name) ->
-    fun(R) when is_record(R, dns_rr) -> R#dns_rr.name =:= Name end.
+  fun(R) when is_record(R, dns_rr) ->
+      R#dns_rr.name =:= Name
+  end.
 
 -spec match_type(dns:type()) -> fun((dns:rr()) -> boolean()).
 match_type(Type) ->
-    fun(R) when is_record(R, dns_rr) -> R#dns_rr.type =:= Type end.
+  fun(R) when is_record(R, dns_rr) ->
+      R#dns_rr.type =:= Type
+  end.
 
 -spec match_name_and_type(dns:name(), dns:type()) -> fun((dns:rr()) -> boolean()).
 match_name_and_type(Name, Type) ->
-    fun(R) when is_record(R, dns_rr) -> (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type) end.
+  fun(R) when is_record(R, dns_rr) ->
+      (R#dns_rr.name =:= Name) and (R#dns_rr.type =:= Type)
+  end.
 
 -spec match_types([dns:type()]) -> fun((dns:rr()) -> boolean()).
 match_types(Types) ->
-    fun(R) when is_record(R, dns_rr) -> lists:any(fun(T) -> R#dns_rr.type =:= T end, Types) end.
+  fun(R) when is_record(R, dns_rr) ->
+      lists:any(fun(T) -> R#dns_rr.type =:= T end, Types)
+  end.
 
 -spec match_wildcard() -> fun((dns:rr()) -> boolean()).
 match_wildcard() ->
-    fun(R) when is_record(R, dns_rr) -> lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name)) end.
+  fun(R) when is_record(R, dns_rr) ->
+      lists:any(match_wildcard_label(), dns:dname_to_labels(R#dns_rr.name))
+  end.
 
 -spec match_wildcard_label() -> fun((binary()) -> boolean()).
 match_wildcard_label() ->
-    fun(L) -> L =:= <<"*">> end.
+  fun(L) ->
+      L =:= <<"*">>
+  end.
 
 -spec match_delegation(dns:dname()) -> fun((dns:rr()) -> boolean()).
 match_delegation(Name) ->
-    fun(R) when is_record(R, dns_rr) -> R#dns_rr.data =:= #dns_rrdata_ns{dname = Name} end.
+  fun(R) when is_record(R, dns_rr) ->
+      R#dns_rr.data =:= #dns_rrdata_ns{dname=Name}
+  end.
 
--spec match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean()).
+-spec(match_type_covered(dns:type()) -> fun((dns:rr()) -> boolean())).
 match_type_covered(Qtype) ->
-    fun(RRSig) -> RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype end.
+  fun(RRSig) ->
+      RRSig#dns_rr.data#dns_rrdata_rrsig.type_covered =:= Qtype
+  end.
+
 
 %% Replacement functions.
 
 replace_name(Name) ->
-    fun(R) when is_record(R, dns_rr) -> R#dns_rr{name = Name} end.
+  fun(R) when is_record(R, dns_rr) ->
+      R#dns_rr{name = Name}
+  end.
 
 %% @doc Returns the type value given a binary string.
--spec name_type(binary()) -> dns:type() | undefined.
+-spec name_type(binary()) -> dns:type() | 'undefined'.
 name_type(Type) when is_binary(Type) ->
-    case Type of
-        ?DNS_TYPE_A_BSTR ->
-            ?DNS_TYPE_A_NUMBER;
-        ?DNS_TYPE_NS_BSTR ->
-            ?DNS_TYPE_NS_NUMBER;
-        ?DNS_TYPE_MD_BSTR ->
-            ?DNS_TYPE_MD_NUMBER;
-        ?DNS_TYPE_MF_BSTR ->
-            ?DNS_TYPE_MF_NUMBER;
-        ?DNS_TYPE_CNAME_BSTR ->
-            ?DNS_TYPE_CNAME_NUMBER;
-        ?DNS_TYPE_SOA_BSTR ->
-            ?DNS_TYPE_SOA_NUMBER;
-        ?DNS_TYPE_MB_BSTR ->
-            ?DNS_TYPE_MB_NUMBER;
-        ?DNS_TYPE_MG_BSTR ->
-            ?DNS_TYPE_MG_NUMBER;
-        ?DNS_TYPE_MR_BSTR ->
-            ?DNS_TYPE_MR_NUMBER;
-        ?DNS_TYPE_NULL_BSTR ->
-            ?DNS_TYPE_NULL_NUMBER;
-        ?DNS_TYPE_WKS_BSTR ->
-            ?DNS_TYPE_WKS_NUMBER;
-        ?DNS_TYPE_PTR_BSTR ->
-            ?DNS_TYPE_PTR_NUMBER;
-        ?DNS_TYPE_HINFO_BSTR ->
-            ?DNS_TYPE_HINFO_NUMBER;
-        ?DNS_TYPE_MINFO_BSTR ->
-            ?DNS_TYPE_MINFO_NUMBER;
-        ?DNS_TYPE_MX_BSTR ->
-            ?DNS_TYPE_MX_NUMBER;
-        ?DNS_TYPE_TXT_BSTR ->
-            ?DNS_TYPE_TXT_NUMBER;
-        ?DNS_TYPE_RP_BSTR ->
-            ?DNS_TYPE_RP_NUMBER;
-        ?DNS_TYPE_AFSDB_BSTR ->
-            ?DNS_TYPE_AFSDB_NUMBER;
-        ?DNS_TYPE_X25_BSTR ->
-            ?DNS_TYPE_X25_NUMBER;
-        ?DNS_TYPE_ISDN_BSTR ->
-            ?DNS_TYPE_ISDN_NUMBER;
-        ?DNS_TYPE_RT_BSTR ->
-            ?DNS_TYPE_RT_NUMBER;
-        ?DNS_TYPE_NSAP_BSTR ->
-            ?DNS_TYPE_NSAP_NUMBER;
-        ?DNS_TYPE_SIG_BSTR ->
-            ?DNS_TYPE_SIG_NUMBER;
-        ?DNS_TYPE_KEY_BSTR ->
-            ?DNS_TYPE_KEY_NUMBER;
-        ?DNS_TYPE_PX_BSTR ->
-            ?DNS_TYPE_PX_NUMBER;
-        ?DNS_TYPE_GPOS_BSTR ->
-            ?DNS_TYPE_GPOS_NUMBER;
-        ?DNS_TYPE_AAAA_BSTR ->
-            ?DNS_TYPE_AAAA_NUMBER;
-        ?DNS_TYPE_LOC_BSTR ->
-            ?DNS_TYPE_LOC_NUMBER;
-        ?DNS_TYPE_NXT_BSTR ->
-            ?DNS_TYPE_NXT_NUMBER;
-        ?DNS_TYPE_EID_BSTR ->
-            ?DNS_TYPE_EID_NUMBER;
-        ?DNS_TYPE_NIMLOC_BSTR ->
-            ?DNS_TYPE_NIMLOC_NUMBER;
-        ?DNS_TYPE_SRV_BSTR ->
-            ?DNS_TYPE_SRV_NUMBER;
-        ?DNS_TYPE_ATMA_BSTR ->
-            ?DNS_TYPE_ATMA_NUMBER;
-        ?DNS_TYPE_NAPTR_BSTR ->
-            ?DNS_TYPE_NAPTR_NUMBER;
-        ?DNS_TYPE_KX_BSTR ->
-            ?DNS_TYPE_KX_NUMBER;
-        ?DNS_TYPE_CERT_BSTR ->
-            ?DNS_TYPE_CERT_NUMBER;
-        ?DNS_TYPE_DNAME_BSTR ->
-            ?DNS_TYPE_DNAME_NUMBER;
-        ?DNS_TYPE_SINK_BSTR ->
-            ?DNS_TYPE_SINK_NUMBER;
-        ?DNS_TYPE_OPT_BSTR ->
-            ?DNS_TYPE_OPT_NUMBER;
-        ?DNS_TYPE_APL_BSTR ->
-            ?DNS_TYPE_APL_NUMBER;
-        ?DNS_TYPE_DS_BSTR ->
-            ?DNS_TYPE_DS_NUMBER;
-        ?DNS_TYPE_CDS_BSTR ->
-            ?DNS_TYPE_CDS_NUMBER;
-        ?DNS_TYPE_SSHFP_BSTR ->
-            ?DNS_TYPE_SSHFP_NUMBER;
-        ?DNS_TYPE_IPSECKEY_BSTR ->
-            ?DNS_TYPE_IPSECKEY_NUMBER;
-        ?DNS_TYPE_RRSIG_BSTR ->
-            ?DNS_TYPE_RRSIG_NUMBER;
-        ?DNS_TYPE_NSEC_BSTR ->
-            ?DNS_TYPE_NSEC_NUMBER;
-        ?DNS_TYPE_DNSKEY_BSTR ->
-            ?DNS_TYPE_DNSKEY_NUMBER;
-        ?DNS_TYPE_CDNSKEY_BSTR ->
-            ?DNS_TYPE_CDNSKEY_NUMBER;
-        ?DNS_TYPE_NSEC3_BSTR ->
-            ?DNS_TYPE_NSEC3_NUMBER;
-        ?DNS_TYPE_NSEC3PARAM_BSTR ->
-            ?DNS_TYPE_NSEC3PARAM_NUMBER;
-        ?DNS_TYPE_DHCID_BSTR ->
-            ?DNS_TYPE_DHCID_NUMBER;
-        ?DNS_TYPE_HIP_BSTR ->
-            ?DNS_TYPE_HIP_NUMBER;
-        ?DNS_TYPE_NINFO_BSTR ->
-            ?DNS_TYPE_NINFO_NUMBER;
-        ?DNS_TYPE_RKEY_BSTR ->
-            ?DNS_TYPE_RKEY_NUMBER;
-        ?DNS_TYPE_TALINK_BSTR ->
-            ?DNS_TYPE_TALINK_NUMBER;
-        ?DNS_TYPE_SPF_BSTR ->
-            ?DNS_TYPE_SPF_NUMBER;
-        ?DNS_TYPE_UINFO_BSTR ->
-            ?DNS_TYPE_UINFO_NUMBER;
-        ?DNS_TYPE_UID_BSTR ->
-            ?DNS_TYPE_UID_NUMBER;
-        ?DNS_TYPE_GID_BSTR ->
-            ?DNS_TYPE_GID_NUMBER;
-        ?DNS_TYPE_UNSPEC_BSTR ->
-            ?DNS_TYPE_UNSPEC_NUMBER;
-        ?DNS_TYPE_TKEY_BSTR ->
-            ?DNS_TYPE_TKEY_NUMBER;
-        ?DNS_TYPE_TSIG_BSTR ->
-            ?DNS_TYPE_TSIG_NUMBER;
-        ?DNS_TYPE_IXFR_BSTR ->
-            ?DNS_TYPE_IXFR_NUMBER;
-        ?DNS_TYPE_AXFR_BSTR ->
-            ?DNS_TYPE_AXFR_NUMBER;
-        ?DNS_TYPE_MAILB_BSTR ->
-            ?DNS_TYPE_MAILB_NUMBER;
-        ?DNS_TYPE_MAILA_BSTR ->
-            ?DNS_TYPE_MAILA_NUMBER;
-        ?DNS_TYPE_ANY_BSTR ->
-            ?DNS_TYPE_ANY_NUMBER;
-        ?DNS_TYPE_CAA_BSTR ->
-            ?DNS_TYPE_CAA_NUMBER;
-        ?DNS_TYPE_DLV_BSTR ->
-            ?DNS_TYPE_DLV_NUMBER;
-        _ ->
-            undefined
-    end.
+  case Type of
+    ?DNS_TYPE_A_BSTR -> ?DNS_TYPE_A_NUMBER;
+    ?DNS_TYPE_NS_BSTR -> ?DNS_TYPE_NS_NUMBER;
+    ?DNS_TYPE_MD_BSTR -> ?DNS_TYPE_MD_NUMBER;
+    ?DNS_TYPE_MF_BSTR -> ?DNS_TYPE_MF_NUMBER;
+    ?DNS_TYPE_CNAME_BSTR -> ?DNS_TYPE_CNAME_NUMBER;
+    ?DNS_TYPE_SOA_BSTR -> ?DNS_TYPE_SOA_NUMBER;
+    ?DNS_TYPE_MB_BSTR -> ?DNS_TYPE_MB_NUMBER;
+    ?DNS_TYPE_MG_BSTR -> ?DNS_TYPE_MG_NUMBER;
+    ?DNS_TYPE_MR_BSTR -> ?DNS_TYPE_MR_NUMBER;
+    ?DNS_TYPE_NULL_BSTR -> ?DNS_TYPE_NULL_NUMBER;
+    ?DNS_TYPE_WKS_BSTR -> ?DNS_TYPE_WKS_NUMBER;
+    ?DNS_TYPE_PTR_BSTR -> ?DNS_TYPE_PTR_NUMBER;
+    ?DNS_TYPE_HINFO_BSTR -> ?DNS_TYPE_HINFO_NUMBER;
+    ?DNS_TYPE_MINFO_BSTR -> ?DNS_TYPE_MINFO_NUMBER;
+    ?DNS_TYPE_MX_BSTR -> ?DNS_TYPE_MX_NUMBER;
+    ?DNS_TYPE_TXT_BSTR -> ?DNS_TYPE_TXT_NUMBER;
+    ?DNS_TYPE_RP_BSTR -> ?DNS_TYPE_RP_NUMBER;
+    ?DNS_TYPE_AFSDB_BSTR -> ?DNS_TYPE_AFSDB_NUMBER;
+    ?DNS_TYPE_X25_BSTR -> ?DNS_TYPE_X25_NUMBER;
+    ?DNS_TYPE_ISDN_BSTR -> ?DNS_TYPE_ISDN_NUMBER;
+    ?DNS_TYPE_RT_BSTR -> ?DNS_TYPE_RT_NUMBER;
+    ?DNS_TYPE_NSAP_BSTR -> ?DNS_TYPE_NSAP_NUMBER;
+    ?DNS_TYPE_SIG_BSTR -> ?DNS_TYPE_SIG_NUMBER;
+    ?DNS_TYPE_KEY_BSTR -> ?DNS_TYPE_KEY_NUMBER;
+    ?DNS_TYPE_PX_BSTR -> ?DNS_TYPE_PX_NUMBER;
+    ?DNS_TYPE_GPOS_BSTR -> ?DNS_TYPE_GPOS_NUMBER;
+    ?DNS_TYPE_AAAA_BSTR -> ?DNS_TYPE_AAAA_NUMBER;
+    ?DNS_TYPE_LOC_BSTR -> ?DNS_TYPE_LOC_NUMBER;
+    ?DNS_TYPE_NXT_BSTR -> ?DNS_TYPE_NXT_NUMBER;
+    ?DNS_TYPE_EID_BSTR -> ?DNS_TYPE_EID_NUMBER;
+    ?DNS_TYPE_NIMLOC_BSTR -> ?DNS_TYPE_NIMLOC_NUMBER;
+    ?DNS_TYPE_SRV_BSTR -> ?DNS_TYPE_SRV_NUMBER;
+    ?DNS_TYPE_ATMA_BSTR -> ?DNS_TYPE_ATMA_NUMBER;
+    ?DNS_TYPE_NAPTR_BSTR -> ?DNS_TYPE_NAPTR_NUMBER;
+    ?DNS_TYPE_KX_BSTR -> ?DNS_TYPE_KX_NUMBER;
+    ?DNS_TYPE_CERT_BSTR -> ?DNS_TYPE_CERT_NUMBER;
+    ?DNS_TYPE_DNAME_BSTR -> ?DNS_TYPE_DNAME_NUMBER;
+    ?DNS_TYPE_SINK_BSTR -> ?DNS_TYPE_SINK_NUMBER;
+    ?DNS_TYPE_OPT_BSTR -> ?DNS_TYPE_OPT_NUMBER;
+    ?DNS_TYPE_APL_BSTR -> ?DNS_TYPE_APL_NUMBER;
+    ?DNS_TYPE_DS_BSTR -> ?DNS_TYPE_DS_NUMBER;
+    ?DNS_TYPE_CDS_BSTR -> ?DNS_TYPE_CDS_NUMBER;
+    ?DNS_TYPE_SSHFP_BSTR -> ?DNS_TYPE_SSHFP_NUMBER;
+    ?DNS_TYPE_IPSECKEY_BSTR -> ?DNS_TYPE_IPSECKEY_NUMBER;
+    ?DNS_TYPE_RRSIG_BSTR -> ?DNS_TYPE_RRSIG_NUMBER;
+    ?DNS_TYPE_NSEC_BSTR -> ?DNS_TYPE_NSEC_NUMBER;
+    ?DNS_TYPE_DNSKEY_BSTR -> ?DNS_TYPE_DNSKEY_NUMBER;
+    ?DNS_TYPE_CDNSKEY_BSTR -> ?DNS_TYPE_CDNSKEY_NUMBER;
+    ?DNS_TYPE_NSEC3_BSTR -> ?DNS_TYPE_NSEC3_NUMBER;
+    ?DNS_TYPE_NSEC3PARAM_BSTR -> ?DNS_TYPE_NSEC3PARAM_NUMBER;
+    ?DNS_TYPE_DHCID_BSTR -> ?DNS_TYPE_DHCID_NUMBER;
+    ?DNS_TYPE_HIP_BSTR -> ?DNS_TYPE_HIP_NUMBER;
+    ?DNS_TYPE_NINFO_BSTR -> ?DNS_TYPE_NINFO_NUMBER;
+    ?DNS_TYPE_RKEY_BSTR -> ?DNS_TYPE_RKEY_NUMBER;
+    ?DNS_TYPE_TALINK_BSTR -> ?DNS_TYPE_TALINK_NUMBER;
+    ?DNS_TYPE_SPF_BSTR -> ?DNS_TYPE_SPF_NUMBER;
+    ?DNS_TYPE_UINFO_BSTR -> ?DNS_TYPE_UINFO_NUMBER;
+    ?DNS_TYPE_UID_BSTR -> ?DNS_TYPE_UID_NUMBER;
+    ?DNS_TYPE_GID_BSTR -> ?DNS_TYPE_GID_NUMBER;
+    ?DNS_TYPE_UNSPEC_BSTR -> ?DNS_TYPE_UNSPEC_NUMBER;
+    ?DNS_TYPE_TKEY_BSTR -> ?DNS_TYPE_TKEY_NUMBER;
+    ?DNS_TYPE_TSIG_BSTR -> ?DNS_TYPE_TSIG_NUMBER;
+    ?DNS_TYPE_IXFR_BSTR -> ?DNS_TYPE_IXFR_NUMBER;
+    ?DNS_TYPE_AXFR_BSTR -> ?DNS_TYPE_AXFR_NUMBER;
+    ?DNS_TYPE_MAILB_BSTR -> ?DNS_TYPE_MAILB_NUMBER;
+    ?DNS_TYPE_MAILA_BSTR -> ?DNS_TYPE_MAILA_NUMBER;
+    ?DNS_TYPE_ANY_BSTR -> ?DNS_TYPE_ANY_NUMBER;
+    ?DNS_TYPE_CAA_BSTR -> ?DNS_TYPE_CAA_NUMBER;
+    ?DNS_TYPE_DLV_BSTR -> ?DNS_TYPE_DLV_NUMBER;
+    _ -> undefined
+  end.
 
--spec root_hints() -> {[dns:rr()], [dns:rr()]}.
+-spec(root_hints() -> {[dns:rr()], [dns:rr()]}).
 root_hints() ->
-    {[#dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}],
-     [#dns_rr{name = <<"a.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {198, 41, 0, 4}}},
-      #dns_rr{name = <<"b.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 228, 79, 201}}},
-      #dns_rr{name = <<"c.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 33, 4, 12}}},
-      #dns_rr{name = <<"d.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {128, 8, 10, 90}}},
-      #dns_rr{name = <<"e.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 203, 230, 10}}},
-      #dns_rr{name = <<"f.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 5, 5, 241}}},
-      #dns_rr{name = <<"g.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 112, 36, 4}}},
-      #dns_rr{name = <<"h.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {128, 63, 2, 53}}},
-      #dns_rr{name = <<"i.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 36, 148, 17}}},
-      #dns_rr{name = <<"j.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 58, 128, 30}}},
-      #dns_rr{name = <<"k.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {193, 0, 14, 129}}},
-      #dns_rr{name = <<"l.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {198, 32, 64, 12}}},
-      #dns_rr{name = <<"m.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {202, 12, 27, 33}}}]}.
+  {
+   [
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
+    #dns_rr{name = <<"">>, type=?DNS_TYPE_NS, ttl=518400, data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}
+   ],
+   [
+    #dns_rr{name = <<"a.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,41,0,4}}},
+    #dns_rr{name = <<"b.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,228,79,201}}},
+    #dns_rr{name = <<"c.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,33,4,12}}},
+    #dns_rr{name = <<"d.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,8,10,90}}},
+    #dns_rr{name = <<"e.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,203,230,10}}},
+    #dns_rr{name = <<"f.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,5,5,241}}},
+    #dns_rr{name = <<"g.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,112,36,4}}},
+    #dns_rr{name = <<"h.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {128,63,2,53}}},
+    #dns_rr{name = <<"i.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,36,148,17}}},
+    #dns_rr{name = <<"j.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {192,58,128,30}}},
+    #dns_rr{name = <<"k.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {193,0,14,129}}},
+    #dns_rr{name = <<"l.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {198,32,64,12}}},
+    #dns_rr{name = <<"m.root-servers.net">>, type=?DNS_TYPE_A, ttl=3600000, data = #dns_rrdata_a{ip = {202,12,27,33}}}
+   ]
+  }.
+
+
 
 -ifdef(TEST).
 
 wildcard_qname_test_() ->
-    ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
+  ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
 
 minimum_soa_ttl_test_() ->
-    [?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
-     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
-     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))].
+  [
+   ?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
+   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
+   ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))
+  ].
 
 replace_name_test_() ->
-    [?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
-     ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))].
+  [
+   ?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
+   ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))
+  ].
 
 match_name_test_() ->
-    [?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
-     ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))].
+  [
+   ?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
+   ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))
+  ].
 
 match_type_test_() ->
-    [?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))].
+  [
+   ?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
+   ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))
+  ].
 
 match_types_test_() ->
-    [?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))].
+  [
+   ?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
+   ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
+   ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))
+  ].
 
 match_wildcard_test_() ->
-    [?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
-     ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))].
+  [
+   ?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
+   ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))
+  ].
 
 match_delegation_test_() ->
-    [?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
-     ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))].
+  [
+   ?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
+   ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))
+  ].
 
 match_wildcard_label_test_() ->
-    [?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
-     ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))].
+  [
+   ?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
+   ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))
+  ].
 
 -endif.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -16,389 +16,412 @@
 -module(erldns_resolver).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([resolve/3]).
 
 -ifdef(TEST).
+
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 %% @doc Resolve the first question in the message. If no message is present, return the original
 %% message. If multiple questions are present, only resolve the first question.
--spec(resolve(
-        Message :: dns:message(),
-        AuthorityRecords :: [dns:rr()],
-        Host :: dns:ip()) ->
-  dns:message()).
+-spec resolve(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Host) ->
-  case Message#dns_message.questions of
-    [] -> Message;
-    [Question] -> resolve_question(Message, AuthorityRecords, Host, Question);
-    [Question|_] -> resolve_question(Message, AuthorityRecords, Host, Question)
-  end.
+    case Message#dns_message.questions of
+        [] ->
+            Message;
+        [Question] ->
+            resolve_question(Message, AuthorityRecords, Host, Question);
+        [Question | _] ->
+            resolve_question(Message, AuthorityRecords, Host, Question)
+    end.
 
 -ifdef(TEST).
+
 resolve_no_question_returns_message_test() ->
-  Q = #dns_message{questions = []},
-  ?assertEqual(Q, resolve(Q, [], {1, 1, 1, 1})).
+    Q = #dns_message{questions = []},
+    ?assertEqual(Q, resolve(Q, [], {1, 1, 1, 1})).
 
 -endif.
 
-
 %% @doc Start the resolution process on the given question.
 %% Step 1: Set the RA bit to false as we do not handle recursive queries.
--spec(resolve_question(
-        Message :: dns:message(),
-        AuthorityRecords :: [dns:rr()],
-        Host :: dns:ip(),
-        Questions :: dns:questions() | dns:query()) ->
-  dns:message()).
+-spec resolve_question(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip(), Questions :: dns:questions() | dns:query()) ->
+                          dns:message().
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
-  case Question#dns_query.type of
-    ?DNS_TYPE_RRSIG ->
-      % Refuse all RRSIG requests.
-      Message#dns_message{ra = false, ad = false, cd = false, rc = ?DNS_RCODE_REFUSED};
-    Qtype ->
-      check_dnssec(Message, Host, Question),
-      resolve_qname_and_qtype(Message#dns_message{ra = false, ad = false, cd = false}, AuthorityRecords, Question#dns_query.name, Qtype, Host)
-  end.
+    case Question#dns_query.type of
+        ?DNS_TYPE_RRSIG ->
+            % Refuse all RRSIG requests.
+            Message#dns_message{ra = false,
+                                ad = false,
+                                cd = false,
+                                rc = ?DNS_RCODE_REFUSED};
+        Qtype ->
+            check_dnssec(Message, Host, Question),
+            resolve_qname_and_qtype(Message#dns_message{ra = false,
+                                                        ad = false,
+                                                        cd = false},
+                                    AuthorityRecords,
+                                    Question#dns_query.name,
+                                    Qtype,
+                                    Host)
+    end.
 
 -ifdef(TEST).
+
 resolve_rrsig_refused_test() ->
-  Q = #dns_message{questions = [#dns_query{type = ?DNS_TYPE_RRSIG}]},
-  A = resolve(Q, [], {1, 1, 1, 1}),
-  ?assertEqual(?DNS_RCODE_REFUSED, A#dns_message.rc).
+    Q = #dns_message{questions = [#dns_query{type = ?DNS_TYPE_RRSIG}]},
+    A = resolve(Q, [], {1, 1, 1, 1}),
+    ?assertEqual(?DNS_RCODE_REFUSED, A#dns_message.rc).
+
 -endif.
 
 %% @doc With the extracted Qname and Qtype in hand, find the nearest zone
 %% Step 2: Search the available zones for the zone which is the nearest ancestor to QNAME
 %%
 %% If the request required DNSSEC, apply the DNSSEC records. Sort answers prior to returning.
--spec resolve_qname_and_qtype(
-        Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
+-spec resolve_qname_and_qtype(Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  case AuthorityRecords of
-    [] ->
-      % Authority records is empty, refuse query
-      Message#dns_message{rc = ?DNS_RCODE_REFUSED}; 
-    _ ->
-      % Authority records present, continue resolution
-      Zone = erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)),
-      ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
-      sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
-  end.
+    case AuthorityRecords of
+        [] ->
+            % Authority records is empty, refuse query
+            Message#dns_message{rc = ?DNS_RCODE_REFUSED};
+        _ ->
+            % Authority records present, continue resolution
+            Zone = erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)),
+            ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
+            sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
+    end.
 
 -ifdef(TEST).
-resolve_no_authority_refused_test() ->
-  Q = #dns_message{questions = [#dns_query{type = Qtype = ?DNS_TYPE_A, name = Qname = <<"example.com">>}]},
-  A = resolve_qname_and_qtype(Q, [], Qname, Qtype, {1, 1, 1, 1}),
-  ?assertEqual(?DNS_RCODE_REFUSED, A#dns_message.rc).
--endif.
 
+resolve_no_authority_refused_test() ->
+    Q = #dns_message{questions = [#dns_query{type = Qtype = ?DNS_TYPE_A, name = Qname = <<"example.com">>}]},
+    A = resolve_qname_and_qtype(Q, [], Qname, Qtype, {1, 1, 1, 1}),
+    ?assertEqual(?DNS_RCODE_REFUSED, A#dns_message.rc).
+
+-endif.
 
 %% An SOA was found, thus we are authoritative and have the zone.
 %%
 %% Step 3: Match records
--spec(resolve_authoritative(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Zone :: #zone{},
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_authoritative(Message :: dns:message(),
+                            Qname :: dns:dname(),
+                            Qtype :: dns:type(),
+                            Zone :: #zone{},
+                            Host :: dns:ip(),
+                            CnameChain :: [dns:rr()]) ->
+                               dns:message().
 resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain) ->
-  Result = case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
-             {false, []} ->
-               % No host name with the given record in the zone, return NXDOMAIN and include authority
-               Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority};
-             _ ->
-               case erldns_zone_cache:get_records_by_name(Qname) of
-                 [] ->
-                   % No exact match of name and type, move to best match resolution
-                   best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
-                 Records ->
-                   % Exact match of name and type
-                   exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
-               end
-           end,
+    Result =
+        case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
+            {false, []} ->
+                % No host name with the given record in the zone, return NXDOMAIN and include authority
+                Message#dns_message{aa = true,
+                                    rc = ?DNS_RCODE_NXDOMAIN,
+                                    authority = Zone#zone.authority};
+            _ ->
+                case erldns_zone_cache:get_records_by_name(Qname) of
+                    [] ->
+                        % No exact match of name and type, move to best match resolution
+                        best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
+                    Records ->
+                        % Exact match of name and type
+                        exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
+                end
+        end,
 
-  case detect_zonecut(Zone, Qname) of
-    [] ->
-      Result;
-    ZonecutRecords ->
-      CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
-      FilteredCnameAnswers = lists:filter(fun(RR) ->
-                                              case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
-                                                [] -> false;
-                                                _ -> true
-                                              end
-                                          end, CnameAnswers),
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = ZonecutRecords, answers = FilteredCnameAnswers}
-  end.
+    case detect_zonecut(Zone, Qname) of
+        [] ->
+            Result;
+        ZonecutRecords ->
+            CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
+            FilteredCnameAnswers =
+                lists:filter(fun(RR) ->
+                                case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
+                                    [] -> false;
+                                    _ -> true
+                                end
+                             end,
+                             CnameAnswers),
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_NOERROR,
+                                authority = ZonecutRecords,
+                                answers = FilteredCnameAnswers}
+    end.
 
 -ifdef(TEST).
+
 resolve_authoritative_host_not_found_test() ->
-  erldns_zone_cache:start_link(),
-  Qname = <<"example.com">>,
-  Z = #zone{name = <<"example.com">>, authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]},
-  Q = #dns_message{questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]},
-  A = resolve_authoritative(Q, Qname, Qtype, Z, {}, _CnameChain = []),
-  ?assertEqual(true, A#dns_message.aa),
-  ?assertEqual(?DNS_RCODE_NXDOMAIN, A#dns_message.rc),
-  ?assertEqual(Authority, A#dns_message.authority).
+    erldns_zone_cache:start_link(),
+    Qname = <<"example.com">>,
+    Z = #zone{name = <<"example.com">>, authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]},
+    Q = #dns_message{questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]},
+    A = resolve_authoritative(Q, Qname, Qtype, Z, {}, _CnameChain = []),
+    ?assertEqual(true, A#dns_message.aa),
+    ?assertEqual(?DNS_RCODE_NXDOMAIN, A#dns_message.rc),
+    ?assertEqual(Authority, A#dns_message.authority).
 
 resolve_authoritative_zone_cut_test() ->
-  erldns_zone_cache:start_link(),
-  erldns_handler:start_link(),
-  Qname = <<"delegated.example.com">>,
-  NsRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NS}],
-  Z = #zone{name = ZoneName = <<"example.com">>, authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]},
-  Q = #dns_message{questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]},
-  erldns_zone_cache:put_zone({ZoneName, <<"_">>, Authority ++ NsRecords}),
-  A = resolve_authoritative(Q, Qname, Qtype, Z, {}, []),
-  ?assertEqual(false, A#dns_message.aa),
-  ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
-  ?assertEqual(NsRecords, A#dns_message.authority),
-  ?assertEqual([], A#dns_message.answers),
-  erldns_zone_cache:delete_zone(ZoneName).
+    erldns_zone_cache:start_link(),
+    erldns_handler:start_link(),
+    Qname = <<"delegated.example.com">>,
+    NsRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_NS}],
+    Z = #zone{name = ZoneName = <<"example.com">>, authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]},
+    Q = #dns_message{questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]},
+    erldns_zone_cache:put_zone({ZoneName, <<"_">>, Authority ++ NsRecords}),
+    A = resolve_authoritative(Q, Qname, Qtype, Z, {}, []),
+    ?assertEqual(false, A#dns_message.aa),
+    ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
+    ?assertEqual(NsRecords, A#dns_message.authority),
+    ?assertEqual([], A#dns_message.answers),
+    erldns_zone_cache:delete_zone(ZoneName).
 
 resolve_authoritative_zone_cut_with_cnames_test() ->
-  erldns_zone_cache:start_link(),
-  erldns_handler:start_link(),
-  Qname = <<"delegated.example.com">>,
-  CnameRecords = [#dns_rr{name = Qname, type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = <<"delegated-ns.example.com">>}}],
-  NsRecords = [#dns_rr{name = <<"delegated-ns.example.com">>, type = ?DNS_TYPE_NS}],
-  Z = #zone{
-         name = ZoneName = <<"example.com">>,
-         authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]
-        },
-  Q = #dns_message{
-         questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]
-         },
-  erldns_zone_cache:put_zone({ZoneName, <<"_">>, Authority ++ NsRecords ++ CnameRecords}),
-  A = resolve_authoritative(Q, Qname, Qtype, Z, {}, _CnameChain = []),
-  ?assertEqual(false, A#dns_message.aa),
-  ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
-  ?assertEqual(NsRecords, A#dns_message.authority),
-  ?assertEqual(CnameRecords, A#dns_message.answers),
-  erldns_zone_cache:delete_zone(ZoneName).
+    erldns_zone_cache:start_link(),
+    erldns_handler:start_link(),
+    Qname = <<"delegated.example.com">>,
+    CnameRecords =
+        [#dns_rr{name = Qname,
+                 type = ?DNS_TYPE_CNAME,
+                 data = #dns_rrdata_cname{dname = <<"delegated-ns.example.com">>}}],
+    NsRecords = [#dns_rr{name = <<"delegated-ns.example.com">>, type = ?DNS_TYPE_NS}],
+    Z = #zone{name = ZoneName = <<"example.com">>, authority = Authority = [#dns_rr{name = <<"example.com">>, type = ?DNS_TYPE_SOA}]},
+    Q = #dns_message{questions = [#dns_query{name = Qname, type = Qtype = ?DNS_TYPE_A}]},
+    erldns_zone_cache:put_zone({ZoneName, <<"_">>, Authority ++ NsRecords ++ CnameRecords}),
+    A = resolve_authoritative(Q, Qname, Qtype, Z, {}, _CnameChain = []),
+    ?assertEqual(false, A#dns_message.aa),
+    ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
+    ?assertEqual(NsRecords, A#dns_message.authority),
+    ?assertEqual(CnameRecords, A#dns_message.answers),
+    erldns_zone_cache:delete_zone(ZoneName).
+
 -endif.
 
 %% Determine if there is a CNAME anywhere in the records with the given Qname.
 exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-  case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
-    [] ->
-      % No CNAME records found in the record set for the Qname
-      resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
-    CnameRecords ->
-      % CNAME records found in the record set for the Qname
-      resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
-  end.
-
+    case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
+        [] ->
+            % No CNAME records found in the record set for the Qname
+            resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
+        CnameRecords ->
+            % CNAME records found in the record set for the Qname
+            resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
+    end.
 
 %% There were no CNAMEs found in the exact name matches, so now we grab the authority
 %% records and find any type matches on QTYPE and continue on.
 %%
 %% This function will search both MatchedRecords and custom handlers.
--spec(resolve_exact_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec resolve_exact_match(Message :: dns:message(),
+                          Qname :: dns:dname(),
+                          Qtype :: dns:type(),
+                          Host :: dns:ip(),
+                          CnameChain :: [dns:rr()],
+                          MatchedRecords :: [dns:rr()],
+                          Zone :: #zone{}) ->
+                             dns:message().
 resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-  TypeMatches = case Qtype of
-                  ?DNS_TYPE_ANY ->
-                    filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-                  _ ->
-                    lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-                end,
-  ExactTypeMatches = case TypeMatches of
-              [] ->
+    TypeMatches =
+        case Qtype of
+            ?DNS_TYPE_ANY ->
+                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+            _ ->
+                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+        end,
+    ExactTypeMatches =
+        case TypeMatches of
+            [] ->
                 % No records matched the qtype, call custom handler
                 Handlers = erldns_handler:get_versioned_handlers(),
                 HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
                 erldns_dnssec:maybe_sign_rrset(Message, HandlerRecords, Zone);
-              _ ->
+            _ ->
                 % Records match qtype, use them
                 TypeMatches
-            end,
-  AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
-  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
-  case {ExactTypeMatches, ReferralRecords} of
-    {[], []} ->
-      % There are no exact type matches and no referrals, return NOERROR with the authority set
-      Message#dns_message{aa = true, authority = Zone#zone.authority};
-    {[], _} ->
-      % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
-      resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
-    _ ->
-      % There were exact matches of name and type.
-      resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
-  end.
+        end,
+    AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
+    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
+    case {ExactTypeMatches, ReferralRecords} of
+        {[], []} ->
+            % There are no exact type matches and no referrals, return NOERROR with the authority set
+            Message#dns_message{aa = true, authority = Zone#zone.authority};
+        {[], _} ->
+            % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
+            resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
+        _ ->
+            % There were exact matches of name and type.
+            resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
+    end.
 
-
--spec(resolve_exact_type_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        AuthorityRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_type_match(Message :: dns:message(),
+                               Qname :: dns:dname(),
+                               Qtype :: dns:type(),
+                               Host :: dns:ip(),
+                               CnameChain :: [dns:rr()],
+                               MatchedRecords :: [dns:rr()],
+                               Zone :: #zone{},
+                               AuthorityRecords :: [dns:rr()]) ->
+                                  dns:message().
 resolve_exact_type_match(Message, Qname, ?DNS_TYPE_NS, Host, CnameChain, MatchedRecords, Zone, []) ->
-  % There was an exact type match for an NS query, however there is no SOA record for the zone.
-  lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
-  Answer = lists:last(MatchedRecords),
-  Name = Answer#dns_rr.name,
-  % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
-  restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+    % There was an exact type match for an NS query, however there is no SOA record for the zone.
+    lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
+    Answer = lists:last(MatchedRecords),
+    Name = Answer#dns_rr.name,
+    % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
+    restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
 resolve_exact_type_match(Message, _Qname, ?DNS_TYPE_NS, _Host, _CnameChain, MatchedRecords, _Zone, _AuthorityRecords) ->
-  % There was an exact type match for an NS query and an SOA record.
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
+    % There was an exact type match for an NS query and an SOA record.
+    Message#dns_message{aa = true,
+                        rc = ?DNS_RCODE_NOERROR,
+                        answers = Message#dns_message.answers ++ MatchedRecords};
 resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords) ->
-  % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
-  Answer = lists:last(MatchedRecords),
-  case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
-    [] ->
-      % We are authoritative and there are no NS records here.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
-    NSRecords ->
-      % NOTE: this is a potential bug because it assumes the last record is the one to examine.
-      NSRecord = lists:last(NSRecords),
-      SoaRecord = lists:last(Zone#zone.authority),
-      case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
-        true ->
-          % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
-          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
-        false ->
-          % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
-          % delegated to another zone in the cache
-          resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
-      end
-  end.
-
+    % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
+    Answer = lists:last(MatchedRecords),
+    case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
+        [] ->
+            % We are authoritative and there are no NS records here.
+            Message#dns_message{aa = true,
+                                rc = ?DNS_RCODE_NOERROR,
+                                answers = Message#dns_message.answers ++ MatchedRecords};
+        NSRecords ->
+            % NOTE: this is a potential bug because it assumes the last record is the one to examine.
+            NSRecord = lists:last(NSRecords),
+            SoaRecord = lists:last(Zone#zone.authority),
+            case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
+                true ->
+                    % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
+                    Message#dns_message{aa = true,
+                                        rc = ?DNS_RCODE_NOERROR,
+                                        answers = Message#dns_message.answers ++ MatchedRecords};
+                false ->
+                    % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
+                    % delegated to another zone in the cache
+                    resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
+            end
+    end.
 
 %% @doc There is an exact name and type match and there NS records present. This may indicate the name is at the apex
 %% or it may indicate that the name is delegated.
--spec(resolve_exact_type_match_delegated(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        AuthorityRecords :: [dns:rr()],
-        NSRecords:: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_type_match_delegated(Message :: dns:message(),
+                                         Qname :: dns:dname(),
+                                         Qtype :: dns:type(),
+                                         Host :: dns:ip(),
+                                         CnameChain :: [dns:rr()],
+                                         MatchedRecords :: [dns:rr()],
+                                         Zone :: #zone{},
+                                         AuthorityRecords :: [dns:rr()],
+                                         NSRecords :: [dns:rr()]) ->
+                                            dns:message().
 resolve_exact_type_match_delegated(Message, _Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _AuthorityRecords, NSRecords) ->
-  % We are authoritative and there are NS records here.
-  % NOTE: there are potential bugs here because it assumes the last record is the one to examine
-  Answer = lists:last(MatchedRecords),
-  NSRecord = lists:last(NSRecords),
-  Name = NSRecord#dns_rr.name,
-  case Name =:= Answer#dns_rr.name of
-    true ->
-      % NS name matches answer name, thus it's a recursion, so return the message
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NSRecords};
-    false ->
-      % NS name is different than the name in the matched records
-      case check_if_parent(Name, Answer#dns_rr.name) of
+    % We are authoritative and there are NS records here.
+    % NOTE: there are potential bugs here because it assumes the last record is the one to examine
+    Answer = lists:last(MatchedRecords),
+    NSRecord = lists:last(NSRecords),
+    Name = NSRecord#dns_rr.name,
+    case Name =:= Answer#dns_rr.name of
         true ->
-          % NS record name is a parent of the answer name
-          restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+            % NS name matches answer name, thus it's a recursion, so return the message
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_NOERROR,
+                                authority = Message#dns_message.authority ++ NSRecords};
         false ->
-          % NS record name is not a parent of the answer name
-          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords, additional = Message#dns_message.additional}
-      end
-  end.
+            % NS name is different than the name in the matched records
+            case check_if_parent(Name, Answer#dns_rr.name) of
+                true ->
+                    % NS record name is a parent of the answer name
+                    restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+                false ->
+                    % NS record name is not a parent of the answer name
+                    Message#dns_message{aa = true,
+                                        rc = ?DNS_RCODE_NOERROR,
+                                        answers = Message#dns_message.answers ++ MatchedRecords,
+                                        additional = Message#dns_message.additional}
+            end
+    end.
 
-
--spec(resolve_exact_match_referral(
-        Message :: dns:message(),
-        Qtype :: dns:type(),
-        MatchedRecords :: [dns:rr()],
-        ReferralRecords :: [dns:rr()],
-        AuthorityRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_match_referral(Message :: dns:message(),
+                                   Qtype :: dns:type(),
+                                   MatchedRecords :: [dns:rr()],
+                                   ReferralRecords :: [dns:rr()],
+                                   AuthorityRecords :: [dns:rr()]) ->
+                                      dns:message().
 resolve_exact_match_referral(Message, _Qtype, _MatchedRecords, ReferralRecords, []) ->
-  % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
-  % add the NS records to the authority section of the message.
-  Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
+    % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
+    % add the NS records to the authority section of the message.
+    Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_ANY, MatchedRecords, _ReferralRecords, _AuthorityRecords) ->
-  % Given an exact name match and the type of ANY, return all of the matched records.
-  Message#dns_message{aa = true, answers = MatchedRecords};
+    % Given an exact name match and the type of ANY, return all of the matched records.
+    Message#dns_message{aa = true, answers = MatchedRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_NS, _MatchedRecords, ReferralRecords, _AuthorityRecords) ->
-  % Given an exact name match and the type NS, where the NS records are not found in record set
-  % return the NS records in the answers section of the message.
-  Message#dns_message{aa = true, answers = ReferralRecords};
+    % Given an exact name match and the type NS, where the NS records are not found in record set
+    % return the NS records in the answers section of the message.
+    Message#dns_message{aa = true, answers = ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_SOA, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-  % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
-  % return the SOA records in the answers section of the message.
-  Message#dns_message{aa = true, answers = AuthorityRecords};
+    % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
+    % return the SOA records in the answers section of the message.
+    Message#dns_message{aa = true, answers = AuthorityRecords};
 resolve_exact_match_referral(Message, _, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-  % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
-  % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, authority = AuthorityRecords}.
+    % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
+    % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
+    Message#dns_message{aa = true,
+                        rc = ?DNS_RCODE_NOERROR,
+                        authority = AuthorityRecords}.
 
-
-
--spec(resolve_exact_match_with_cname(
-        Message :: dns:message(),
-        Qtype :: ?DNS_TYPE_CNAME,
-        Host :: dns:ip(), 
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_match_with_cname(Message :: dns:message(),
+                                     Qtype :: ?DNS_TYPE_CNAME,
+                                     Host :: dns:ip(),
+                                     CnameChain :: [dns:rr()],
+                                     MatchedRecords :: [dns:rr()],
+                                     Zone :: #zone{},
+                                     CnameRecords :: [dns:rr()]) ->
+                                        dns:message().
 resolve_exact_match_with_cname(Message, ?DNS_TYPE_CNAME, _Host, _CnameChain, _MatchedRecords, _Zone, CnameRecords) ->
-  % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
-  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+    % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
+    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, _MatchedRecords, Zone, CnameRecords) ->
-  % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
-  case lists:member(lists:last(CnameRecords), CnameChain) of
-    true ->
-      % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-    false ->
-      % No CNAME loop, restart the query with the CNAME content.
-      CnameRecord = lists:last(CnameRecords),
-      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-      restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
-  end.
+    % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
+    case lists:member(lists:last(CnameRecords), CnameChain) of
+        true ->
+            % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
+            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+        false ->
+            % No CNAME loop, restart the query with the CNAME content.
+            CnameRecord = lists:last(CnameRecords),
+            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+            restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+                          Name,
+                          Qtype,
+                          Host,
+                          CnameChain ++ CnameRecords,
+                          Zone,
+                          erldns_zone_cache:in_zone(Name))
+    end.
 
-
--spec(best_match_resolution(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec best_match_resolution(Message :: dns:message(),
+                            Qname :: dns:dname(),
+                            Qtype :: dns:type(),
+                            Host :: dns:ip(),
+                            CnameChain :: [dns:rr()],
+                            BestMatchRecords :: [dns:rr()],
+                            Zone :: #zone{}) ->
+                               dns:message().
 best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-  % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
-  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords), 
-  case ReferralRecords of
-    [] ->
-      % There were no NS records in the best matches.
-      resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
-    _ ->
-      % There were NS records in the best matches, so this is a referral.
-      resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
-  end.
-
+    % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
+    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords),
+    case ReferralRecords of
+        [] ->
+            % There were no NS records in the best matches.
+            resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
+        _ ->
+            % There were NS records in the best matches, so this is a referral.
+            resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
+    end.
 
 %% @doc There is no referral, so check to see if there is a wildcard.
 %%
@@ -408,351 +431,347 @@ best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords,
 %%
 %% If there is no wildcard present and the qname does not match the origina question then return NOERROR
 %% and include root hints in the additional section if necessary.
--spec(resolve_best_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec resolve_best_match(Message :: dns:message(),
+                         Qname :: dns:dname(),
+                         Qtype :: dns:type(),
+                         Host :: dns:ip(),
+                         CnameChain :: [dns:rr()],
+                         BestMatchRecords :: [dns:rr()],
+                         Zone :: #zone{}) ->
+                            dns:message().
 resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-  case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
-    true ->
-      % It's a wildcard match
-      CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
-      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
-    false ->
-      % It's not a wildcard
-      [Question|_] = Message#dns_message.questions,
-      case Qname =:= Question#dns_query.name of % TODO this logic can be moved up higher in processing potentially.
+    case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
         true ->
-          % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
-          Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority, aa = true};
+            % It's a wildcard match
+            CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
+            resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
         false ->
-          % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
-          % something other than CNAME. Note that the response is still NOERROR here.
-          %
-          % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
-          optionally_add_root_hints(Message)
-      end
-  end.
+            % It's not a wildcard
+            [Question | _] = Message#dns_message.questions,
+            case Qname =:= Question#dns_query.name % TODO this logic can be moved up higher in processing potentially.
+            of
+                true ->
+                    % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
+                    Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN,
+                                        authority = Zone#zone.authority,
+                                        aa = true};
+                false ->
+                    % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
+                    % something other than CNAME. Note that the response is still NOERROR here.
+                    %
+                    % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
+                    optionally_add_root_hints(Message)
+            end
+    end.
 
-
--spec(resolve_best_match_with_wildcard(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_with_wildcard(Message :: dns:message(),
+                                       Qname :: dns:dname(),
+                                       Qtype :: dns:type(),
+                                       Host :: dns:ip(),
+                                       CnameChain :: [dns:rr()],
+                                       BestMatchRecords :: [dns:rr()],
+                                       Zone :: #zone{},
+                                       CnameRecords :: [dns:rr()]) ->
+                                          dns:message().
 resolve_best_match_with_wildcard(Message, Qname, Qtype, _Host, _CnameChain, MatchedRecords, Zone, []) ->
-  % Handle best match resolving with a wildcard name in the zone.
-  TypeMatchedRecords = case Qtype of
-                         ?DNS_TYPE_ANY ->
-                           filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-                         _ ->
-                           lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-                       end,
-  TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
-  case TypeMatches of
-    [] ->
-      % There is no exact type matches for the original qtype, ask the custom handlers for their records.
-      Handlers = erldns_handler:get_versioned_handlers(),
-      HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
-      Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
-      NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
-      case NewRecords of
+    % Handle best match resolving with a wildcard name in the zone.
+    TypeMatchedRecords =
+        case Qtype of
+            ?DNS_TYPE_ANY ->
+                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+            _ ->
+                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+        end,
+    TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
+    case TypeMatches of
         [] ->
-          % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
-          Message#dns_message{aa = true, authority=Zone#zone.authority};
-        NewRecords ->
-          % Custom handlers returned answers
-          Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
-      end;
-    _ ->
-      % There is an exact type match
-      Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
-  end;
+            % There is no exact type matches for the original qtype, ask the custom handlers for their records.
+            Handlers = erldns_handler:get_versioned_handlers(),
+            HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
+            Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
+            NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
+            case NewRecords of
+                [] ->
+                    % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
+                    Message#dns_message{aa = true, authority = Zone#zone.authority};
+                NewRecords ->
+                    % Custom handlers returned answers
+                    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
+            end;
+        _ ->
+            % There is an exact type match
+            Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
+    end;
 resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords) ->
-  % It is a wildcard CNAME
-  resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
-
+    % It is a wildcard CNAME
+    resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
 
 % Handle the case where the wildcard is a CNAME in the zone. If the Qtype was CNAME then answer, otherwise determine if
 % the CNAME should be followed
--spec(resolve_best_match_with_wildcard_cname(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_with_wildcard_cname(Message :: dns:message(),
+                                             Qname :: dns:dname(),
+                                             Qtype :: dns:type(),
+                                             Host :: dns:ip(),
+                                             CnameChain :: [dns:rr()],
+                                             BestMatchRecords :: [dns:rr()],
+                                             Zone :: #zone{},
+                                             CnameRecords :: [dns:rr()]) ->
+                                                dns:message().
 resolve_best_match_with_wildcard_cname(Message, _Qname, ?DNS_TYPE_CNAME, _Host, _CnameChain, _BestMatchRecords, _Zone, CnameRecords) ->
-  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_best_match_with_wildcard_cname(Message, _Qname, Qtype, Host, CnameChain, _BestMatchRecords, Zone, CnameRecords) ->
-  CnameRecord = lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
-  case lists:member(CnameRecord, CnameChain) of
-    true ->
-      % Indicates CNAME loop
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-    false ->
-      % Follow the CNAME
-      CnameRecord = lists:last(CnameRecords),
-      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-      UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
-      restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
-  end.
-
+    CnameRecord = lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
+    case lists:member(CnameRecord, CnameChain) of
+        true ->
+            % Indicates CNAME loop
+            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+        false ->
+            % Follow the CNAME
+            CnameRecord = lists:last(CnameRecords),
+            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+            UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+            restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+    end.
 
 % There are referral records
--spec(resolve_best_match_referral(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_referral(Message :: dns:message(),
+                                  Qname :: dns:dname(),
+                                  Qtype :: dns:type(),
+                                  Host :: dns:ip(),
+                                  CnameChain :: [dns:rr()],
+                                  BestMatchRecords :: [dns:rr()],
+                                  Zone :: #zone{},
+                                  CnameRecords :: [dns:rr()]) ->
+                                     dns:message().
 resolve_best_match_referral(Message, _Qname, Qtype, _Host, CnameChain, BestMatchRecords, _Zone, ReferralRecords) ->
-  Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
-  case {Qtype, Authority, CnameChain} of
-    {_,[],[]} ->
-      % We are authoritative for the name since there was an SOA record in the best match results.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Authority};
-    {_,_,[]} ->
-      % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
-      % The name has thus been delegated to another authority.
-      Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
-    {?DNS_TYPE_ANY,_,_} ->
-      % We are authoritative and the Qtype is ANY, return the original message
-      Message;
-    _ ->
-      % We are authoritative and the Qtype is something other than ANY, set the authority in the response
-      Message#dns_message{authority = Authority}
-  end.
-
+    Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
+    case {Qtype, Authority, CnameChain} of
+        {_, [], []} ->
+            % We are authoritative for the name since there was an SOA record in the best match results.
+            Message#dns_message{aa = true,
+                                rc = ?DNS_RCODE_NXDOMAIN,
+                                authority = Authority};
+        {_, _, []} ->
+            % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
+            % The name has thus been delegated to another authority.
+            Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
+        {?DNS_TYPE_ANY, _, _} ->
+            % We are authoritative and the Qtype is ANY, return the original message
+            Message;
+        _ ->
+            % We are authoritative and the Qtype is something other than ANY, set the authority in the response
+            Message#dns_message{authority = Authority}
+    end.
 
 % The CNAME is in a zone. If it is the same zone, then continue the chain, otherwise return the message
--spec(restart_query(
-        Message :: dns:message(),
-        Name :: dns:dname(),
-        Qtype :: 0..255,
-        Host :: any(),
-        CnameChain :: any(),
-        Zone :: #zone{},
-        InZone :: boolean()) ->
-  dns:message()).
+-spec restart_query(Message :: dns:message(),
+                    Name :: dns:dname(),
+                    Qtype :: 0..255,
+                    Host :: any(),
+                    CnameChain :: any(),
+                    Zone :: #zone{},
+                    InZone :: boolean()) ->
+                       dns:message().
 restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
-  case check_if_parent(Zone#zone.name, Name) of
-    true -> resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
-    false -> Message
-  end;
+    case check_if_parent(Zone#zone.name, Name) of
+        true ->
+            resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
+        false ->
+            Message
+    end;
 % The CNAME is not in a zone, do not restart the query, return the answer.
 restart_query(Message, _Name, _Qtype, _Host, _CnameChain, _Zone, false) ->
-  Message.
+    Message.
 
-
--spec(restart_delegated_query(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        Zone :: #zone{},
-        InZone :: boolean()) ->
-  dns:message()).
+-spec restart_delegated_query(Message :: dns:message(),
+                              Qname :: dns:dname(),
+                              Qtype :: dns:type(),
+                              Host :: dns:ip(),
+                              CnameChain :: [dns:rr()],
+                              Zone :: #zone{},
+                              InZone :: boolean()) ->
+                                 dns:message().
 % Delegated, but in the same zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, true) ->
-  resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
+    resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
 % Delegated to a different zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, false) ->
-  resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
-
+    resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
 
 %% Utility functions
 
-
 %% @doc If root hints are enabled, return an updated message with the root hints.
--spec(optionally_add_root_hints(dns:message()) -> dns:message()).
+-spec optionally_add_root_hints(dns:message()) -> dns:message().
 optionally_add_root_hints(Message) ->
-  case erldns_config:use_root_hints() of
-    true ->
-      {Authority, Additional} = erldns_records:root_hints(),
-      Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
-    _ ->
-      Message
-  end.
+    case erldns_config:use_root_hints() of
+        true ->
+            {Authority, Additional} = erldns_records:root_hints(),
+            Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
+        _ ->
+            Message
+    end.
 
 %% Returns true if the first domain name is a parent of the second domain name.
 check_if_parent(PossibleParentName, Name) ->
-  case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
-    [] -> true;
-    _ -> false
-  end.
-
+    case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
+        [] ->
+            true;
+        _ ->
+            false
+    end.
 
 % Find the best match records for the given Qname in the given zone. This will attempt to walk through the
 % domain hierarchy in the Qname looking for both exact and wildcard matches.
 -spec best_match(dns:dname(), #zone{}) -> [dns:rr()].
-best_match(Qname, Zone) -> best_match(Qname, Zone, dns:dname_to_labels(Qname)).
+best_match(Qname, Zone) ->
+    best_match(Qname, Zone, dns:dname_to_labels(Qname)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()]) -> [dns:rr()].
-best_match(_Qname, _Zone, []) -> [];
-best_match(Qname, Zone, [_|Rest]) ->
-  WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
-  best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
+best_match(_Qname, _Zone, []) ->
+    [];
+best_match(Qname, Zone, [_ | Rest]) ->
+    WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
+    best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()], [dns:rr()]) -> [dns:rr()].
-best_match(_Qname, _Zone, [], []) -> [];
+best_match(_Qname, _Zone, [], []) ->
+    [];
 best_match(Qname, Zone, Labels, []) ->
-  Name = dns:labels_to_dname(Labels),
-  case erldns_zone_cache:get_records_by_name(Name) of
-    [] -> best_match(Qname, Zone, Labels);
-    Matches -> Matches
-  end;
-best_match(_Qname, _Zone, _Labels, WildcardMatches) -> WildcardMatches.
-
+    Name = dns:labels_to_dname(Labels),
+    case erldns_zone_cache:get_records_by_name(Name) of
+        [] ->
+            best_match(Qname, Zone, Labels);
+        Matches ->
+            Matches
+    end;
+best_match(_Qname, _Zone, _Labels, WildcardMatches) ->
+    WildcardMatches.
 
 %% Call all registered handlers.
 -spec call_handlers(dns:dname(), dns:type(), [dns:rr()], dns:message()) -> fun(({module(), [dns:type()], integer()}) -> [dns:rr()]).
 call_handlers(Qname, Qtype, Records, Message) ->
-  fun({Module, Types, Version}) ->
-      case Version of
-        1 ->
-          case lists:member(Qtype, Types) of
-            true -> Module:handle(Qname, Qtype, Records);
-            false ->
-              case Qtype =:= ?DNS_TYPE_ANY of
-                true -> Module:handle(Qname, Qtype, Records);
-                false -> []
-              end
-          end;
-        2 ->
-          case lists:member(Qtype, Types) of
-            true -> Module:handle(Qname, Qtype, Records, Message);
-            false ->
-              case Qtype =:= ?DNS_TYPE_ANY of
-                true -> Module:handle(Qname, Qtype, Records, Message);
-                false -> []
-              end
-          end
-      end
-  end.
-
+    fun({Module, Types, Version}) ->
+       case Version of
+           1 ->
+               case lists:member(Qtype, Types) of
+                   true -> Module:handle(Qname, Qtype, Records);
+                   false ->
+                       case Qtype =:= ?DNS_TYPE_ANY of
+                           true -> Module:handle(Qname, Qtype, Records);
+                           false -> []
+                       end
+               end;
+           2 ->
+               case lists:member(Qtype, Types) of
+                   true -> Module:handle(Qname, Qtype, Records, Message);
+                   false ->
+                       case Qtype =:= ?DNS_TYPE_ANY of
+                           true -> Module:handle(Qname, Qtype, Records, Message);
+                           false -> []
+                       end
+               end
+       end
+    end.
 
 % Filter records through registered handlers.
-filter_records(Records, []) -> Records;
-filter_records(Records, [{Handler, _Types, Version}|Rest]) ->
-  case Version of
-    1 -> filter_records(Handler:filter(Records), Rest);
-    2 -> filter_records(Handler:filter(Records), Rest);
-    _ -> []
-  end.
-
+filter_records(Records, []) ->
+    Records;
+filter_records(Records, [{Handler, _Types, Version} | Rest]) ->
+    case Version of
+        1 ->
+            filter_records(Handler:filter(Records), Rest);
+        2 ->
+            filter_records(Handler:filter(Records), Rest);
+        _ ->
+            []
+    end.
 
 %% See if additional processing is necessary.
 additional_processing(Message, Host, Zone) ->
-  RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
-  additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
+    RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
+    additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
+
 %% No records require additional processing.
 additional_processing(Message, _Host, _Zone, []) ->
-  Message;
+    Message;
 %% There are records with names that require additional processing.
 additional_processing(Message, Host, Zone, Names) ->
-  RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
-  Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
-  additional_processing(Message, Host, Zone, Names, Records).
+    RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
+    Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
+    additional_processing(Message, Host, Zone, Names, Records).
 
 %% No additional A records were found, so just return the message.
 additional_processing(Message, _Host, _Zone, _Names, []) ->
-  Message;
+    Message;
 %% Additional A records were found, so we add them to the additional section.
 additional_processing(Message, _Host, _Zone, _Names, Records) ->
-  Message#dns_message{additional = Message#dns_message.additional ++ Records}.
-
-
+    Message#dns_message{additional = Message#dns_message.additional ++ Records}.
 
 %% Given a list of answers find the names that require additional processing.
--spec(requires_additional_processing(
-        Records :: [dns:rr()],
-        RecordsRequiringAdditionalProcessing :: [dns:rr()]) ->
-  [dns:rr()]).
-requires_additional_processing([], RequiresAdditional) -> RequiresAdditional;
-requires_additional_processing([Answer|Rest], RequiresAdditional) ->
-  Names = case Answer#dns_rr.data of
-            Data when is_record(Data, dns_rrdata_ns) -> [Data#dns_rrdata_ns.dname];
-            Data when is_record(Data, dns_rrdata_mx) -> [Data#dns_rrdata_mx.exchange];
-            _ -> []
-          end,
-  requires_additional_processing(Rest, RequiresAdditional ++ Names).
-
+-spec requires_additional_processing(Records :: [dns:rr()], RecordsRequiringAdditionalProcessing :: [dns:rr()]) -> [dns:rr()].
+requires_additional_processing([], RequiresAdditional) ->
+    RequiresAdditional;
+requires_additional_processing([Answer | Rest], RequiresAdditional) ->
+    Names =
+        case Answer#dns_rr.data of
+            Data when is_record(Data, dns_rrdata_ns) ->
+                [Data#dns_rrdata_ns.dname];
+            Data when is_record(Data, dns_rrdata_mx) ->
+                [Data#dns_rrdata_mx.exchange];
+            _ ->
+                []
+        end,
+    requires_additional_processing(Rest, RequiresAdditional ++ Names).
 
 %% @doc Return true if DNSSEC is requested and enabled.
--spec(check_dnssec(
-        Message :: dns:message(),
-        Host :: dns:ip(),
-        Question :: dns:query()) ->
-  boolean()).
+-spec check_dnssec(Message :: dns:message(), Host :: dns:ip(), Question :: dns:query()) -> boolean().
 check_dnssec(Message, Host, Question) ->
-  case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
-    true ->
-      erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
-      true;
-    false ->
-      false
-  end.
-
+    case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
+        true ->
+            erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
+            true;
+        false ->
+            false
+    end.
 
 %% @doc Sort the answers in the given message.
 -spec sort_answers(dns:message()) -> dns:message().
 sort_answers(Message) ->
-  Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
+    Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
 
 -spec sort_fun(dns:rr(), dns:rr()) -> boolean().
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}},
-         #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
-  true;
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name},
-         #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}}) ->
-  false;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}, #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
+    true;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name}, #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}) ->
+    false;
 sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME}, #dns_rr{}) ->
-  true;
+    true;
 sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
-  false;
+    false;
 sort_fun(A, B) ->
-  A =< B.
+    A =< B.
 
 % Extract the name from the first record in the list.
 zone_authority_name([Record | _]) ->
-  Record#dns_rr.name.
+    Record#dns_rr.name.
 
 % Find NS records that represent a zone cut.
 detect_zonecut(Zone, Qname) when is_binary(Qname) ->
-  detect_zonecut(Zone, dns:dname_to_labels(Qname));
+    detect_zonecut(Zone, dns:dname_to_labels(Qname));
 detect_zonecut(_Zone, []) ->
-  [];
+    [];
 detect_zonecut(_Zone, [_Label]) ->
-  [];
+    [];
 detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
-  Qname = dns:labels_to_dname(Labels),
-  case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
-    true ->
-      [];
-    false ->
-      case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
-        [] ->
-          detect_zonecut(Zone, ParentLabels);
-        ZonecutNSRecords ->
-          ZonecutNSRecords
-      end
-  end.
+    Qname = dns:labels_to_dname(Labels),
+    case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
+        true ->
+            [];
+        false ->
+            case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
+                [] ->
+                    detect_zonecut(Zone, ParentLabels);
+                ZonecutNSRecords ->
+                    ZonecutNSRecords
+            end
+    end.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -16,330 +16,316 @@
 -module(erldns_resolver).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([resolve/3]).
 
+
 %% @doc Resolve the first question in the message. If no message is present, return the original
 %% message. If multiple questions are present, only resolve the first question.
--spec resolve(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
+-spec(resolve(
+        Message :: dns:message(),
+        AuthorityRecords :: [dns:rr()],
+        Host :: dns:ip()) ->
+  dns:message()).
 resolve(Message, AuthorityRecords, Host) ->
-    case Message#dns_message.questions of
-        [] ->
-            Message;
-        [Question] ->
-            resolve_question(Message, AuthorityRecords, Host, Question);
-        [Question | _] ->
-            resolve_question(Message, AuthorityRecords, Host, Question)
-    end.
+  case Message#dns_message.questions of
+    [] -> Message;
+    [Question] -> resolve_question(Message, AuthorityRecords, Host, Question);
+    [Question|_] -> resolve_question(Message, AuthorityRecords, Host, Question)
+  end.
+
 
 %% @doc Start the resolution process on the given question.
 %% Step 1: Set the RA bit to false as we do not handle recursive queries.
 %%
 %% Refuse all RRSIG requests.
--spec resolve_question(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip(), Questions :: dns:questions() | dns:query()) ->
-                          dns:message().
+-spec(resolve_question(
+        Message :: dns:message(),
+        AuthorityRecords :: [dns:rr()],
+        Host :: dns:ip(),
+        Questions :: dns:questions() | dns:query()) ->
+  dns:message()).
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
-    case Question#dns_query.type of
-        ?DNS_TYPE_RRSIG ->
-            Message#dns_message{ra = false,
-                                ad = false,
-                                cd = false,
-                                rc = ?DNS_RCODE_REFUSED};
-        Qtype ->
-            check_dnssec(Message, Host, Question),
-            resolve_qname_and_qtype(Message#dns_message{ra = false,
-                                                        ad = false,
-                                                        cd = false},
-                                    AuthorityRecords,
-                                    Question#dns_query.name,
-                                    Qtype,
-                                    Host)
-    end.
+  case Question#dns_query.type of
+    ?DNS_TYPE_RRSIG ->
+      Message#dns_message{ra = false, ad = false, cd = false, rc = ?DNS_RCODE_REFUSED};
+    Qtype ->
+      check_dnssec(Message, Host, Question),
+      resolve_qname_and_qtype(Message#dns_message{ra = false, ad = false, cd = false}, AuthorityRecords, Question#dns_query.name, Qtype, Host)
+  end.
 
 %% @doc With the extracted Qname and Qtype in hand, find the nearest zone
 %% Step 2: Search the available zones for the zone which is the nearest ancestor to QNAME
 %%
 %% If the request required DNSSEC, apply the DNSSEC records. Sort answers prior to returning.
--spec resolve_qname_and_qtype(Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
+-spec resolve_qname_and_qtype(
+        Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
-    case erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) of
-        {error, not_authoritative} ->
-            % No SOA was found for the Qname so we return the root hints
-            % Note: it seems odd that we are indicating we are authoritative here.
-            optionally_add_root_hints(Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR});
-        Zone ->
-            ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
-            sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
-    end.
+  case erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) of
+    {error, not_authoritative} ->
+      % No SOA was found for the Qname so we return the root hints
+      % Note: it seems odd that we are indicating we are authoritative here.
+      optionally_add_root_hints(Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR});
+    Zone ->
+      ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
+      sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
+  end.
 
 %% An SOA was found, thus we are authoritative and have the zone.
 %%
 %% Step 3: Match records
--spec resolve_authoritative(Message :: dns:message(),
-                            Qname :: dns:dname(),
-                            Qtype :: dns:type(),
-                            Zone :: #zone{},
-                            Host :: dns:ip(),
-                            CnameChain :: [dns:rr()]) ->
-                               dns:message().
+-spec(resolve_authoritative(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Zone :: #zone{},
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()]) ->
+  dns:message()).
 resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain) ->
-    Result =
-        case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
-            {false, []} ->
-                % No host name with the given record in the zone, return NXDOMAIN and include authority
-                Message#dns_message{aa = true,
-                                    rc = ?DNS_RCODE_NXDOMAIN,
-                                    authority = Zone#zone.authority};
-            _ ->
-                case erldns_zone_cache:get_records_by_name(Qname) of
-                    [] ->
-                        % No exact match of name and type, move to best match resolution
-                        best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
-                    Records ->
-                        % Exact match of name and type
-                        exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
-                end
-        end,
-    case detect_zonecut(Zone, Qname) of
-        [] ->
-            Result;
-        ZonecutRecords ->
-            CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
-            FilteredCnameAnswers =
-                lists:filter(fun(RR) ->
-                                case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
-                                    [] -> false;
-                                    _ -> true
-                                end
-                             end,
-                             CnameAnswers),
-            Message#dns_message{aa = false,
-                                rc = ?DNS_RCODE_NOERROR,
-                                authority = ZonecutRecords,
-                                answers = FilteredCnameAnswers}
-    end.
+  Result = case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
+             {false, []} ->
+               % No host name with the given record in the zone, return NXDOMAIN and include authority
+               Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority};
+             _ ->
+               case erldns_zone_cache:get_records_by_name(Qname) of
+                 [] ->
+                   % No exact match of name and type, move to best match resolution
+                   best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
+                 Records ->
+                   % Exact match of name and type
+                   exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
+               end
+           end,
+
+  case detect_zonecut(Zone, Qname) of
+    [] ->
+      Result;
+    ZonecutRecords ->
+      CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
+      FilteredCnameAnswers = lists:filter(fun(RR) ->
+                                              case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
+                                                [] -> false;
+                                                _ -> true
+                                              end
+                                          end, CnameAnswers),
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = ZonecutRecords, answers = FilteredCnameAnswers}
+  end.
+
 
 %% Determine if there is a CNAME anywhere in the records with the given Qname.
 exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-    case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
-        [] ->
-            % No CNAME records found in the record set for the Qname
-            resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
-        CnameRecords ->
-            % CNAME records found in the record set for the Qname
-            resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
-    end.
+  case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
+    [] ->
+      % No CNAME records found in the record set for the Qname
+      resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
+    CnameRecords ->
+      % CNAME records found in the record set for the Qname
+      resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
+  end.
+
 
 %% There were no CNAMEs found in the exact name matches, so now we grab the authority
 %% records and find any type matches on QTYPE and continue on.
 %%
 %% This function will search both MatchedRecords and custom handlers.
--spec resolve_exact_match(Message :: dns:message(),
-                          Qname :: dns:dname(),
-                          Qtype :: dns:type(),
-                          Host :: dns:ip(),
-                          CnameChain :: [dns:rr()],
-                          MatchedRecords :: [dns:rr()],
-                          Zone :: #zone{}) ->
-                             dns:message().
+-spec(resolve_exact_match(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{}) ->
+  dns:message()).
 resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-    TypeMatches =
-        case Qtype of
-            ?DNS_TYPE_ANY ->
-                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-            _ ->
-                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-        end,
-    ExactTypeMatches =
-        case TypeMatches of
-            [] ->
+  TypeMatches = case Qtype of
+                  ?DNS_TYPE_ANY ->
+                    filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+                  _ ->
+                    lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+                end,
+  ExactTypeMatches = case TypeMatches of
+              [] ->
                 % No records matched the qtype, call custom handler
                 Handlers = erldns_handler:get_versioned_handlers(),
                 HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
                 erldns_dnssec:maybe_sign_rrset(Message, HandlerRecords, Zone);
-            _ ->
+              _ ->
                 % Records match qtype, use them
                 TypeMatches
-        end,
-    AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
-    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
-    case {ExactTypeMatches, ReferralRecords} of
-        {[], []} ->
-            % There are no exact type matches and no referrals, return NOERROR with the authority set
-            Message#dns_message{aa = true, authority = Zone#zone.authority};
-        {[], _} ->
-            % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
-            resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
-        _ ->
-            % There were exact matches of name and type.
-            resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
-    end.
+            end,
+  AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
+  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
+  case {ExactTypeMatches, ReferralRecords} of
+    {[], []} ->
+      % There are no exact type matches and no referrals, return NOERROR with the authority set
+      Message#dns_message{aa = true, authority = Zone#zone.authority};
+    {[], _} ->
+      % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
+      resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
+    _ ->
+      % There were exact matches of name and type.
+      resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
+  end.
 
--spec resolve_exact_type_match(Message :: dns:message(),
-                               Qname :: dns:dname(),
-                               Qtype :: dns:type(),
-                               Host :: dns:ip(),
-                               CnameChain :: [dns:rr()],
-                               MatchedRecords :: [dns:rr()],
-                               Zone :: #zone{},
-                               AuthorityRecords :: [dns:rr()]) ->
-                                  dns:message().
+
+-spec(resolve_exact_type_match(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{},
+        AuthorityRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_type_match(Message, Qname, ?DNS_TYPE_NS, Host, CnameChain, MatchedRecords, Zone, []) ->
-    % There was an exact type match for an NS query, however there is no SOA record for the zone.
-    lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
-    Answer = lists:last(MatchedRecords),
-    Name = Answer#dns_rr.name,
-    % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
-    restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+  % There was an exact type match for an NS query, however there is no SOA record for the zone.
+  lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
+  Answer = lists:last(MatchedRecords),
+  Name = Answer#dns_rr.name,
+  % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
+  restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
 resolve_exact_type_match(Message, _Qname, ?DNS_TYPE_NS, _Host, _CnameChain, MatchedRecords, _Zone, _AuthorityRecords) ->
-    % There was an exact type match for an NS query and an SOA record.
-    Message#dns_message{aa = true,
-                        rc = ?DNS_RCODE_NOERROR,
-                        answers = Message#dns_message.answers ++ MatchedRecords};
+  % There was an exact type match for an NS query and an SOA record.
+  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
 resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords) ->
-    % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
-    Answer = lists:last(MatchedRecords),
-    case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
-        [] ->
-            % We are authoritative and there are no NS records here.
-            Message#dns_message{aa = true,
-                                rc = ?DNS_RCODE_NOERROR,
-                                answers = Message#dns_message.answers ++ MatchedRecords};
-        NSRecords ->
-            % NOTE: this is a potential bug because it assumes the last record is the one to examine.
-            NSRecord = lists:last(NSRecords),
-            SoaRecord = lists:last(Zone#zone.authority),
-            case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
-                true ->
-                    % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
-                    Message#dns_message{aa = true,
-                                        rc = ?DNS_RCODE_NOERROR,
-                                        answers = Message#dns_message.answers ++ MatchedRecords};
-                false ->
-                    % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
-                    % delegated to another zone in the cache
-                    resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
-            end
-    end.
+  % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
+  Answer = lists:last(MatchedRecords),
+  case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
+    [] ->
+      % We are authoritative and there are no NS records here.
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
+    NSRecords ->
+      % NOTE: this is a potential bug because it assumes the last record is the one to examine.
+      NSRecord = lists:last(NSRecords),
+      SoaRecord = lists:last(Zone#zone.authority),
+      case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
+        true ->
+          % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
+          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
+        false ->
+          % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
+          % delegated to another zone in the cache
+          resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
+      end
+  end.
+
 
 %% @doc There is an exact name and type match and there NS records present. This may indicate the name is at the apex
 %% or it may indicate that the name is delegated.
--spec resolve_exact_type_match_delegated(Message :: dns:message(),
-                                         Qname :: dns:dname(),
-                                         Qtype :: dns:type(),
-                                         Host :: dns:ip(),
-                                         CnameChain :: [dns:rr()],
-                                         MatchedRecords :: [dns:rr()],
-                                         Zone :: #zone{},
-                                         AuthorityRecords :: [dns:rr()],
-                                         NSRecords :: [dns:rr()]) ->
-                                            dns:message().
+-spec(resolve_exact_type_match_delegated(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{},
+        AuthorityRecords :: [dns:rr()],
+        NSRecords:: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_type_match_delegated(Message, _Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _AuthorityRecords, NSRecords) ->
-    % We are authoritative and there are NS records here.
-    % NOTE: there are potential bugs here because it assumes the last record is the one to examine
-    Answer = lists:last(MatchedRecords),
-    NSRecord = lists:last(NSRecords),
-    Name = NSRecord#dns_rr.name,
-    case Name =:= Answer#dns_rr.name of
+  % We are authoritative and there are NS records here.
+  % NOTE: there are potential bugs here because it assumes the last record is the one to examine
+  Answer = lists:last(MatchedRecords),
+  NSRecord = lists:last(NSRecords),
+  Name = NSRecord#dns_rr.name,
+  case Name =:= Answer#dns_rr.name of
+    true ->
+      % NS name matches answer name, thus it's a recursion, so return the message
+      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NSRecords};
+    false ->
+      % NS name is different than the name in the matched records
+      case check_if_parent(Name, Answer#dns_rr.name) of
         true ->
-            % NS name matches answer name, thus it's a recursion, so return the message
-            Message#dns_message{aa = false,
-                                rc = ?DNS_RCODE_NOERROR,
-                                authority = Message#dns_message.authority ++ NSRecords};
+          % NS record name is a parent of the answer name
+          restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
         false ->
-            % NS name is different than the name in the matched records
-            case check_if_parent(Name, Answer#dns_rr.name) of
-                true ->
-                    % NS record name is a parent of the answer name
-                    restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
-                false ->
-                    % NS record name is not a parent of the answer name
-                    Message#dns_message{aa = true,
-                                        rc = ?DNS_RCODE_NOERROR,
-                                        answers = Message#dns_message.answers ++ MatchedRecords,
-                                        additional = Message#dns_message.additional}
-            end
-    end.
+          % NS record name is not a parent of the answer name
+          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords, additional = Message#dns_message.additional}
+      end
+  end.
 
--spec resolve_exact_match_referral(Message :: dns:message(),
-                                   Qtype :: dns:type(),
-                                   MatchedRecords :: [dns:rr()],
-                                   ReferralRecords :: [dns:rr()],
-                                   AuthorityRecords :: [dns:rr()]) ->
-                                      dns:message().
+
+-spec(resolve_exact_match_referral(
+        Message :: dns:message(),
+        Qtype :: dns:type(),
+        MatchedRecords :: [dns:rr()],
+        ReferralRecords :: [dns:rr()],
+        AuthorityRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_match_referral(Message, _Qtype, _MatchedRecords, ReferralRecords, []) ->
-    % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
-    % add the NS records to the authority section of the message.
-    Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
+  % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
+  % add the NS records to the authority section of the message.
+  Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_ANY, MatchedRecords, _ReferralRecords, _AuthorityRecords) ->
-    % Given an exact name match and the type of ANY, return all of the matched records.
-    Message#dns_message{aa = true, answers = MatchedRecords};
+  % Given an exact name match and the type of ANY, return all of the matched records.
+  Message#dns_message{aa = true, answers = MatchedRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_NS, _MatchedRecords, ReferralRecords, _AuthorityRecords) ->
-    % Given an exact name match and the type NS, where the NS records are not found in record set
-    % return the NS records in the answers section of the message.
-    Message#dns_message{aa = true, answers = ReferralRecords};
+  % Given an exact name match and the type NS, where the NS records are not found in record set
+  % return the NS records in the answers section of the message.
+  Message#dns_message{aa = true, answers = ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_SOA, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-    % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
-    % return the SOA records in the answers section of the message.
-    Message#dns_message{aa = true, answers = AuthorityRecords};
+  % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
+  % return the SOA records in the answers section of the message.
+  Message#dns_message{aa = true, answers = AuthorityRecords};
 resolve_exact_match_referral(Message, _, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-    % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
-    % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
-    Message#dns_message{aa = true,
-                        rc = ?DNS_RCODE_NOERROR,
-                        authority = AuthorityRecords}.
+  % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
+  % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
+  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, authority = AuthorityRecords}.
 
--spec resolve_exact_match_with_cname(Message :: dns:message(),
-                                     Qtype :: '?DNS_TYPE_CNAME',
-                                     Host :: dns:ip(),
-                                     CnameChain :: [dns:rr()],
-                                     MatchedRecords :: [dns:rr()],
-                                     Zone :: #zone{},
-                                     CnameRecords :: [dns:rr()]) ->
-                                        dns:message().
+
+
+-spec(resolve_exact_match_with_cname(
+        Message :: dns:message(),
+        Qtype :: ?DNS_TYPE_CNAME,
+        Host :: dns:ip(), 
+        CnameChain :: [dns:rr()],
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_match_with_cname(Message, ?DNS_TYPE_CNAME, _Host, _CnameChain, _MatchedRecords, _Zone, CnameRecords) ->
-    % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
-    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+  % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
+  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, _MatchedRecords, Zone, CnameRecords) ->
-    % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
-    case lists:member(lists:last(CnameRecords), CnameChain) of
-        true ->
-            % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
-            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-        false ->
-            % No CNAME loop, restart the query with the CNAME content.
-            CnameRecord = lists:last(CnameRecords),
-            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-            restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
-                          Name,
-                          Qtype,
-                          Host,
-                          CnameChain ++ CnameRecords,
-                          Zone,
-                          erldns_zone_cache:in_zone(Name))
-    end.
+  % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
+  case lists:member(lists:last(CnameRecords), CnameChain) of
+    true ->
+      % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+    false ->
+      % No CNAME loop, restart the query with the CNAME content.
+      CnameRecord = lists:last(CnameRecords),
+      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+      restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+  end.
 
--spec best_match_resolution(Message :: dns:message(),
-                            Qname :: dns:dname(),
-                            Qtype :: dns:type(),
-                            Host :: dns:ip(),
-                            CnameChain :: [dns:rr()],
-                            BestMatchRecords :: [dns:rr()],
-                            Zone :: #zone{}) ->
-                               dns:message().
+
+-spec(best_match_resolution(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{}) ->
+  dns:message()).
 best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-    % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
-    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords),
-    case ReferralRecords of
-        [] ->
-            % There were no NS records in the best matches.
-            resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
-        _ ->
-            % There were NS records in the best matches, so this is a referral.
-            resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
-    end.
+  % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
+  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords), 
+  case ReferralRecords of
+    [] ->
+      % There were no NS records in the best matches.
+      resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
+    _ ->
+      % There were NS records in the best matches, so this is a referral.
+      resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
+  end.
+
 
 %% @doc There is no referral, so check to see if there is a wildcard.
 %%
@@ -349,349 +335,351 @@ best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords,
 %%
 %% If there is no wildcard present and the qname does not match the origina question then return NOERROR
 %% and include root hints in the additional section if necessary.
--spec resolve_best_match(Message :: dns:message(),
-                         Qname :: dns:dname(),
-                         Qtype :: dns:type(),
-                         Host :: dns:ip(),
-                         CnameChain :: [dns:rr()],
-                         BestMatchRecords :: [dns:rr()],
-                         Zone :: #zone{}) ->
-                            dns:message().
+-spec(resolve_best_match(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{}) ->
+  dns:message()).
 resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-    case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
+  case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
+    true ->
+      % It's a wildcard match
+      CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
+      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
+    false ->
+      % It's not a wildcard
+      [Question|_] = Message#dns_message.questions,
+      case Qname =:= Question#dns_query.name of % TODO this logic can be moved up higher in processing potentially.
         true ->
-            % It's a wildcard match
-            CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
-            resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
+          % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
+          Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority, aa = true};
         false ->
-            % It's not a wildcard
-            [Question | _] = Message#dns_message.questions,
-            case Qname =:=
-                     Question#dns_query.name % TODO this logic can be moved up higher in processing potentially.
-            of
-                true ->
-                    % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
-                    Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN,
-                                        authority = Zone#zone.authority,
-                                        aa = true};
-                false ->
-                    % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
-                    % something other than CNAME. Note that the response is still NOERROR here.
-                    %
-                    % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
-                    optionally_add_root_hints(Message)
-            end
-    end.
+          % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
+          % something other than CNAME. Note that the response is still NOERROR here.
+          %
+          % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
+          optionally_add_root_hints(Message)
+      end
+  end.
 
--spec resolve_best_match_with_wildcard(Message :: dns:message(),
-                                       Qname :: dns:dname(),
-                                       Qtype :: dns:type(),
-                                       Host :: dns:ip(),
-                                       CnameChain :: [dns:rr()],
-                                       BestMatchRecords :: [dns:rr()],
-                                       Zone :: #zone{},
-                                       CnameRecords :: [dns:rr()]) ->
-                                          dns:message().
+
+-spec(resolve_best_match_with_wildcard(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_best_match_with_wildcard(Message, Qname, Qtype, _Host, _CnameChain, MatchedRecords, Zone, []) ->
-    % Handle best match resolving with a wildcard name in the zone.
-    TypeMatchedRecords =
-        case Qtype of
-            ?DNS_TYPE_ANY ->
-                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-            _ ->
-                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-        end,
-    TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
-    case TypeMatches of
+  % Handle best match resolving with a wildcard name in the zone.
+  TypeMatchedRecords = case Qtype of
+                         ?DNS_TYPE_ANY ->
+                           filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+                         _ ->
+                           lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+                       end,
+  TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
+  case TypeMatches of
+    [] ->
+      % There is no exact type matches for the original qtype, ask the custom handlers for their records.
+      Handlers = erldns_handler:get_versioned_handlers(),
+      HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
+      Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
+      NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
+      case NewRecords of
         [] ->
-            % There is no exact type matches for the original qtype, ask the custom handlers for their records.
-            Handlers = erldns_handler:get_versioned_handlers(),
-            HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
-            Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
-            NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
-            case NewRecords of
-                [] ->
-                    % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
-                    Message#dns_message{aa = true, authority = Zone#zone.authority};
-                NewRecords ->
-                    % Custom handlers returned answers
-                    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
-            end;
-        _ ->
-            % There is an exact type match
-            Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
-    end;
+          % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
+          Message#dns_message{aa = true, authority=Zone#zone.authority};
+        NewRecords ->
+          % Custom handlers returned answers
+          Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
+      end;
+    _ ->
+      % There is an exact type match
+      Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
+  end;
 resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords) ->
-    % It is a wildcard CNAME
-    resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
+  % It is a wildcard CNAME
+  resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
+
 
 % Handle the case where the wildcard is a CNAME in the zone. If the Qtype was CNAME then answer, otherwise determine if
 % the CNAME should be followed
--spec resolve_best_match_with_wildcard_cname(Message :: dns:message(),
-                                             Qname :: dns:dname(),
-                                             Qtype :: dns:type(),
-                                             Host :: dns:ip(),
-                                             CnameChain :: [dns:rr()],
-                                             BestMatchRecords :: [dns:rr()],
-                                             Zone :: #zone{},
-                                             CnameRecords :: [dns:rr()]) ->
-                                                dns:message().
+-spec(resolve_best_match_with_wildcard_cname(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_best_match_with_wildcard_cname(Message, _Qname, ?DNS_TYPE_CNAME, _Host, _CnameChain, _BestMatchRecords, _Zone, CnameRecords) ->
-    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_best_match_with_wildcard_cname(Message, _Qname, Qtype, Host, CnameChain, _BestMatchRecords, Zone, CnameRecords) ->
-    CnameRecord =
-        lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
-    case lists:member(CnameRecord, CnameChain) of
-        true ->
-            % Indicates CNAME loop
-            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-        false ->
-            % Follow the CNAME
-            CnameRecord = lists:last(CnameRecords),
-            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-            UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
-            restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
-    end.
+  CnameRecord = lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
+  case lists:member(CnameRecord, CnameChain) of
+    true ->
+      % Indicates CNAME loop
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+    false ->
+      % Follow the CNAME
+      CnameRecord = lists:last(CnameRecords),
+      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+      UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+      restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+  end.
+
 
 % There are referral records
--spec resolve_best_match_referral(Message :: dns:message(),
-                                  Qname :: dns:dname(),
-                                  Qtype :: dns:type(),
-                                  Host :: dns:ip(),
-                                  CnameChain :: [dns:rr()],
-                                  BestMatchRecords :: [dns:rr()],
-                                  Zone :: #zone{},
-                                  CnameRecords :: [dns:rr()]) ->
-                                     dns:message().
+-spec(resolve_best_match_referral(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_best_match_referral(Message, _Qname, Qtype, _Host, CnameChain, BestMatchRecords, _Zone, ReferralRecords) ->
-    Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
-    case {Qtype, Authority, CnameChain} of
-        {_, [], []} ->
-            % We are authoritative for the name since there was an SOA record in the best match results.
-            Message#dns_message{aa = true,
-                                rc = ?DNS_RCODE_NXDOMAIN,
-                                authority = Authority};
-        {_, _, []} ->
-            % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
-            % The name has thus been delegated to another authority.
-            Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
-        {?DNS_TYPE_ANY, _, _} ->
-            % We are authoritative and the Qtype is ANY, return the original message
-            Message;
-        _ ->
-            % We are authoritative and the Qtype is something other than ANY, set the authority in the response
-            Message#dns_message{authority = Authority}
-    end.
+  Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
+  case {Qtype, Authority, CnameChain} of
+    {_,[],[]} ->
+      % We are authoritative for the name since there was an SOA record in the best match results.
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Authority};
+    {_,_,[]} ->
+      % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
+      % The name has thus been delegated to another authority.
+      Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
+    {?DNS_TYPE_ANY,_,_} ->
+      % We are authoritative and the Qtype is ANY, return the original message
+      Message;
+    _ ->
+      % We are authoritative and the Qtype is something other than ANY, set the authority in the response
+      Message#dns_message{authority = Authority}
+  end.
+
 
 % The CNAME is in a zone. If it is the same zone, then continue the chain, otherwise return the message
--spec restart_query(Message :: dns:message(),
-                    Name :: dns:dname(),
-                    Qtype :: 0..255,
-                    Host :: any(),
-                    CnameChain :: any(),
-                    Zone :: #zone{},
-                    InZone :: boolean()) ->
-                       dns:message().
+-spec(restart_query(
+        Message :: dns:message(),
+        Name :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        Zone :: #zone{},
+        InZone :: boolean()) ->
+  dns:message()).
 restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
-    case check_if_parent(Zone#zone.name, Name) of
-        true ->
-            resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
-        false ->
-            Message
-    end;
+  case check_if_parent(Zone#zone.name, Name) of
+    true -> resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
+    false -> Message
+  end;
 % The CNAME is not in a zone, do not restart the query, return the answer.
 restart_query(Message, _Name, _Qtype, _Host, _CnameChain, _Zone, false) ->
-    Message.
+  Message.
 
--spec restart_delegated_query(Message :: dns:message(),
-                              Qname :: dns:dname(),
-                              Qtype :: dns:type(),
-                              Host :: dns:ip(),
-                              CnameChain :: [dns:rr()],
-                              Zone :: #zone{},
-                              InZone :: boolean()) ->
-                                 dns:message().
+
+-spec(restart_delegated_query(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: dns:ip(),
+        CnameChain :: [dns:rr()],
+        Zone :: #zone{},
+        InZone :: boolean()) ->
+  dns:message()).
 % Delegated, but in the same zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, true) ->
-    resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
+  resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
 % Delegated to a different zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, false) ->
-    resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
+  resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
+
 
 %% Utility functions
 
+
 %% @doc If root hints are enabled, return an updated message with the root hints.
--spec optionally_add_root_hints(dns:message()) -> dns:message().
+-spec(optionally_add_root_hints(dns:message()) -> dns:message()).
 optionally_add_root_hints(Message) ->
-    case erldns_config:use_root_hints() of
-        true ->
-            {Authority, Additional} = erldns_records:root_hints(),
-            Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
-        _ ->
-            Message
-    end.
+  case erldns_config:use_root_hints() of
+    true ->
+      {Authority, Additional} = erldns_records:root_hints(),
+      Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
+    _ ->
+      Message
+  end.
 
 %% Returns true if the first domain name is a parent of the second domain name.
 check_if_parent(PossibleParentName, Name) ->
-    case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
-        [] ->
-            true;
-        _ ->
-            false
-    end.
+  case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
+    [] -> true;
+    _ -> false
+  end.
+
 
 % Find the best match records for the given Qname in the given zone. This will attempt to walk through the
 % domain hierarchy in the Qname looking for both exact and wildcard matches.
 -spec best_match(dns:dname(), #zone{}) -> [dns:rr()].
-best_match(Qname, Zone) ->
-    best_match(Qname, Zone, dns:dname_to_labels(Qname)).
+best_match(Qname, Zone) -> best_match(Qname, Zone, dns:dname_to_labels(Qname)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()]) -> [dns:rr()].
-best_match(_Qname, _Zone, []) ->
-    [];
-best_match(Qname, Zone, [_ | Rest]) ->
-    WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
-    best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
+best_match(_Qname, _Zone, []) -> [];
+best_match(Qname, Zone, [_|Rest]) ->
+  WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
+  best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()], [dns:rr()]) -> [dns:rr()].
-best_match(_Qname, _Zone, [], []) ->
-    [];
+best_match(_Qname, _Zone, [], []) -> [];
 best_match(Qname, Zone, Labels, []) ->
-    Name = dns:labels_to_dname(Labels),
-    case erldns_zone_cache:get_records_by_name(Name) of
-        [] ->
-            best_match(Qname, Zone, Labels);
-        Matches ->
-            Matches
-    end;
-best_match(_Qname, _Zone, _Labels, WildcardMatches) ->
-    WildcardMatches.
+  Name = dns:labels_to_dname(Labels),
+  case erldns_zone_cache:get_records_by_name(Name) of
+    [] -> best_match(Qname, Zone, Labels);
+    Matches -> Matches
+  end;
+best_match(_Qname, _Zone, _Labels, WildcardMatches) -> WildcardMatches.
+
 
 %% Call all registered handlers.
 -spec call_handlers(dns:dname(), dns:type(), [dns:rr()], dns:message()) -> fun(({module(), [dns:type()], integer()}) -> [dns:rr()]).
 call_handlers(Qname, Qtype, Records, Message) ->
-    fun({Module, Types, Version}) ->
-       case Version of
-           1 ->
-               case lists:member(Qtype, Types) of
-                   true -> Module:handle(Qname, Qtype, Records);
-                   false ->
-                       case Qtype =:= ?DNS_TYPE_ANY of
-                           true -> Module:handle(Qname, Qtype, Records);
-                           false -> []
-                       end
-               end;
-           2 ->
-               case lists:member(Qtype, Types) of
-                   true -> Module:handle(Qname, Qtype, Records, Message);
-                   false ->
-                       case Qtype =:= ?DNS_TYPE_ANY of
-                           true -> Module:handle(Qname, Qtype, Records, Message);
-                           false -> []
-                       end
-               end
-       end
-    end.
+  fun({Module, Types, Version}) ->
+      case Version of
+        1 ->
+          case lists:member(Qtype, Types) of
+            true -> Module:handle(Qname, Qtype, Records);
+            false ->
+              case Qtype =:= ?DNS_TYPE_ANY of
+                true -> Module:handle(Qname, Qtype, Records);
+                false -> []
+              end
+          end;
+        2 ->
+          case lists:member(Qtype, Types) of
+            true -> Module:handle(Qname, Qtype, Records, Message);
+            false ->
+              case Qtype =:= ?DNS_TYPE_ANY of
+                true -> Module:handle(Qname, Qtype, Records, Message);
+                false -> []
+              end
+          end
+      end
+  end.
+
 
 % Filter records through registered handlers.
-filter_records(Records, []) ->
-    Records;
-filter_records(Records, [{Handler, _Types, Version} | Rest]) ->
-    case Version of
-        1 ->
-            filter_records(Handler:filter(Records), Rest);
-        2 ->
-            filter_records(Handler:filter(Records), Rest);
-        _ ->
-            []
-    end.
+filter_records(Records, []) -> Records;
+filter_records(Records, [{Handler, _Types, Version}|Rest]) ->
+  case Version of
+    1 -> filter_records(Handler:filter(Records), Rest);
+    2 -> filter_records(Handler:filter(Records), Rest);
+    _ -> []
+  end.
+
 
 %% See if additional processing is necessary.
 additional_processing(Message, Host, Zone) ->
-    RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
-    additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
-
+  RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
+  additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
 %% No records require additional processing.
 additional_processing(Message, _Host, _Zone, []) ->
-    Message;
+  Message;
 %% There are records with names that require additional processing.
 additional_processing(Message, Host, Zone, Names) ->
-    RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
-    Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
-    additional_processing(Message, Host, Zone, Names, Records).
+  RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
+  Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
+  additional_processing(Message, Host, Zone, Names, Records).
 
 %% No additional A records were found, so just return the message.
 additional_processing(Message, _Host, _Zone, _Names, []) ->
-    Message;
+  Message;
 %% Additional A records were found, so we add them to the additional section.
 additional_processing(Message, _Host, _Zone, _Names, Records) ->
-    Message#dns_message{additional = Message#dns_message.additional ++ Records}.
+  Message#dns_message{additional = Message#dns_message.additional ++ Records}.
+
+
 
 %% Given a list of answers find the names that require additional processing.
--spec requires_additional_processing(Records :: [dns:rr()], RecordsRequiringAdditionalProcessing :: [dns:rr()]) -> [dns:rr()].
-requires_additional_processing([], RequiresAdditional) ->
-    RequiresAdditional;
-requires_additional_processing([Answer | Rest], RequiresAdditional) ->
-    Names =
-        case Answer#dns_rr.data of
-            Data when is_record(Data, dns_rrdata_ns) ->
-                [Data#dns_rrdata_ns.dname];
-            Data when is_record(Data, dns_rrdata_mx) ->
-                [Data#dns_rrdata_mx.exchange];
-            _ ->
-                []
-        end,
-    requires_additional_processing(Rest, RequiresAdditional ++ Names).
+-spec(requires_additional_processing(
+        Records :: [dns:rr()],
+        RecordsRequiringAdditionalProcessing :: [dns:rr()]) ->
+  [dns:rr()]).
+requires_additional_processing([], RequiresAdditional) -> RequiresAdditional;
+requires_additional_processing([Answer|Rest], RequiresAdditional) ->
+  Names = case Answer#dns_rr.data of
+            Data when is_record(Data, dns_rrdata_ns) -> [Data#dns_rrdata_ns.dname];
+            Data when is_record(Data, dns_rrdata_mx) -> [Data#dns_rrdata_mx.exchange];
+            _ -> []
+          end,
+  requires_additional_processing(Rest, RequiresAdditional ++ Names).
+
 
 %% @doc Return true if DNSSEC is requested and enabled.
--spec check_dnssec(Message :: dns:message(), Host :: dns:ip(), Question :: dns:query()) -> boolean().
+-spec(check_dnssec(
+        Message :: dns:message(),
+        Host :: dns:ip(),
+        Question :: dns:query()) ->
+  boolean()).
 check_dnssec(Message, Host, Question) ->
-    case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
-        true ->
-            erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
-            true;
-        false ->
-            false
-    end.
+  case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
+    true ->
+      erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
+      true;
+    false ->
+      false
+  end.
+
 
 %% @doc Sort the answers in the given message.
 -spec sort_answers(dns:message()) -> dns:message().
 sort_answers(Message) ->
-    Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
+  Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
 
 -spec sort_fun(dns:rr(), dns:rr()) -> boolean().
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}, #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
-    true;
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name}, #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}) ->
-    false;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}},
+         #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
+  true;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name},
+         #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}}) ->
+  false;
 sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME}, #dns_rr{}) ->
-    true;
+  true;
 sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
-    false;
+  false;
 sort_fun(A, B) ->
-    A =< B.
+  A =< B.
 
 % Extract the name from the first record in the list.
 zone_authority_name([Record | _]) ->
-    Record#dns_rr.name.
+  Record#dns_rr.name.
 
 % Find NS records that represent a zone cut.
 detect_zonecut(Zone, Qname) when is_binary(Qname) ->
-    detect_zonecut(Zone, dns:dname_to_labels(Qname));
+  detect_zonecut(Zone, dns:dname_to_labels(Qname));
 detect_zonecut(_Zone, []) ->
-    [];
+  [];
 detect_zonecut(_Zone, [_Label]) ->
-    [];
+  [];
 detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
-    Qname = dns:labels_to_dname(Labels),
-    case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
-        true ->
-            [];
-        false ->
-            case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
-                [] ->
-                    detect_zonecut(Zone, ParentLabels);
-                ZonecutNSRecords ->
-                    ZonecutNSRecords
-            end
-    end.
+  Qname = dns:labels_to_dname(Labels),
+  case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
+    true ->
+      [];
+    false ->
+      case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
+        [] ->
+          detect_zonecut(Zone, ParentLabels);
+        ZonecutNSRecords ->
+          ZonecutNSRecords
+      end
+  end.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -172,24 +172,18 @@ resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zon
 resolve_exact_match(Message, _Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _ExactTypeMatches = [], AuthorityRecords) ->
   ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords), % Query matched records for NS type
   resolve_no_exact_type_match(Message, Qtype, Host, CnameChain, [], Zone, MatchedRecords, ReferralRecords, AuthorityRecords);
-
 %% There were exact matches of name and type.
 resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, _MatchedRecords, Zone, ExactTypeMatches, AuthorityRecords) ->
   resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords).
-
-
-
 %% There was an exact type match for an NS query, however there is no SOA record for the zone.
 resolve_exact_type_match(Message, _Qname, ?DNS_TYPE_NS, Host, CnameChain, MatchedRecords, Zone, []) ->
   Answer = lists:last(MatchedRecords),
   Name = Answer#dns_rr.name,
   % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
   restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
-
 %% There was an exact type match for an NS query and an SOA record.
 resolve_exact_type_match(Message, _Qname, ?DNS_TYPE_NS, _Host, _CnameChain, MatchedRecords, _Zone, _AuthorityRecords) ->
   Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
-
 %% There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
 resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _AuthorityRecords) ->
   % NOTE: this is a potential bug because it assumes the last record is the one to examine.
@@ -213,9 +207,19 @@ resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords
   end.
 
 %% We are authoritative and there were no NS records here.
+-spec(resolve_exact_type_match(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{},
+        AuthorityRecords :: dns:authority(),
+        NSRecords:: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_type_match(Message, _Qname, _Qtype, _Host, _CnameChain, MatchedRecords, _Zone, _AuthorityRecords, _NSRecords = []) ->
   Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords, additional = Message#dns_message.additional};
-
 %% We are authoritative and there are NS records here.
 resolve_exact_type_match(Message, _Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _AuthorityRecords, NSRecords) ->
   % NOTE: there are potential bugs here because it assumes the last record is the one to examine
@@ -246,7 +250,16 @@ check_if_parent(PossibleParentName, Name) ->
 
 %% There were no exact type matches, but there were other name matches and there are NS records.
 %% Since the Qtype is ANY we indicate we are authoritative and include the NS records.
--spec(resolve_no_exact_type_match(Message :: dns:message(), Qtype :: 0..255, Host :: any(), CnameChain :: any(), ExactTypeMatches :: dns:answers(), Zone :: #zone{}, MatchedRecords :: [dns:rr()], ReferralRecords :: [dns:rr()], AuthorityRecords :: dns:authority()) ->
+-spec(resolve_no_exact_type_match(
+        Message :: dns:message(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        ExactTypeMatches :: dns:answers(),
+        Zone :: #zone{},
+        MatchedRecords :: [dns:rr()],
+        ReferralRecords :: [dns:rr()],
+        AuthorityRecords :: dns:authority()) ->
   dns:message()).
 resolve_no_exact_type_match(Message, _Qtype, _Host, _CnameChain, [], Zone, _MatchedRecords, [], _AuthorityRecords) ->
   Message#dns_message{aa = true, authority = Zone#zone.authority};
@@ -257,9 +270,15 @@ resolve_no_exact_type_match(Message, Qtype, _Host, _CnameChain, _ExactTypeMatche
 
 % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
 % add the NS records to the authority section of the message.
+-spec(resolve_exact_match_referral(
+        Message :: dns:message(),
+        Qtype :: 0..255,
+        MatchedRecords :: [dns:rr()],
+        ReferralRecords :: [dns:rr()],
+        AuthorityRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_match_referral(Message, _Qtype, _MatchedRecords, ReferralRecords, []) ->
   Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
-
 % Given an exact name match and the type of ANY, return all of the matched records.
 resolve_exact_match_referral(Message, ?DNS_TYPE_ANY, MatchedRecords, _ReferralRecords, _AuthorityRecords) ->
   Message#dns_message{aa = true, answers = MatchedRecords};
@@ -281,24 +300,42 @@ resolve_exact_match_referral(Message, _, _MatchedRecords, _ReferralRecords, Auth
 
 % There is a CNAME record and the request was for a CNAME record so append the CNAME records to
 % the answers section.
+-spec(resolve_exact_match_with_cname(
+        Message :: dns:message(),
+        Qtype :: ?DNS_TYPE_CNAME,
+        Host :: any(),
+        CnameChain :: any(),
+        MatchedRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_exact_match_with_cname(Message, ?DNS_TYPE_CNAME, _Host, _CnameChain, _MatchedRecords, _Zone, CnameRecords) ->
   Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
-resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords) ->
-  resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords, lists:member(lists:last(CnameRecords), CnameChain)).
-
-%% Indicates a CNAME loop. The response code is a SERVFAIL in this case.
-resolve_exact_match_with_cname(Message, _Qtype, _Host, _CnameChain, _MatchedRecords, _Zone, _CnameRecords, true) ->
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-% No CNAME loop, restart the query with the CNAME content.
-resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, _MatchedRecords, Zone, CnameRecords, false) ->
-  CnameRecord = lists:last(CnameRecords),
-  Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-  restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name)).
+resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, _MatchedRecords, Zone, CnameRecords) ->
+  case lists:member(lists:last(CnameRecords), CnameChain) of
+    true ->
+      %% Indicates a CNAME loop. The response code is a SERVFAIL in this case.
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+    % No CNAME loop, restart the query with the CNAME content.
+    false ->
+      CnameRecord = lists:last(CnameRecords),
+      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+      restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+  end.
 
 
 
 % The CNAME is in a zone. If it is the same zone, then continue the chain, otherwise return the message
+-spec(restart_query(
+        Message :: dns:message(),
+        Name :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        Zone :: #zone{},
+        InZone :: boolean()) ->
+  dns:message()).
 restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
   Parent = check_if_parent(Zone#zone.name, Name),
   case Parent of
@@ -311,60 +348,103 @@ restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
 restart_query(Message, _Name, _Qtype, _Host, _CnameChain, _Zone, false) ->
   Message.
 
+
+-spec(restart_delegated_query(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        Zone :: #zone{},
+        InZone :: boolean()) ->
+  dns:message()).
 % Delegated, but in the same zone.
-restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
-  resolve(Message, Name, Qtype, Zone, Host, CnameChain);
+restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, true) ->
+  resolve(Message, Qname, Qtype, Zone, Host, CnameChain);
 % Delegated to a different zone.
-restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, false) ->
-  resolve(Message, Name, Qtype, erldns_zone_cache:find_zone(Name, Zone#zone.authority), Host, CnameChain). % Zone lookup
+restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, false) ->
+  resolve(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
 
 
-
-% There was no exact match for the Qname, so we use the best matches that were
-% returned by the best_match() function.
+% There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
+-spec(best_match_resolution(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{}) ->
+  dns:message()).
 best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
   ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords), % NS lookup
-  best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords).
-
-% There were no NS records in the best matches.
-best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, []) ->
-  resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
-% There were NS records in the best matches, so this is a referral.
-best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords) ->
-  resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords).
+  case ReferralRecords of
+    [] ->
+      % There were no NS records in the best matches.
+      resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
+    _ ->
+      % There were NS records in the best matches, so this is a referral.
+      resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
+  end.
 
 
 % There is no referral, so check to see if there is a wildcard.
+%
+% If there is a wildcard present, then the resolver needs to continue to handle various possible types.
+%
+% If there is no wildcard present and the qname matches the original question then return NXDOMAIN.
+%
+% If there is no wildcard present and the qname does not match the origina question then return NOERROR
+% and include root hints in the additional section if necessary.
+-spec(resolve_best_match(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: 0..255,
+        Host :: any(),
+        CnameChain :: any(),
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{}) ->
+  dns:message()).
 resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-  resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, lists:any(erldns_records:match_wildcard(), BestMatchRecords)).
-
-%% It's a wildcard match
-resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, true) ->
-  CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
-  resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
-%% It is not a wildcard.
-resolve_best_match(Message, Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, Zone, false) ->
-  [Question|_] = Message#dns_message.questions,
-  case Qname =:= Question#dns_query.name of
+  case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
     true ->
-      Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority, aa = true};
+      % It's a wildcard match
+      CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
+      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
     false ->
-      % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
-      % something other than CNAME. Note that the response is still NOERROR here.
-      %
-      % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
-      case erldns_config:use_root_hints() of
+      % It's not a wildcard
+      [Question|_] = Message#dns_message.questions,
+      case Qname =:= Question#dns_query.name of % TODO this logic can be moved up higher in processing potentially.
         true ->
-          {Authority, Additional} = erldns_records:root_hints(),
-          Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
-        _ ->
-          Message
+          Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority, aa = true};
+        false ->
+          % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
+          % something other than CNAME. Note that the response is still NOERROR here.
+          %
+          % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
+          case erldns_config:use_root_hints() of
+            true ->
+              {Authority, Additional} = erldns_records:root_hints(),
+              Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
+            _ ->
+              Message
+          end
       end
   end.
 
 
-% It's a wildcard CNAME
-resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, []) ->
+% Handle best match resolving with a wildcard name in the zone.
+-spec(resolve_best_match_with_wildcard(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: any(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
+resolve_best_match_with_wildcard(Message, Qname, Qtype, _Host, _CnameChain, MatchedRecords, Zone, []) ->
   TypeMatchedRecords = case Qtype of
                          ?DNS_TYPE_ANY ->
                            filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
@@ -374,75 +454,86 @@ resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, Matche
   TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
   case TypeMatches of
     [] ->
-      %% Ask the custom handlers for their records.
+      % There is no exact type matches for the original qtype
+      % Ask the custom handlers for their records.
       CustomHandlers = erldns_handler:get_versioned_handlers(),
-      Records = lists:map(erldns_records:replace_name(Qname), lists:flatten(lists:map(custom_lookup(Qname, Qtype, MatchedRecords, Message), CustomHandlers))),
+      CustomHandlerRecords = lists:flatten(lists:map(custom_lookup(Qname, Qtype, MatchedRecords, Message), CustomHandlers)),
+      Records = lists:map(erldns_records:replace_name(Qname), CustomHandlerRecords),
       NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
-      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, [], NewRecords);
+      case NewRecords of
+        [] ->
+          % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
+          Message#dns_message{aa = true, authority=Zone#zone.authority};
+        NewRecords ->
+          % Custom handlers returned answers
+          Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
+      end;
     _ ->
-      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, [], TypeMatches)
+      % There is an exact type match
+      Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
   end;
-
 % It is a wildcard CNAME
 resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords) ->
   resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
 
-% It is not a CNAME and there were no exact type matches
-resolve_best_match_with_wildcard(Message, _Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, Zone, [], []) ->
-  Message#dns_message{aa = true, authority=Zone#zone.authority};
 
-% It is not a CNAME and there were exact type matches
-resolve_best_match_with_wildcard(Message, _Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, _Zone, [], TypeMatches) ->
-  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}.
-
-
-
-
-% It is a CNAME and the Qtype was CNAME
+% Handle the case where the wildcard is a CNAME in the zone. If the Qtype was CNAME then answer, otherwise determine if
+% the CNAME should be followed
+-spec(resolve_best_match_with_wildcard_cname(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: any(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
 resolve_best_match_with_wildcard_cname(Message, _Qname, ?DNS_TYPE_CNAME, _Host, _CnameChain, _BestMatchRecords, _Zone, CnameRecords) ->
   Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
-
-% It is a CNAME and the Qtype was not CNAME
-resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords) ->
+resolve_best_match_with_wildcard_cname(Message, _Qname, Qtype, Host, CnameChain, _BestMatchRecords, Zone, CnameRecords) ->
   CnameRecord = lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
-  resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords, lists:member(CnameRecord, CnameChain)).
-
-% Indicates CNAME loop
-resolve_best_match_with_wildcard_cname(Message, _Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, _Zone, _CnameRecords, true) ->
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-
-% We should follow the CNAME
-resolve_best_match_with_wildcard_cname(Message, _Qname, Qtype, Host, CnameChain, _BestMatchRecords, Zone, CnameRecords, false) ->
-  CnameRecord = lists:last(CnameRecords),
-  Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-  restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name)).
-
-
+  case lists:member(CnameRecord, CnameChain) of
+    true ->
+      % Indicates CNAME loop
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+    false ->
+      % Follow the CNAME
+      CnameRecord = lists:last(CnameRecords),
+      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+      UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+      restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+  end.
 
 
 % There are referral records
-resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords) ->
-  resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords, lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords)). % Lookup SOA in best match records
-
-% Indicate that we are not authoritative for the name as there were no
-% SOA records in the best-match results. The name has thus been delegated
-% to another authority.
-resolve_best_match_referral(Message, _Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, _Zone, ReferralRecords, []) ->
-  Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
-
-% We are authoritative for the name since there was an SOA record in
-% the best match results.
-resolve_best_match_referral(Message, _Qname, _Qtype, _Host, [], _BestMatchRecords, _Zone, _ReferralRecords, Authority) ->
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Authority};
-
-% We are authoritative and the Qtype is ANY so we just return the 
-% original message.
-resolve_best_match_referral(Message, _Qname, ?DNS_TYPE_ANY, _Host, _CnameChain, _BestMatchRecords, _Zone, _ReferralRecords, _Authority) ->
-  Message;
-resolve_best_match_referral(Message, _Qname, _Qtype, _Host, _CnameChain, _BestMatchRecords, _Zone, _ReferralRecords, Authority) ->
-  Message#dns_message{authority = Authority}.
-
-
+-spec(resolve_best_match_referral(
+        Message :: dns:message(),
+        Qname :: dns:dname(),
+        Qtype :: dns:type(),
+        Host :: any(),
+        CnameChain :: [dns:rr()],
+        BestMatchRecords :: [dns:rr()],
+        Zone :: #zone{},
+        CnameRecords :: [dns:rr()]) ->
+  dns:message()).
+resolve_best_match_referral(Message, _Qname, Qtype, _Host, CnameChain, BestMatchRecords, _Zone, ReferralRecords) ->
+  Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
+  case {Qtype, Authority, CnameChain} of
+    {_,[],[]} ->
+      % We are authoritative for the name since there was an SOA record in the best match results.
+      Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Authority};
+    {_,_,[]} ->
+      % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
+      % The name has thus been delegated to another authority.
+      Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
+    {?DNS_TYPE_ANY,_,_} ->
+      % We are authoritative and the Qtype is ANY so we just return the original message
+      Message;
+    _ ->
+      % We are authoritative and the Qtype is something other than ANY, set the authority in the response
+      Message#dns_message{authority = Authority}
+  end.
 
 
 % Find the best match records for the given Qname in the
@@ -550,13 +641,10 @@ zone_authority_name([Record | _]) ->
 
 detect_zonecut(Zone, Qname) when is_binary(Qname) ->
   detect_zonecut(Zone, dns:dname_to_labels(Qname));
-
 detect_zonecut(_Zone, []) ->
   [];
-
 detect_zonecut(_Zone, [_Label]) ->
   [];
-
 detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
   Qname = dns:labels_to_dname(Labels),
   case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -21,58 +21,66 @@
 -export([resolve/3]).
 
 
-%% @doc Resolve the questions in the message.
--spec resolve(
-        Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
+%% @doc Resolve the first question in the message. If no message is present, return the original
+%% message. If multiple questions are present, only resolve the first question.
+-spec(resolve(
+        Message :: dns:message(),
+        AuthorityRecords :: [dns:rr()],
+        Host :: dns:ip()) ->
+  dns:message()).
 resolve(Message, AuthorityRecords, Host) ->
-  resolve(Message, AuthorityRecords, Host, Message#dns_message.questions).
+  case Message#dns_message.questions of
+    [] -> Message;
+    [Question] -> resolve_question(Message, AuthorityRecords, Host, Question);
+    [Question|_] -> resolve_question(Message, AuthorityRecords, Host, Question)
+  end.
 
-%% There were no questions in the message so just return it.
--spec resolve(dns:message(), [dns:rr()], dns:ip(), dns:questions() | dns:query()) -> dns:message().
-resolve(Message, _AuthorityRecords, _Host, []) -> Message;
-%% There is one question in the message; resolve it.
-resolve(Message, AuthorityRecords, Host, [Question]) -> resolve(Message, AuthorityRecords, Host, Question);
-%% Resolve the first question. Additional questions will be thrown away for now.
-resolve(Message, AuthorityRecords, Host, [Question|_]) -> resolve(Message, AuthorityRecords, Host, Question);
-%% Start the resolution process on the given question.
+
+%% @doc Start the resolution process on the given question.
 %% Step 1: Set the RA bit to false as we do not handle recursive queries.
 %%
 %% Refuse all RRSIG requests.
-resolve(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
+-spec(resolve_question(
+        Message :: dns:message(),
+        AuthorityRecords :: [dns:rr()],
+        Host :: dns:ip(),
+        Questions :: dns:questions() | dns:query()) ->
+  dns:message()).
+resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
   case Question#dns_query.type of
     ?DNS_TYPE_RRSIG ->
       Message#dns_message{ra = false, ad = false, cd = false, rc = ?DNS_RCODE_REFUSED};
     Qtype ->
       check_dnssec(Message, Host, Question),
-      resolve(Message#dns_message{ra = false, ad = false, cd = false}, AuthorityRecords, Question#dns_query.name, Qtype, Host)
+      resolve_qname_and_qtype(Message#dns_message{ra = false, ad = false, cd = false}, AuthorityRecords, Question#dns_query.name, Qtype, Host)
   end.
 
-%% With the extracted Qname and Qtype in hand, find the nearest zone
+%% @doc With the extracted Qname and Qtype in hand, find the nearest zone
 %% Step 2: Search the available zones for the zone which is the nearest ancestor to QNAME
 %%
-%% If the request required DNSSEC, apply the DNSSEC records
--spec resolve(dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
-resolve(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  Zone = erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)), 
-  Records = resolve(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
-  sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(Records), Host, Zone), Zone, Qname, Qtype)).
+%% If the request required DNSSEC, apply the DNSSEC records. Sort answers prior to returning.
+-spec resolve_qname_and_qtype(dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
+resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
+  case erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) of
+    {error, not_authoritative} ->
+      %% No SOA was found for the Qname so we return the root hints
+      %% Note: it seems odd that we are indicating we are authoritative here.
+      case erldns_config:use_root_hints() of
+        true ->
+          {Authority, Additional} = erldns_records:root_hints(),
+          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, authority = Authority, additional = Message#dns_message.additional ++ Additional};
+        _ ->
+          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR}
+      end;
+    Zone ->
+      Records = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
+      sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(Records), Host, Zone), Zone, Qname, Qtype))
+  end.
 
-
-
-%% No SOA was found for the Qname so we return the root hints
-%% Note: it seems odd that we are indicating we are authoritative here.
-resolve(Message, _Qname, _Qtype, {error, not_authoritative}, _Host, _CnameChain) ->
-  case erldns_config:use_root_hints() of
-    true ->
-      {Authority, Additional} = erldns_records:root_hints(),
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, authority = Authority, additional = Message#dns_message.additional ++ Additional};
-    _ ->
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR}
-  end;
 
 %% An SOA was found, thus we are authoritative and have the zone.
 %% Step 3: Match records
-resolve(Message, Qname, Qtype, Zone, Host, CnameChain) ->
+resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain) ->
   Result = case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
              {false, []} ->
                lager:debug("Record name is not in zone (zone: ~p, qname: ~p)", [Zone#zone.name, Qname]),
@@ -325,7 +333,7 @@ restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
   Parent = check_if_parent(Zone#zone.name, Name),
   case Parent of
     true ->
-      resolve(Message, Name, Qtype, Zone, Host, CnameChain);
+      resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
     false ->
       Message
   end;
@@ -345,10 +353,10 @@ restart_query(Message, _Name, _Qtype, _Host, _CnameChain, _Zone, false) ->
   dns:message()).
 % Delegated, but in the same zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, true) ->
-  resolve(Message, Qname, Qtype, Zone, Host, CnameChain);
+  resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
 % Delegated to a different zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, false) ->
-  resolve(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
+  resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
 
 
 % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
@@ -521,6 +529,9 @@ resolve_best_match_referral(Message, _Qname, Qtype, _Host, CnameChain, BestMatch
   end.
 
 
+%% Utility functions
+
+
 % Find the best match records for the given Qname in the
 % given zone. This will attempt to walk through the
 % domain hierarchy in the Qname looking for both exact and
@@ -579,8 +590,6 @@ filter_records(Records, [{Handler, _Types, Version}|Rest]) ->
   end.
 
 %% See if additional processing is necessary.
-additional_processing(Message, _Host, {error, _}) ->
-  Message;
 additional_processing(Message, Host, Zone) ->
   RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
   additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
@@ -621,6 +630,7 @@ check_dnssec(Message, Host, Question) ->
       ok
   end.
 
+%% @doc Sort the answers in the given message.
 -spec sort_answers(dns:message()) -> dns:message().
 sort_answers(Message) ->
   Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
@@ -639,9 +649,11 @@ sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
 sort_fun(A, B) ->
   A =< B.
 
+% Extract the name from the first record in the list.
 zone_authority_name([Record | _]) ->
   Record#dns_rr.name.
 
+% Find NS records that represent a zone cut.
 detect_zonecut(Zone, Qname) when is_binary(Qname) ->
   detect_zonecut(Zone, dns:dname_to_labels(Qname));
 detect_zonecut(_Zone, []) ->

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -79,6 +79,7 @@ resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
 
 
 %% An SOA was found, thus we are authoritative and have the zone.
+%%
 %% Step 3: Match records
 -spec(resolve_authoritative(
         Message :: dns:message(),
@@ -91,6 +92,7 @@ resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
 resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain) ->
   Result = case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
              {false, []} ->
+               % No host name with the given record in the zone, return NXDOMAIN and include authority
                Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority};
              _ ->
                case erldns_zone_cache:get_records_by_name(Qname) of

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -16,316 +16,330 @@
 -module(erldns_resolver).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([resolve/3]).
 
-
 %% @doc Resolve the first question in the message. If no message is present, return the original
 %% message. If multiple questions are present, only resolve the first question.
--spec(resolve(
-        Message :: dns:message(),
-        AuthorityRecords :: [dns:rr()],
-        Host :: dns:ip()) ->
-  dns:message()).
+-spec resolve(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Host) ->
-  case Message#dns_message.questions of
-    [] -> Message;
-    [Question] -> resolve_question(Message, AuthorityRecords, Host, Question);
-    [Question|_] -> resolve_question(Message, AuthorityRecords, Host, Question)
-  end.
-
+    case Message#dns_message.questions of
+        [] ->
+            Message;
+        [Question] ->
+            resolve_question(Message, AuthorityRecords, Host, Question);
+        [Question | _] ->
+            resolve_question(Message, AuthorityRecords, Host, Question)
+    end.
 
 %% @doc Start the resolution process on the given question.
 %% Step 1: Set the RA bit to false as we do not handle recursive queries.
 %%
 %% Refuse all RRSIG requests.
--spec(resolve_question(
-        Message :: dns:message(),
-        AuthorityRecords :: [dns:rr()],
-        Host :: dns:ip(),
-        Questions :: dns:questions() | dns:query()) ->
-  dns:message()).
+-spec resolve_question(Message :: dns:message(), AuthorityRecords :: [dns:rr()], Host :: dns:ip(), Questions :: dns:questions() | dns:query()) ->
+                          dns:message().
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
-  case Question#dns_query.type of
-    ?DNS_TYPE_RRSIG ->
-      Message#dns_message{ra = false, ad = false, cd = false, rc = ?DNS_RCODE_REFUSED};
-    Qtype ->
-      check_dnssec(Message, Host, Question),
-      resolve_qname_and_qtype(Message#dns_message{ra = false, ad = false, cd = false}, AuthorityRecords, Question#dns_query.name, Qtype, Host)
-  end.
+    case Question#dns_query.type of
+        ?DNS_TYPE_RRSIG ->
+            Message#dns_message{ra = false,
+                                ad = false,
+                                cd = false,
+                                rc = ?DNS_RCODE_REFUSED};
+        Qtype ->
+            check_dnssec(Message, Host, Question),
+            resolve_qname_and_qtype(Message#dns_message{ra = false,
+                                                        ad = false,
+                                                        cd = false},
+                                    AuthorityRecords,
+                                    Question#dns_query.name,
+                                    Qtype,
+                                    Host)
+    end.
 
 %% @doc With the extracted Qname and Qtype in hand, find the nearest zone
 %% Step 2: Search the available zones for the zone which is the nearest ancestor to QNAME
 %%
 %% If the request required DNSSEC, apply the DNSSEC records. Sort answers prior to returning.
--spec resolve_qname_and_qtype(
-        Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
+-spec resolve_qname_and_qtype(Message :: dns:message(), [dns:rr()], dns:dname(), dns:type(), dns:ip()) -> dns:message().
 resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
-  case erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) of
-    {error, not_authoritative} ->
-      % No SOA was found for the Qname so we return the root hints
-      % Note: it seems odd that we are indicating we are authoritative here.
-      optionally_add_root_hints(Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR});
-    Zone ->
-      ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
-      sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
-  end.
+    case erldns_zone_cache:find_zone(Qname, lists:last(AuthorityRecords)) of
+        {error, not_authoritative} ->
+            % No SOA was found for the Qname so we return the root hints
+            % Note: it seems odd that we are indicating we are authoritative here.
+            optionally_add_root_hints(Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR});
+        Zone ->
+            ResolvedMessage = resolve_authoritative(Message, Qname, Qtype, Zone, Host, _CnameChain = []),
+            sort_answers(erldns_dnssec:handle(additional_processing(erldns_records:rewrite_soa_ttl(ResolvedMessage), Host, Zone), Zone, Qname, Qtype))
+    end.
 
 %% An SOA was found, thus we are authoritative and have the zone.
 %%
 %% Step 3: Match records
--spec(resolve_authoritative(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Zone :: #zone{},
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_authoritative(Message :: dns:message(),
+                            Qname :: dns:dname(),
+                            Qtype :: dns:type(),
+                            Zone :: #zone{},
+                            Host :: dns:ip(),
+                            CnameChain :: [dns:rr()]) ->
+                               dns:message().
 resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain) ->
-  Result = case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
-             {false, []} ->
-               % No host name with the given record in the zone, return NXDOMAIN and include authority
-               Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority};
-             _ ->
-               case erldns_zone_cache:get_records_by_name(Qname) of
-                 [] ->
-                   % No exact match of name and type, move to best match resolution
-                   best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
-                 Records ->
-                   % Exact match of name and type
-                   exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
-               end
-           end,
-
-  case detect_zonecut(Zone, Qname) of
-    [] ->
-      Result;
-    ZonecutRecords ->
-      CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
-      FilteredCnameAnswers = lists:filter(fun(RR) ->
-                                              case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
-                                                [] -> false;
-                                                _ -> true
-                                              end
-                                          end, CnameAnswers),
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = ZonecutRecords, answers = FilteredCnameAnswers}
-  end.
-
+    Result =
+        case {erldns_zone_cache:record_name_in_zone(Zone#zone.name, Qname), CnameChain} of
+            {false, []} ->
+                % No host name with the given record in the zone, return NXDOMAIN and include authority
+                Message#dns_message{aa = true,
+                                    rc = ?DNS_RCODE_NXDOMAIN,
+                                    authority = Zone#zone.authority};
+            _ ->
+                case erldns_zone_cache:get_records_by_name(Qname) of
+                    [] ->
+                        % No exact match of name and type, move to best match resolution
+                        best_match_resolution(Message, Qname, Qtype, Host, CnameChain, best_match(Qname, Zone), Zone);
+                    Records ->
+                        % Exact match of name and type
+                        exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, Records, Zone)
+                end
+        end,
+    case detect_zonecut(Zone, Qname) of
+        [] ->
+            Result;
+        ZonecutRecords ->
+            CnameAnswers = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), Result#dns_message.answers),
+            FilteredCnameAnswers =
+                lists:filter(fun(RR) ->
+                                case detect_zonecut(Zone, RR#dns_rr.data#dns_rrdata_cname.dname) of
+                                    [] -> false;
+                                    _ -> true
+                                end
+                             end,
+                             CnameAnswers),
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_NOERROR,
+                                authority = ZonecutRecords,
+                                answers = FilteredCnameAnswers}
+    end.
 
 %% Determine if there is a CNAME anywhere in the records with the given Qname.
 exact_match_resolution(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-  case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
-    [] ->
-      % No CNAME records found in the record set for the Qname
-      resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
-    CnameRecords ->
-      % CNAME records found in the record set for the Qname
-      resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
-  end.
-
+    case lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), MatchedRecords) of
+        [] ->
+            % No CNAME records found in the record set for the Qname
+            resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone);
+        CnameRecords ->
+            % CNAME records found in the record set for the Qname
+            resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, MatchedRecords, Zone, CnameRecords)
+    end.
 
 %% There were no CNAMEs found in the exact name matches, so now we grab the authority
 %% records and find any type matches on QTYPE and continue on.
 %%
 %% This function will search both MatchedRecords and custom handlers.
--spec(resolve_exact_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec resolve_exact_match(Message :: dns:message(),
+                          Qname :: dns:dname(),
+                          Qtype :: dns:type(),
+                          Host :: dns:ip(),
+                          CnameChain :: [dns:rr()],
+                          MatchedRecords :: [dns:rr()],
+                          Zone :: #zone{}) ->
+                             dns:message().
 resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone) ->
-  TypeMatches = case Qtype of
-                  ?DNS_TYPE_ANY ->
-                    filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-                  _ ->
-                    lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-                end,
-  ExactTypeMatches = case TypeMatches of
-              [] ->
+    TypeMatches =
+        case Qtype of
+            ?DNS_TYPE_ANY ->
+                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+            _ ->
+                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+        end,
+    ExactTypeMatches =
+        case TypeMatches of
+            [] ->
                 % No records matched the qtype, call custom handler
                 Handlers = erldns_handler:get_versioned_handlers(),
                 HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
                 erldns_dnssec:maybe_sign_rrset(Message, HandlerRecords, Zone);
-              _ ->
+            _ ->
                 % Records match qtype, use them
                 TypeMatches
-            end,
-  AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
-  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
-  case {ExactTypeMatches, ReferralRecords} of
-    {[], []} ->
-      % There are no exact type matches and no referrals, return NOERROR with the authority set
-      Message#dns_message{aa = true, authority = Zone#zone.authority};
-    {[], _} ->
-      % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
-      resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
-    _ ->
-      % There were exact matches of name and type.
-      resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
-  end.
+        end,
+    AuthorityRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), MatchedRecords),
+    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), MatchedRecords),
+    case {ExactTypeMatches, ReferralRecords} of
+        {[], []} ->
+            % There are no exact type matches and no referrals, return NOERROR with the authority set
+            Message#dns_message{aa = true, authority = Zone#zone.authority};
+        {[], _} ->
+            % There were no exact type matches, but there were other name matches and there are NS records, so this is an exact match referral
+            resolve_exact_match_referral(Message, Qtype, MatchedRecords, ReferralRecords, AuthorityRecords);
+        _ ->
+            % There were exact matches of name and type.
+            resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, ExactTypeMatches, Zone, AuthorityRecords)
+    end.
 
-
--spec(resolve_exact_type_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        AuthorityRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_type_match(Message :: dns:message(),
+                               Qname :: dns:dname(),
+                               Qtype :: dns:type(),
+                               Host :: dns:ip(),
+                               CnameChain :: [dns:rr()],
+                               MatchedRecords :: [dns:rr()],
+                               Zone :: #zone{},
+                               AuthorityRecords :: [dns:rr()]) ->
+                                  dns:message().
 resolve_exact_type_match(Message, Qname, ?DNS_TYPE_NS, Host, CnameChain, MatchedRecords, Zone, []) ->
-  % There was an exact type match for an NS query, however there is no SOA record for the zone.
-  lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
-  Answer = lists:last(MatchedRecords),
-  Name = Answer#dns_rr.name,
-  % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
-  restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+    % There was an exact type match for an NS query, however there is no SOA record for the zone.
+    lager:info("Exact match for NS with no SOA in the zone (qname: ~p)", [Qname]),
+    Answer = lists:last(MatchedRecords),
+    Name = Answer#dns_rr.name,
+    % It isn't clear what the QTYPE should be on a delegated restart. I assume an A record.
+    restart_delegated_query(Message, Name, ?DNS_TYPE_A, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
 resolve_exact_type_match(Message, _Qname, ?DNS_TYPE_NS, _Host, _CnameChain, MatchedRecords, _Zone, _AuthorityRecords) ->
-  % There was an exact type match for an NS query and an SOA record.
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
+    % There was an exact type match for an NS query and an SOA record.
+    Message#dns_message{aa = true,
+                        rc = ?DNS_RCODE_NOERROR,
+                        answers = Message#dns_message.answers ++ MatchedRecords};
 resolve_exact_type_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords) ->
-  % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
-  Answer = lists:last(MatchedRecords),
-  case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
-    [] ->
-      % We are authoritative and there are no NS records here.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
-    NSRecords ->
-      % NOTE: this is a potential bug because it assumes the last record is the one to examine.
-      NSRecord = lists:last(NSRecords),
-      SoaRecord = lists:last(Zone#zone.authority),
-      case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
-        true ->
-          % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
-          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords};
-        false ->
-          % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
-          % delegated to another zone in the cache
-          resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
-      end
-  end.
-
+    % There was an exact type match for something other than an NS record and we are authoritative because there is an SOA record.
+    Answer = lists:last(MatchedRecords),
+    case erldns_zone_cache:get_delegations(Answer#dns_rr.name) of
+        [] ->
+            % We are authoritative and there are no NS records here.
+            Message#dns_message{aa = true,
+                                rc = ?DNS_RCODE_NOERROR,
+                                answers = Message#dns_message.answers ++ MatchedRecords};
+        NSRecords ->
+            % NOTE: this is a potential bug because it assumes the last record is the one to examine.
+            NSRecord = lists:last(NSRecords),
+            SoaRecord = lists:last(Zone#zone.authority),
+            case SoaRecord#dns_rr.name =:= NSRecord#dns_rr.name of
+                true ->
+                    % The SOA record name matches the NS record name, we are at the apex, NOERROR and append the matched records to the answers
+                    Message#dns_message{aa = true,
+                                        rc = ?DNS_RCODE_NOERROR,
+                                        answers = Message#dns_message.answers ++ MatchedRecords};
+                false ->
+                    % The SOA record and NS name do not match, so this may require restarting the search as the name may or may not be
+                    % delegated to another zone in the cache
+                    resolve_exact_type_match_delegated(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, AuthorityRecords, NSRecords)
+            end
+    end.
 
 %% @doc There is an exact name and type match and there NS records present. This may indicate the name is at the apex
 %% or it may indicate that the name is delegated.
--spec(resolve_exact_type_match_delegated(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        AuthorityRecords :: [dns:rr()],
-        NSRecords:: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_type_match_delegated(Message :: dns:message(),
+                                         Qname :: dns:dname(),
+                                         Qtype :: dns:type(),
+                                         Host :: dns:ip(),
+                                         CnameChain :: [dns:rr()],
+                                         MatchedRecords :: [dns:rr()],
+                                         Zone :: #zone{},
+                                         AuthorityRecords :: [dns:rr()],
+                                         NSRecords :: [dns:rr()]) ->
+                                            dns:message().
 resolve_exact_type_match_delegated(Message, _Qname, Qtype, Host, CnameChain, MatchedRecords, Zone, _AuthorityRecords, NSRecords) ->
-  % We are authoritative and there are NS records here.
-  % NOTE: there are potential bugs here because it assumes the last record is the one to examine
-  Answer = lists:last(MatchedRecords),
-  NSRecord = lists:last(NSRecords),
-  Name = NSRecord#dns_rr.name,
-  case Name =:= Answer#dns_rr.name of
-    true ->
-      % NS name matches answer name, thus it's a recursion, so return the message
-      Message#dns_message{aa = false, rc = ?DNS_RCODE_NOERROR, authority = Message#dns_message.authority ++ NSRecords};
-    false ->
-      % NS name is different than the name in the matched records
-      case check_if_parent(Name, Answer#dns_rr.name) of
+    % We are authoritative and there are NS records here.
+    % NOTE: there are potential bugs here because it assumes the last record is the one to examine
+    Answer = lists:last(MatchedRecords),
+    NSRecord = lists:last(NSRecords),
+    Name = NSRecord#dns_rr.name,
+    case Name =:= Answer#dns_rr.name of
         true ->
-          % NS record name is a parent of the answer name
-          restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+            % NS name matches answer name, thus it's a recursion, so return the message
+            Message#dns_message{aa = false,
+                                rc = ?DNS_RCODE_NOERROR,
+                                authority = Message#dns_message.authority ++ NSRecords};
         false ->
-          % NS record name is not a parent of the answer name
-          Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, answers = Message#dns_message.answers ++ MatchedRecords, additional = Message#dns_message.additional}
-      end
-  end.
+            % NS name is different than the name in the matched records
+            case check_if_parent(Name, Answer#dns_rr.name) of
+                true ->
+                    % NS record name is a parent of the answer name
+                    restart_delegated_query(Message, Name, Qtype, Host, CnameChain, Zone, erldns_zone_cache:in_zone(Name));
+                false ->
+                    % NS record name is not a parent of the answer name
+                    Message#dns_message{aa = true,
+                                        rc = ?DNS_RCODE_NOERROR,
+                                        answers = Message#dns_message.answers ++ MatchedRecords,
+                                        additional = Message#dns_message.additional}
+            end
+    end.
 
-
--spec(resolve_exact_match_referral(
-        Message :: dns:message(),
-        Qtype :: dns:type(),
-        MatchedRecords :: [dns:rr()],
-        ReferralRecords :: [dns:rr()],
-        AuthorityRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_match_referral(Message :: dns:message(),
+                                   Qtype :: dns:type(),
+                                   MatchedRecords :: [dns:rr()],
+                                   ReferralRecords :: [dns:rr()],
+                                   AuthorityRecords :: [dns:rr()]) ->
+                                      dns:message().
 resolve_exact_match_referral(Message, _Qtype, _MatchedRecords, ReferralRecords, []) ->
-  % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
-  % add the NS records to the authority section of the message.
-  Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
+    % Given an exact name match where the Qtype is not found in the record set and we are not authoritative,
+    % add the NS records to the authority section of the message.
+    Message#dns_message{authority = Message#dns_message.authority ++ ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_ANY, MatchedRecords, _ReferralRecords, _AuthorityRecords) ->
-  % Given an exact name match and the type of ANY, return all of the matched records.
-  Message#dns_message{aa = true, answers = MatchedRecords};
+    % Given an exact name match and the type of ANY, return all of the matched records.
+    Message#dns_message{aa = true, answers = MatchedRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_NS, _MatchedRecords, ReferralRecords, _AuthorityRecords) ->
-  % Given an exact name match and the type NS, where the NS records are not found in record set
-  % return the NS records in the answers section of the message.
-  Message#dns_message{aa = true, answers = ReferralRecords};
+    % Given an exact name match and the type NS, where the NS records are not found in record set
+    % return the NS records in the answers section of the message.
+    Message#dns_message{aa = true, answers = ReferralRecords};
 resolve_exact_match_referral(Message, ?DNS_TYPE_SOA, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-  % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
-  % return the SOA records in the answers section of the message.
-  Message#dns_message{aa = true, answers = AuthorityRecords};
+    % Given an exact name match and the type SOA, where the SOA record is not found in the records set,
+    % return the SOA records in the answers section of the message.
+    Message#dns_message{aa = true, answers = AuthorityRecords};
 resolve_exact_match_referral(Message, _, _MatchedRecords, _ReferralRecords, AuthorityRecords) ->
-  % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
-  % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
-  Message#dns_message{aa = true, rc = ?DNS_RCODE_NOERROR, authority = AuthorityRecords}.
+    % Given an exact name match where the Qtype is not found in the record set and is not ANY, SOA or NS,
+    % return the SOA records for the zone in the authority section of the message and set the RC to NOERROR.
+    Message#dns_message{aa = true,
+                        rc = ?DNS_RCODE_NOERROR,
+                        authority = AuthorityRecords}.
 
-
-
--spec(resolve_exact_match_with_cname(
-        Message :: dns:message(),
-        Qtype :: ?DNS_TYPE_CNAME,
-        Host :: dns:ip(), 
-        CnameChain :: [dns:rr()],
-        MatchedRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_exact_match_with_cname(Message :: dns:message(),
+                                     Qtype :: '?DNS_TYPE_CNAME',
+                                     Host :: dns:ip(),
+                                     CnameChain :: [dns:rr()],
+                                     MatchedRecords :: [dns:rr()],
+                                     Zone :: #zone{},
+                                     CnameRecords :: [dns:rr()]) ->
+                                        dns:message().
 resolve_exact_match_with_cname(Message, ?DNS_TYPE_CNAME, _Host, _CnameChain, _MatchedRecords, _Zone, CnameRecords) ->
-  % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
-  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+    % There is a CNAME record and the request was for a CNAME record so append the CNAME records to the answers section.
+    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_exact_match_with_cname(Message, Qtype, Host, CnameChain, _MatchedRecords, Zone, CnameRecords) ->
-  % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
-  case lists:member(lists:last(CnameRecords), CnameChain) of
-    true ->
-      % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-    false ->
-      % No CNAME loop, restart the query with the CNAME content.
-      CnameRecord = lists:last(CnameRecords),
-      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-      restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords}, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
-  end.
+    % There is a CNAME record, however the Qtype is not CNAME, check for a CNAME loop before continuing.
+    case lists:member(lists:last(CnameRecords), CnameChain) of
+        true ->
+            % Indicates a CNAME loop. The response code is a SERVFAIL in this case.
+            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+        false ->
+            % No CNAME loop, restart the query with the CNAME content.
+            CnameRecord = lists:last(CnameRecords),
+            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+            restart_query(Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+                          Name,
+                          Qtype,
+                          Host,
+                          CnameChain ++ CnameRecords,
+                          Zone,
+                          erldns_zone_cache:in_zone(Name))
+    end.
 
-
--spec(best_match_resolution(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec best_match_resolution(Message :: dns:message(),
+                            Qname :: dns:dname(),
+                            Qtype :: dns:type(),
+                            Host :: dns:ip(),
+                            CnameChain :: [dns:rr()],
+                            BestMatchRecords :: [dns:rr()],
+                            Zone :: #zone{}) ->
+                               dns:message().
 best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-  % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
-  ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords), 
-  case ReferralRecords of
-    [] ->
-      % There were no NS records in the best matches.
-      resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
-    _ ->
-      % There were NS records in the best matches, so this is a referral.
-      resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
-  end.
-
+    % There was no exact match for the Qname, so we use the best matches that were returned by the best_match() function.
+    ReferralRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_NS), BestMatchRecords),
+    case ReferralRecords of
+        [] ->
+            % There were no NS records in the best matches.
+            resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone);
+        _ ->
+            % There were NS records in the best matches, so this is a referral.
+            resolve_best_match_referral(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, ReferralRecords)
+    end.
 
 %% @doc There is no referral, so check to see if there is a wildcard.
 %%
@@ -335,351 +349,349 @@ best_match_resolution(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords,
 %%
 %% If there is no wildcard present and the qname does not match the origina question then return NOERROR
 %% and include root hints in the additional section if necessary.
--spec(resolve_best_match(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{}) ->
-  dns:message()).
+-spec resolve_best_match(Message :: dns:message(),
+                         Qname :: dns:dname(),
+                         Qtype :: dns:type(),
+                         Host :: dns:ip(),
+                         CnameChain :: [dns:rr()],
+                         BestMatchRecords :: [dns:rr()],
+                         Zone :: #zone{}) ->
+                            dns:message().
 resolve_best_match(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone) ->
-  case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
-    true ->
-      % It's a wildcard match
-      CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
-      resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
-    false ->
-      % It's not a wildcard
-      [Question|_] = Message#dns_message.questions,
-      case Qname =:= Question#dns_query.name of % TODO this logic can be moved up higher in processing potentially.
+    case lists:any(erldns_records:match_wildcard(), BestMatchRecords) of
         true ->
-          % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
-          Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN, authority = Zone#zone.authority, aa = true};
+            % It's a wildcard match
+            CnameRecords = lists:filter(erldns_records:match_type(?DNS_TYPE_CNAME), lists:map(erldns_records:replace_name(Qname), BestMatchRecords)),
+            resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords);
         false ->
-          % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
-          % something other than CNAME. Note that the response is still NOERROR here.
-          %
-          % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
-          optionally_add_root_hints(Message)
-      end
-  end.
+            % It's not a wildcard
+            [Question | _] = Message#dns_message.questions,
+            case Qname =:=
+                     Question#dns_query.name % TODO this logic can be moved up higher in processing potentially.
+            of
+                true ->
+                    % We are authoritative but there is no match on name and type, so respond with NXDOMAIN
+                    Message#dns_message{rc = ?DNS_RCODE_NXDOMAIN,
+                                        authority = Zone#zone.authority,
+                                        aa = true};
+                false ->
+                    % This happens when we have a CNAME to an out-of-balliwick hostname and the query is for
+                    % something other than CNAME. Note that the response is still NOERROR here.
+                    %
+                    % In the dnstest suite, this is hit by cname_to_unauth_any (and others)
+                    optionally_add_root_hints(Message)
+            end
+    end.
 
-
--spec(resolve_best_match_with_wildcard(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_with_wildcard(Message :: dns:message(),
+                                       Qname :: dns:dname(),
+                                       Qtype :: dns:type(),
+                                       Host :: dns:ip(),
+                                       CnameChain :: [dns:rr()],
+                                       BestMatchRecords :: [dns:rr()],
+                                       Zone :: #zone{},
+                                       CnameRecords :: [dns:rr()]) ->
+                                          dns:message().
 resolve_best_match_with_wildcard(Message, Qname, Qtype, _Host, _CnameChain, MatchedRecords, Zone, []) ->
-  % Handle best match resolving with a wildcard name in the zone.
-  TypeMatchedRecords = case Qtype of
-                         ?DNS_TYPE_ANY ->
-                           filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
-                         _ ->
-                           lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
-                       end,
-  TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
-  case TypeMatches of
-    [] ->
-      % There is no exact type matches for the original qtype, ask the custom handlers for their records.
-      Handlers = erldns_handler:get_versioned_handlers(),
-      HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
-      Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
-      NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
-      case NewRecords of
+    % Handle best match resolving with a wildcard name in the zone.
+    TypeMatchedRecords =
+        case Qtype of
+            ?DNS_TYPE_ANY ->
+                filter_records(MatchedRecords, erldns_handler:get_versioned_handlers());
+            _ ->
+                lists:filter(erldns_records:match_type(Qtype), MatchedRecords)
+        end,
+    TypeMatches = lists:map(erldns_records:replace_name(Qname), TypeMatchedRecords),
+    case TypeMatches of
         [] ->
-          % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
-          Message#dns_message{aa = true, authority=Zone#zone.authority};
-        NewRecords ->
-          % Custom handlers returned answers
-          Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
-      end;
-    _ ->
-      % There is an exact type match
-      Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
-  end;
+            % There is no exact type matches for the original qtype, ask the custom handlers for their records.
+            Handlers = erldns_handler:get_versioned_handlers(),
+            HandlerRecords = lists:flatten(lists:map(call_handlers(Qname, Qtype, MatchedRecords, Message), Handlers)),
+            Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
+            NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
+            case NewRecords of
+                [] ->
+                    % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
+                    Message#dns_message{aa = true, authority = Zone#zone.authority};
+                NewRecords ->
+                    % Custom handlers returned answers
+                    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ NewRecords}
+            end;
+        _ ->
+            % There is an exact type match
+            Message#dns_message{aa = true, answers = Message#dns_message.answers ++ TypeMatches}
+    end;
 resolve_best_match_with_wildcard(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords) ->
-  % It is a wildcard CNAME
-  resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
-
+    % It is a wildcard CNAME
+    resolve_best_match_with_wildcard_cname(Message, Qname, Qtype, Host, CnameChain, BestMatchRecords, Zone, CnameRecords).
 
 % Handle the case where the wildcard is a CNAME in the zone. If the Qtype was CNAME then answer, otherwise determine if
 % the CNAME should be followed
--spec(resolve_best_match_with_wildcard_cname(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_with_wildcard_cname(Message :: dns:message(),
+                                             Qname :: dns:dname(),
+                                             Qtype :: dns:type(),
+                                             Host :: dns:ip(),
+                                             CnameChain :: [dns:rr()],
+                                             BestMatchRecords :: [dns:rr()],
+                                             Zone :: #zone{},
+                                             CnameRecords :: [dns:rr()]) ->
+                                                dns:message().
 resolve_best_match_with_wildcard_cname(Message, _Qname, ?DNS_TYPE_CNAME, _Host, _CnameChain, _BestMatchRecords, _Zone, CnameRecords) ->
-  Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
+    Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords};
 resolve_best_match_with_wildcard_cname(Message, _Qname, Qtype, Host, CnameChain, _BestMatchRecords, Zone, CnameRecords) ->
-  CnameRecord = lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
-  case lists:member(CnameRecord, CnameChain) of
-    true ->
-      % Indicates CNAME loop
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
-    false ->
-      % Follow the CNAME
-      CnameRecord = lists:last(CnameRecords),
-      Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
-      UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
-      restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
-  end.
-
+    CnameRecord =
+        lists:last(CnameRecords), % There should only be one CNAME. Multiple CNAMEs kill unicorns.
+    case lists:member(CnameRecord, CnameChain) of
+        true ->
+            % Indicates CNAME loop
+            Message#dns_message{aa = true, rc = ?DNS_RCODE_SERVFAIL};
+        false ->
+            % Follow the CNAME
+            CnameRecord = lists:last(CnameRecords),
+            Name = CnameRecord#dns_rr.data#dns_rrdata_cname.dname,
+            UpdatedMessage = Message#dns_message{aa = true, answers = Message#dns_message.answers ++ CnameRecords},
+            restart_query(UpdatedMessage, Name, Qtype, Host, CnameChain ++ CnameRecords, Zone, erldns_zone_cache:in_zone(Name))
+    end.
 
 % There are referral records
--spec(resolve_best_match_referral(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        BestMatchRecords :: [dns:rr()],
-        Zone :: #zone{},
-        CnameRecords :: [dns:rr()]) ->
-  dns:message()).
+-spec resolve_best_match_referral(Message :: dns:message(),
+                                  Qname :: dns:dname(),
+                                  Qtype :: dns:type(),
+                                  Host :: dns:ip(),
+                                  CnameChain :: [dns:rr()],
+                                  BestMatchRecords :: [dns:rr()],
+                                  Zone :: #zone{},
+                                  CnameRecords :: [dns:rr()]) ->
+                                     dns:message().
 resolve_best_match_referral(Message, _Qname, Qtype, _Host, CnameChain, BestMatchRecords, _Zone, ReferralRecords) ->
-  Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
-  case {Qtype, Authority, CnameChain} of
-    {_,[],[]} ->
-      % We are authoritative for the name since there was an SOA record in the best match results.
-      Message#dns_message{aa = true, rc = ?DNS_RCODE_NXDOMAIN, authority = Authority};
-    {_,_,[]} ->
-      % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
-      % The name has thus been delegated to another authority.
-      Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
-    {?DNS_TYPE_ANY,_,_} ->
-      % We are authoritative and the Qtype is ANY, return the original message
-      Message;
-    _ ->
-      % We are authoritative and the Qtype is something other than ANY, set the authority in the response
-      Message#dns_message{authority = Authority}
-  end.
-
+    Authority = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), BestMatchRecords),
+    case {Qtype, Authority, CnameChain} of
+        {_, [], []} ->
+            % We are authoritative for the name since there was an SOA record in the best match results.
+            Message#dns_message{aa = true,
+                                rc = ?DNS_RCODE_NXDOMAIN,
+                                authority = Authority};
+        {_, _, []} ->
+            % Indicate that we are not authoritative for the name as there were novSOA records in the best-match results.
+            % The name has thus been delegated to another authority.
+            Message#dns_message{aa = false, authority = Message#dns_message.authority ++ ReferralRecords};
+        {?DNS_TYPE_ANY, _, _} ->
+            % We are authoritative and the Qtype is ANY, return the original message
+            Message;
+        _ ->
+            % We are authoritative and the Qtype is something other than ANY, set the authority in the response
+            Message#dns_message{authority = Authority}
+    end.
 
 % The CNAME is in a zone. If it is the same zone, then continue the chain, otherwise return the message
--spec(restart_query(
-        Message :: dns:message(),
-        Name :: dns:dname(),
-        Qtype :: 0..255,
-        Host :: any(),
-        CnameChain :: any(),
-        Zone :: #zone{},
-        InZone :: boolean()) ->
-  dns:message()).
+-spec restart_query(Message :: dns:message(),
+                    Name :: dns:dname(),
+                    Qtype :: 0..255,
+                    Host :: any(),
+                    CnameChain :: any(),
+                    Zone :: #zone{},
+                    InZone :: boolean()) ->
+                       dns:message().
 restart_query(Message, Name, Qtype, Host, CnameChain, Zone, true) ->
-  case check_if_parent(Zone#zone.name, Name) of
-    true -> resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
-    false -> Message
-  end;
+    case check_if_parent(Zone#zone.name, Name) of
+        true ->
+            resolve_authoritative(Message, Name, Qtype, Zone, Host, CnameChain);
+        false ->
+            Message
+    end;
 % The CNAME is not in a zone, do not restart the query, return the answer.
 restart_query(Message, _Name, _Qtype, _Host, _CnameChain, _Zone, false) ->
-  Message.
+    Message.
 
-
--spec(restart_delegated_query(
-        Message :: dns:message(),
-        Qname :: dns:dname(),
-        Qtype :: dns:type(),
-        Host :: dns:ip(),
-        CnameChain :: [dns:rr()],
-        Zone :: #zone{},
-        InZone :: boolean()) ->
-  dns:message()).
+-spec restart_delegated_query(Message :: dns:message(),
+                              Qname :: dns:dname(),
+                              Qtype :: dns:type(),
+                              Host :: dns:ip(),
+                              CnameChain :: [dns:rr()],
+                              Zone :: #zone{},
+                              InZone :: boolean()) ->
+                                 dns:message().
 % Delegated, but in the same zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, true) ->
-  resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
+    resolve_authoritative(Message, Qname, Qtype, Zone, Host, CnameChain);
 % Delegated to a different zone.
 restart_delegated_query(Message, Qname, Qtype, Host, CnameChain, Zone, false) ->
-  resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
-
+    resolve_authoritative(Message, Qname, Qtype, erldns_zone_cache:find_zone(Qname, Zone#zone.authority), Host, CnameChain).
 
 %% Utility functions
 
-
 %% @doc If root hints are enabled, return an updated message with the root hints.
--spec(optionally_add_root_hints(dns:message()) -> dns:message()).
+-spec optionally_add_root_hints(dns:message()) -> dns:message().
 optionally_add_root_hints(Message) ->
-  case erldns_config:use_root_hints() of
-    true ->
-      {Authority, Additional} = erldns_records:root_hints(),
-      Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
-    _ ->
-      Message
-  end.
+    case erldns_config:use_root_hints() of
+        true ->
+            {Authority, Additional} = erldns_records:root_hints(),
+            Message#dns_message{authority = Authority, additional = Message#dns_message.additional ++ Additional};
+        _ ->
+            Message
+    end.
 
 %% Returns true if the first domain name is a parent of the second domain name.
 check_if_parent(PossibleParentName, Name) ->
-  case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
-    [] -> true;
-    _ -> false
-  end.
-
+    case lists:subtract(dns:dname_to_labels(PossibleParentName), dns:dname_to_labels(Name)) of
+        [] ->
+            true;
+        _ ->
+            false
+    end.
 
 % Find the best match records for the given Qname in the given zone. This will attempt to walk through the
 % domain hierarchy in the Qname looking for both exact and wildcard matches.
 -spec best_match(dns:dname(), #zone{}) -> [dns:rr()].
-best_match(Qname, Zone) -> best_match(Qname, Zone, dns:dname_to_labels(Qname)).
+best_match(Qname, Zone) ->
+    best_match(Qname, Zone, dns:dname_to_labels(Qname)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()]) -> [dns:rr()].
-best_match(_Qname, _Zone, []) -> [];
-best_match(Qname, Zone, [_|Rest]) ->
-  WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
-  best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
+best_match(_Qname, _Zone, []) ->
+    [];
+best_match(Qname, Zone, [_ | Rest]) ->
+    WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
+    best_match(Qname, Zone, Rest, erldns_zone_cache:get_records_by_name(WildcardName)).
 
 -spec best_match(dns:dname(), #zone{}, [dns:label()], [dns:rr()]) -> [dns:rr()].
-best_match(_Qname, _Zone, [], []) -> [];
+best_match(_Qname, _Zone, [], []) ->
+    [];
 best_match(Qname, Zone, Labels, []) ->
-  Name = dns:labels_to_dname(Labels),
-  case erldns_zone_cache:get_records_by_name(Name) of
-    [] -> best_match(Qname, Zone, Labels);
-    Matches -> Matches
-  end;
-best_match(_Qname, _Zone, _Labels, WildcardMatches) -> WildcardMatches.
-
+    Name = dns:labels_to_dname(Labels),
+    case erldns_zone_cache:get_records_by_name(Name) of
+        [] ->
+            best_match(Qname, Zone, Labels);
+        Matches ->
+            Matches
+    end;
+best_match(_Qname, _Zone, _Labels, WildcardMatches) ->
+    WildcardMatches.
 
 %% Call all registered handlers.
 -spec call_handlers(dns:dname(), dns:type(), [dns:rr()], dns:message()) -> fun(({module(), [dns:type()], integer()}) -> [dns:rr()]).
 call_handlers(Qname, Qtype, Records, Message) ->
-  fun({Module, Types, Version}) ->
-      case Version of
-        1 ->
-          case lists:member(Qtype, Types) of
-            true -> Module:handle(Qname, Qtype, Records);
-            false ->
-              case Qtype =:= ?DNS_TYPE_ANY of
-                true -> Module:handle(Qname, Qtype, Records);
-                false -> []
-              end
-          end;
-        2 ->
-          case lists:member(Qtype, Types) of
-            true -> Module:handle(Qname, Qtype, Records, Message);
-            false ->
-              case Qtype =:= ?DNS_TYPE_ANY of
-                true -> Module:handle(Qname, Qtype, Records, Message);
-                false -> []
-              end
-          end
-      end
-  end.
-
+    fun({Module, Types, Version}) ->
+       case Version of
+           1 ->
+               case lists:member(Qtype, Types) of
+                   true -> Module:handle(Qname, Qtype, Records);
+                   false ->
+                       case Qtype =:= ?DNS_TYPE_ANY of
+                           true -> Module:handle(Qname, Qtype, Records);
+                           false -> []
+                       end
+               end;
+           2 ->
+               case lists:member(Qtype, Types) of
+                   true -> Module:handle(Qname, Qtype, Records, Message);
+                   false ->
+                       case Qtype =:= ?DNS_TYPE_ANY of
+                           true -> Module:handle(Qname, Qtype, Records, Message);
+                           false -> []
+                       end
+               end
+       end
+    end.
 
 % Filter records through registered handlers.
-filter_records(Records, []) -> Records;
-filter_records(Records, [{Handler, _Types, Version}|Rest]) ->
-  case Version of
-    1 -> filter_records(Handler:filter(Records), Rest);
-    2 -> filter_records(Handler:filter(Records), Rest);
-    _ -> []
-  end.
-
+filter_records(Records, []) ->
+    Records;
+filter_records(Records, [{Handler, _Types, Version} | Rest]) ->
+    case Version of
+        1 ->
+            filter_records(Handler:filter(Records), Rest);
+        2 ->
+            filter_records(Handler:filter(Records), Rest);
+        _ ->
+            []
+    end.
 
 %% See if additional processing is necessary.
 additional_processing(Message, Host, Zone) ->
-  RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
-  additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
+    RequiresAdditionalProcessing = requires_additional_processing(Message#dns_message.answers ++ Message#dns_message.authority, []),
+    additional_processing(Message, Host, Zone, lists:flatten(RequiresAdditionalProcessing)).
+
 %% No records require additional processing.
 additional_processing(Message, _Host, _Zone, []) ->
-  Message;
+    Message;
 %% There are records with names that require additional processing.
 additional_processing(Message, Host, Zone, Names) ->
-  RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
-  Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
-  additional_processing(Message, Host, Zone, Names, Records).
+    RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
+    Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
+    additional_processing(Message, Host, Zone, Names, Records).
 
 %% No additional A records were found, so just return the message.
 additional_processing(Message, _Host, _Zone, _Names, []) ->
-  Message;
+    Message;
 %% Additional A records were found, so we add them to the additional section.
 additional_processing(Message, _Host, _Zone, _Names, Records) ->
-  Message#dns_message{additional = Message#dns_message.additional ++ Records}.
-
-
+    Message#dns_message{additional = Message#dns_message.additional ++ Records}.
 
 %% Given a list of answers find the names that require additional processing.
--spec(requires_additional_processing(
-        Records :: [dns:rr()],
-        RecordsRequiringAdditionalProcessing :: [dns:rr()]) ->
-  [dns:rr()]).
-requires_additional_processing([], RequiresAdditional) -> RequiresAdditional;
-requires_additional_processing([Answer|Rest], RequiresAdditional) ->
-  Names = case Answer#dns_rr.data of
-            Data when is_record(Data, dns_rrdata_ns) -> [Data#dns_rrdata_ns.dname];
-            Data when is_record(Data, dns_rrdata_mx) -> [Data#dns_rrdata_mx.exchange];
-            _ -> []
-          end,
-  requires_additional_processing(Rest, RequiresAdditional ++ Names).
-
+-spec requires_additional_processing(Records :: [dns:rr()], RecordsRequiringAdditionalProcessing :: [dns:rr()]) -> [dns:rr()].
+requires_additional_processing([], RequiresAdditional) ->
+    RequiresAdditional;
+requires_additional_processing([Answer | Rest], RequiresAdditional) ->
+    Names =
+        case Answer#dns_rr.data of
+            Data when is_record(Data, dns_rrdata_ns) ->
+                [Data#dns_rrdata_ns.dname];
+            Data when is_record(Data, dns_rrdata_mx) ->
+                [Data#dns_rrdata_mx.exchange];
+            _ ->
+                []
+        end,
+    requires_additional_processing(Rest, RequiresAdditional ++ Names).
 
 %% @doc Return true if DNSSEC is requested and enabled.
--spec(check_dnssec(
-        Message :: dns:message(),
-        Host :: dns:ip(),
-        Question :: dns:query()) ->
-  boolean()).
+-spec check_dnssec(Message :: dns:message(), Host :: dns:ip(), Question :: dns:query()) -> boolean().
 check_dnssec(Message, Host, Question) ->
-  case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
-    true ->
-      erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
-      true;
-    false ->
-      false
-  end.
-
+    case proplists:get_bool(dnssec, erldns_edns:get_opts(Message)) of
+        true ->
+            erldns_events:notify({?MODULE, dnssec_request, Host, Question#dns_query.name}),
+            true;
+        false ->
+            false
+    end.
 
 %% @doc Sort the answers in the given message.
 -spec sort_answers(dns:message()) -> dns:message().
 sort_answers(Message) ->
-  Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
+    Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
 
 -spec sort_fun(dns:rr(), dns:rr()) -> boolean().
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}},
-         #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
-  true;
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name},
-         #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname=Name}}) ->
-  false;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}, #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}) ->
+    true;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name}, #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}) ->
+    false;
 sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME}, #dns_rr{}) ->
-  true;
+    true;
 sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
-  false;
+    false;
 sort_fun(A, B) ->
-  A =< B.
+    A =< B.
 
 % Extract the name from the first record in the list.
 zone_authority_name([Record | _]) ->
-  Record#dns_rr.name.
+    Record#dns_rr.name.
 
 % Find NS records that represent a zone cut.
 detect_zonecut(Zone, Qname) when is_binary(Qname) ->
-  detect_zonecut(Zone, dns:dname_to_labels(Qname));
+    detect_zonecut(Zone, dns:dname_to_labels(Qname));
 detect_zonecut(_Zone, []) ->
-  [];
+    [];
 detect_zonecut(_Zone, [_Label]) ->
-  [];
+    [];
 detect_zonecut(Zone, [_ | ParentLabels] = Labels) ->
-  Qname = dns:labels_to_dname(Labels),
-  case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
-    true ->
-      [];
-    false ->
-      case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
-        [] ->
-          detect_zonecut(Zone, ParentLabels);
-        ZonecutNSRecords ->
-          ZonecutNSRecords
-      end
-  end.
+    Qname = dns:labels_to_dname(Labels),
+    case dns:compare_dname(zone_authority_name(Zone#zone.authority), Qname) of
+        true ->
+            [];
+        false ->
+            case erldns_zone_cache:get_records_by_name_and_type(Qname, ?DNS_TYPE_NS) of
+                [] ->
+                    detect_zonecut(Zone, ParentLabels);
+                ZonecutNSRecords ->
+                    ZonecutNSRecords
+            end
+    end.

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -49,8 +49,6 @@ resolve_no_question_returns_message_test() ->
 
 %% @doc Start the resolution process on the given question.
 %% Step 1: Set the RA bit to false as we do not handle recursive queries.
-%%
-%% Refuse all RRSIG requests.
 -spec(resolve_question(
         Message :: dns:message(),
         AuthorityRecords :: [dns:rr()],
@@ -60,6 +58,7 @@ resolve_no_question_returns_message_test() ->
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
   case Question#dns_query.type of
     ?DNS_TYPE_RRSIG ->
+      % Refuse all RRSIG requests.
       Message#dns_message{ra = false, ad = false, cd = false, rc = ?DNS_RCODE_REFUSED};
     Qtype ->
       check_dnssec(Message, Host, Question),

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -16,70 +16,65 @@
 %% IPv4 and IPv6 ports. Also runs the zone checker *after* the UDP and TCP
 %% servers are running.
 -module(erldns_server_sup).
+
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
-
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
-
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 init(_Args) ->
-  {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
+    {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
 define_servers(Servers) ->
-  lists:flatten(
-    lists:map(
-      fun(Server) ->
-          Name = erldns_config:keyget(name, Server),
-          Address = erldns_config:keyget(address, Server),
-          Port = erldns_config:keyget(port, Server),
-          Family = erldns_config:keyget(family, Server),
+    lists:flatten(lists:map(fun(Server) ->
+                               Name = erldns_config:keyget(name, Server),
+                               Address = erldns_config:keyget(address, Server),
+                               Port = erldns_config:keyget(port, Server),
+                               Family = erldns_config:keyget(family, Server),
 
-          Processes = erldns_config:keyget(processes, Server, 1),
-          define_server(Name, Address, Port, Family, Processes)
-      end, Servers)
-   ).
+                               Processes = erldns_config:keyget(processes, Server, 1),
+                               define_server(Name, Address, Port, Family, Processes)
+                            end,
+                            Servers)).
 
 define_server(Name, Address, Port, Family, N) ->
-  define_server(Name, Address, Port, Family, N, []).
+    define_server(Name, Address, Port, Family, N, []).
 
 define_server(_, _, _, _, 0, Definitions) ->
-  Definitions;
+    Definitions;
 define_server(Name, Address, Port, Family, 1, []) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name])),
-  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-  [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
-   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
-  ];
+    UDPName = list_to_atom(lists:concat([udp, '_', Name])),
+    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+    [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
+     {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}];
 define_server(Name, Address, Port, Family, N = 1, Definitions) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-  Definition = [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
-   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
-  ],
-  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
+    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+    Definition =
+        [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
+         {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}],
+    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
 define_server(Name, Address, Port, Family, N, Definitions) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-  Definition = [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}
-  ],
-  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
+    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+    Definition = [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}],
+    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
 
 socket_opts() ->
-  case os:type() of
-    {unix, linux} -> [{raw, 1, 15, <<1:32/native>>}];
-    {unix, darwin} -> [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
-    _ -> []
-  end.
+    case os:type() of
+        {unix, linux} ->
+            [{raw, 1, 15, <<1:32/native>>}];
+        {unix, darwin} ->
+            [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
+        _ ->
+            []
+    end.

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -16,64 +16,70 @@
 %% IPv4 and IPv6 ports. Also runs the zone checker *after* the UDP and TCP
 %% servers are running.
 -module(erldns_server_sup).
-
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
+
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
+
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 start_link() ->
-    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 init(_Args) ->
-    {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
+  {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
 define_servers(Servers) ->
-    lists:flatten(lists:map(fun(Server) ->
-                               Name = erldns_config:keyget(name, Server),
-                               Address = erldns_config:keyget(address, Server),
-                               Port = erldns_config:keyget(port, Server),
-                               Family = erldns_config:keyget(family, Server),
-                               Processes = erldns_config:keyget(processes, Server, 1),
-                               define_server(Name, Address, Port, Family, Processes)
-                            end,
-                            Servers)).
+  lists:flatten(
+    lists:map(
+      fun(Server) ->
+          Name = erldns_config:keyget(name, Server),
+          Address = erldns_config:keyget(address, Server),
+          Port = erldns_config:keyget(port, Server),
+          Family = erldns_config:keyget(family, Server),
+
+          Processes = erldns_config:keyget(processes, Server, 1),
+          define_server(Name, Address, Port, Family, Processes)
+      end, Servers)
+   ).
 
 define_server(Name, Address, Port, Family, N) ->
-    define_server(Name, Address, Port, Family, N, []).
+  define_server(Name, Address, Port, Family, N, []).
 
 define_server(_, _, _, _, 0, Definitions) ->
-    Definitions;
+  Definitions;
 define_server(Name, Address, Port, Family, 1, []) ->
-    UDPName = list_to_atom(lists:concat([udp, '_', Name])),
-    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-    [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
-     {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}];
+  UDPName = list_to_atom(lists:concat([udp, '_', Name])),
+  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+  [
+   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
+   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
+  ];
 define_server(Name, Address, Port, Family, N = 1, Definitions) ->
-    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-    Definition =
-        [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
-         {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}],
-    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
+  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+  Definition = [
+   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
+   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
+  ],
+  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
 define_server(Name, Address, Port, Family, N, Definitions) ->
-    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-    Definition = [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}],
-    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
+  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+  Definition = [
+   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}
+  ],
+  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
 
 socket_opts() ->
-    case os:type() of
-        {unix, linux} ->
-            [{raw, 1, 15, <<1:32/native>>}];
-        {unix, darwin} ->
-            [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
-        _ ->
-            []
-    end.
+  case os:type() of
+    {unix, linux} -> [{raw, 1, 15, <<1:32/native>>}];
+    {unix, darwin} -> [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
+    _ -> []
+  end.

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -16,70 +16,64 @@
 %% IPv4 and IPv6 ports. Also runs the zone checker *after* the UDP and TCP
 %% servers are running.
 -module(erldns_server_sup).
+
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
-
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
-
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 init(_Args) ->
-  {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
+    {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
 define_servers(Servers) ->
-  lists:flatten(
-    lists:map(
-      fun(Server) ->
-          Name = erldns_config:keyget(name, Server),
-          Address = erldns_config:keyget(address, Server),
-          Port = erldns_config:keyget(port, Server),
-          Family = erldns_config:keyget(family, Server),
-
-          Processes = erldns_config:keyget(processes, Server, 1),
-          define_server(Name, Address, Port, Family, Processes)
-      end, Servers)
-   ).
+    lists:flatten(lists:map(fun(Server) ->
+                               Name = erldns_config:keyget(name, Server),
+                               Address = erldns_config:keyget(address, Server),
+                               Port = erldns_config:keyget(port, Server),
+                               Family = erldns_config:keyget(family, Server),
+                               Processes = erldns_config:keyget(processes, Server, 1),
+                               define_server(Name, Address, Port, Family, Processes)
+                            end,
+                            Servers)).
 
 define_server(Name, Address, Port, Family, N) ->
-  define_server(Name, Address, Port, Family, N, []).
+    define_server(Name, Address, Port, Family, N, []).
 
 define_server(_, _, _, _, 0, Definitions) ->
-  Definitions;
+    Definitions;
 define_server(Name, Address, Port, Family, 1, []) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name])),
-  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-  [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
-   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
-  ];
+    UDPName = list_to_atom(lists:concat([udp, '_', Name])),
+    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+    [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
+     {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}];
 define_server(Name, Address, Port, Family, N = 1, Definitions) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-  TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-  Definition = [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
-   {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
-  ],
-  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
+    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+    TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
+    Definition =
+        [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
+         {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}],
+    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
 define_server(Name, Address, Port, Family, N, Definitions) ->
-  UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-  Definition = [
-   {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}
-  ],
-  define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
+    UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
+    Definition = [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}],
+    define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
 
 socket_opts() ->
-  case os:type() of
-    {unix, linux} -> [{raw, 1, 15, <<1:32/native>>}];
-    {unix, darwin} -> [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
-    _ -> []
-  end.
+    case os:type() of
+        {unix, linux} ->
+            [{raw, 1, 15, <<1:32/native>>}];
+        {unix, darwin} ->
+            [{raw, 16#ffff, 16#0200, <<1:32/native>>}];
+        _ ->
+            []
+    end.

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -1,4 +1,5 @@
 %% Copyright (c) 2015, SiftLogic LLC
+%% Copyright (c) 2015-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -18,6 +18,7 @@
 
 %% inter-module API
 -export([start_link/0]).
+
 %% API
 -export([create/1,
          insert/2,
@@ -33,6 +34,7 @@
          list_table/1,
          load_zones/0,
          load_zones/1]).
+
 %% gen_server callbacks
 -export([init/1,
          handle_call/3,
@@ -48,33 +50,34 @@
 
 %% Gen Server Callbacks
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Inits the module, and sends a "timeout" to handle_info to start the poller for table backup
 init([]) ->
-    %%This call to handle_info starts the timer to backup tables in the given interval.
-    {ok, #state{}, 0}.
+  %%This call to handle_info starts the timer to backup tables in the given interval.
+  {ok, #state{}, 0}.
 
 handle_call(_Request, _From, State) ->
-    {reply, ok, State, 0}.
+  {reply, ok, State, 0}.
 
 handle_cast(_Msg, State) ->
-    {noreply, State, 0}.
+  {noreply, State, 0}.
 
 %% @doc Backups the tables in the given period
 handle_info(timeout, State) ->
-    Before = erlang:timestamp(),
-    {error, not_implemented} = backup_tables(),
-    TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
-    {noreply, State, max(?POLL_WAIT_HOURS * 60000 - TimeSpentMs, 0)};
+  Before = erlang:timestamp(),
+  {error, not_implemented} = backup_tables(),
+  TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
+  {noreply, State, max((?POLL_WAIT_HOURS * 60000) - TimeSpentMs, 0)};
 handle_info(_Info, State) ->
-    {noreply, State, 0}.
+  {noreply, State, 0}.
 
 terminate(_Reason, _State) ->
-    ok.
+  ok.
 
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
+
 
 %% Public API
 %% @doc API for a module's function calls. Please note that all crashes should be handled at the
@@ -84,127 +87,125 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Call to a module's create. Creates a new table.
 -spec create(atom()) -> ok | {error, Reason :: term()}.
 create(Table) ->
-    Module = mod(Table),
-    Module:create(Table).
+  Module = mod(Table),
+  Module:create(Table).
 
 %% @doc Call to a module's insert. Inserts a value into the table.
 -spec insert(atom(), tuple()) -> ok | {error, Reason :: term()}.
-insert(Table, Value) ->
-    Module = mod(Table),
-    Module:insert(Table, Value).
+insert(Table, Value)->
+  Module = mod(Table),
+  Module:insert(Table, Value).
 
 %% @doc Call to a module's delete_table. Deletes the entire table.
 -spec delete_table(atom()) -> ok | {error, Reason :: term()}.
-delete_table(Table) ->
-    Module = mod(Table),
-    Module:delete_table(Table).
+delete_table(Table)->
+  Module = mod(Table),
+  Module:delete_table(Table).
 
 %% @doc Call to a module's delete. Deletes a key value from a table.
 -spec delete(atom(), term()) -> ok | {error, Reason :: term()}.
 delete(Table, Key) ->
-    Module = mod(Table),
-    Module:delete(Table, Key).
+  Module = mod(Table),
+  Module:delete(Table, Key).
 
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-    Module = mod(Table),
-    Module:select_delete(Table, MatchSpec).
+  Module = mod(Table),
+  Module:select_delete(Table, MatchSpec).
 
 %% @doc Backup the table to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(Table) ->
-    Module = mod(Table),
-    Module:backup_table(Table).
+backup_table(Table)->
+  Module = mod(Table),
+  Module:backup_table(Table).
 
 %% @doc Backup the tables to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-    Module = mod(),
-    Module:backup_tables().
+  Module = mod(),
+  Module:backup_tables().
 
 %% @doc Call to a module's select. Uses table key pair, and can be considered a "lookup" in terms of ets.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-    Module = mod(Table),
-    Module:select(Table, Key).
+  Module = mod(Table),
+  Module:select(Table, Key).
 
 %% @doc Call to a module's select/3 Uses a matchspec to generate matches.
 -spec select(atom(), list(), infinite | integer()) -> [tuple()].
 select(Table, MatchSpec, Limit) ->
-    Module = mod(Table),
-    Module:select(Table, MatchSpec, Limit).
+  Module = mod(Table),
+  Module:select(Table, MatchSpec, Limit).
 
 %% @doc Call to a module's foldl.
--spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-    Module = mod(Table),
-    Module:foldl(Fun, Acc, Table).
+  Module = mod(Table),
+  Module:foldl(Fun, Acc, Table).
 
 %% @doc This function emptys the specified table of all values.
 -spec empty_table(atom()) -> ok | {error, Reason :: term()}.
 empty_table(Table) ->
-    Module = mod(Table),
-    Module:empty_table(Table).
+  Module = mod(Table),
+  Module:empty_table(Table).
 
 %% @doc List all elements in a table.
 -spec list_table(atom()) -> [] | term() | {error, term()}.
 list_table(TableName) ->
-    Module = mod(TableName),
-    Module:list_table(TableName).
+  Module = mod(TableName),
+  Module:list_table(TableName).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones() -> {ok, integer()} | {err, atom()}.
+-spec load_zones() -> {ok, integer()} | {err,  atom()}.
 load_zones() ->
-    load_zones(filename()).
+  load_zones(filename()).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones(list()) -> {ok, integer()} | {err, atom()}.
+-spec load_zones(list()) -> {ok, integer()} | {err,  atom()}.
 load_zones(Filename) when is_list(Filename) ->
-    case file:read_file(Filename) of
-        {ok, Binary} ->
-            lager:debug("Parsing zones JSON"),
-            JsonZones = jsx:decode(Binary),
-            lager:debug("Putting zones into cache"),
-            lists:foreach(fun(JsonZone) ->
-                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-                             ok = erldns_zone_cache:put_zone(Zone)
-                          end,
-                          JsonZones),
-            lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
-            {ok, length(JsonZones)};
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, failed_zones_load, Reason}),
-            {err, Reason}
-    end.
+  case file:read_file(Filename) of
+    {ok, Binary} ->
+      lager:debug("Parsing zones JSON"),
+      JsonZones = jsx:decode(Binary),
+      lager:debug("Putting zones into cache"),
+      lists:foreach(
+        fun(JsonZone) ->
+            Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+            ok = erldns_zone_cache:put_zone(Zone)
+        end, JsonZones),
+      lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
+      {ok, length(JsonZones)};
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, failed_zones_load, Reason}),
+      {err, Reason}
+  end.
 
 %% Internal API
 %% @doc Get file name from env, or return default (copied from erldns_zone_loader.erl)
 filename() ->
-    case application:get_env(erldns, zones) of
-        {ok, Filename} ->
-            Filename;
-        _ ->
-            ?FILENAME
-    end.
+  case application:get_env(erldns, zones) of
+    {ok, Filename} -> Filename;
+    _ -> ?FILENAME
+  end.
 
 %% @doc This function retrieves the module name to be used for a given application or table
 %% (ex. erldns_storage_json...). Matched tables are always going to use ets because they are either
 %% cached, or functionality is optimal in ets.
 %% @end
 mod() ->
-    erldns_config:storage_type().
+  erldns_config:storage_type().
 
 mod(packet_cache) ->
-    erldns_storage_json;
+  erldns_storage_json;
 mod(host_throttle) ->
-    erldns_storage_json;
+  erldns_storage_json;
 mod(handler_registry) ->
-    erldns_storage_json;
+  erldns_storage_json;
 mod(geolocation) ->
-    erldns_storage_mnesia;
+  erldns_storage_mnesia;
 mod(lookup_table) ->
-    erldns_storage_json;
+  erldns_storage_json;
 mod(_Table) ->
-    erldns_config:storage_type().
+  erldns_config:storage_type().

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -18,7 +18,6 @@
 
 %% inter-module API
 -export([start_link/0]).
-
 %% API
 -export([create/1,
          insert/2,
@@ -34,7 +33,6 @@
          list_table/1,
          load_zones/0,
          load_zones/1]).
-
 %% gen_server callbacks
 -export([init/1,
          handle_call/3,
@@ -50,34 +48,33 @@
 
 %% Gen Server Callbacks
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Inits the module, and sends a "timeout" to handle_info to start the poller for table backup
 init([]) ->
-  %%This call to handle_info starts the timer to backup tables in the given interval.
-  {ok, #state{}, 0}.
+    %%This call to handle_info starts the timer to backup tables in the given interval.
+    {ok, #state{}, 0}.
 
 handle_call(_Request, _From, State) ->
-  {reply, ok, State, 0}.
+    {reply, ok, State, 0}.
 
 handle_cast(_Msg, State) ->
-  {noreply, State, 0}.
+    {noreply, State, 0}.
 
 %% @doc Backups the tables in the given period
 handle_info(timeout, State) ->
-  Before = erlang:timestamp(),
-  {error, not_implemented} = backup_tables(),
-  TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
-  {noreply, State, max((?POLL_WAIT_HOURS * 60000) - TimeSpentMs, 0)};
+    Before = erlang:timestamp(),
+    {error, not_implemented} = backup_tables(),
+    TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
+    {noreply, State, max(?POLL_WAIT_HOURS * 60000 - TimeSpentMs, 0)};
 handle_info(_Info, State) ->
-  {noreply, State, 0}.
+    {noreply, State, 0}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
-
+    {ok, State}.
 
 %% Public API
 %% @doc API for a module's function calls. Please note that all crashes should be handled at the
@@ -87,125 +84,127 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Call to a module's create. Creates a new table.
 -spec create(atom()) -> ok | {error, Reason :: term()}.
 create(Table) ->
-  Module = mod(Table),
-  Module:create(Table).
+    Module = mod(Table),
+    Module:create(Table).
 
 %% @doc Call to a module's insert. Inserts a value into the table.
 -spec insert(atom(), tuple()) -> ok | {error, Reason :: term()}.
-insert(Table, Value)->
-  Module = mod(Table),
-  Module:insert(Table, Value).
+insert(Table, Value) ->
+    Module = mod(Table),
+    Module:insert(Table, Value).
 
 %% @doc Call to a module's delete_table. Deletes the entire table.
 -spec delete_table(atom()) -> ok | {error, Reason :: term()}.
-delete_table(Table)->
-  Module = mod(Table),
-  Module:delete_table(Table).
+delete_table(Table) ->
+    Module = mod(Table),
+    Module:delete_table(Table).
 
 %% @doc Call to a module's delete. Deletes a key value from a table.
 -spec delete(atom(), term()) -> ok | {error, Reason :: term()}.
 delete(Table, Key) ->
-  Module = mod(Table),
-  Module:delete(Table, Key).
+    Module = mod(Table),
+    Module:delete(Table, Key).
 
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-  Module = mod(Table),
-  Module:select_delete(Table, MatchSpec).
+    Module = mod(Table),
+    Module:select_delete(Table, MatchSpec).
 
 %% @doc Backup the table to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(Table)->
-  Module = mod(Table),
-  Module:backup_table(Table).
+backup_table(Table) ->
+    Module = mod(Table),
+    Module:backup_table(Table).
 
 %% @doc Backup the tables to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-  Module = mod(),
-  Module:backup_tables().
+    Module = mod(),
+    Module:backup_tables().
 
 %% @doc Call to a module's select. Uses table key pair, and can be considered a "lookup" in terms of ets.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-  Module = mod(Table),
-  Module:select(Table, Key).
+    Module = mod(Table),
+    Module:select(Table, Key).
 
 %% @doc Call to a module's select/3 Uses a matchspec to generate matches.
 -spec select(atom(), list(), infinite | integer()) -> [tuple()].
 select(Table, MatchSpec, Limit) ->
-  Module = mod(Table),
-  Module:select(Table, MatchSpec, Limit).
+    Module = mod(Table),
+    Module:select(Table, MatchSpec, Limit).
 
 %% @doc Call to a module's foldl.
--spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-  Module = mod(Table),
-  Module:foldl(Fun, Acc, Table).
+    Module = mod(Table),
+    Module:foldl(Fun, Acc, Table).
 
 %% @doc This function emptys the specified table of all values.
 -spec empty_table(atom()) -> ok | {error, Reason :: term()}.
 empty_table(Table) ->
-  Module = mod(Table),
-  Module:empty_table(Table).
+    Module = mod(Table),
+    Module:empty_table(Table).
 
 %% @doc List all elements in a table.
 -spec list_table(atom()) -> [] | term() | {error, term()}.
 list_table(TableName) ->
-  Module = mod(TableName),
-  Module:list_table(TableName).
+    Module = mod(TableName),
+    Module:list_table(TableName).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones() -> {ok, integer()} | {err,  atom()}.
+-spec load_zones() -> {ok, integer()} | {err, atom()}.
 load_zones() ->
-  load_zones(filename()).
+    load_zones(filename()).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones(list()) -> {ok, integer()} | {err,  atom()}.
+-spec load_zones(list()) -> {ok, integer()} | {err, atom()}.
 load_zones(Filename) when is_list(Filename) ->
-  case file:read_file(Filename) of
-    {ok, Binary} ->
-      lager:debug("Parsing zones JSON"),
-      JsonZones = jsx:decode(Binary),
-      lager:debug("Putting zones into cache"),
-      lists:foreach(
-        fun(JsonZone) ->
-            Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-            ok = erldns_zone_cache:put_zone(Zone)
-        end, JsonZones),
-      lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
-      {ok, length(JsonZones)};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, failed_zones_load, Reason}),
-      {err, Reason}
-  end.
+    case file:read_file(Filename) of
+        {ok, Binary} ->
+            lager:debug("Parsing zones JSON"),
+            JsonZones = jsx:decode(Binary),
+            lager:debug("Putting zones into cache"),
+            lists:foreach(fun(JsonZone) ->
+                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+                             ok = erldns_zone_cache:put_zone(Zone)
+                          end,
+                          JsonZones),
+            lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
+            {ok, length(JsonZones)};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, failed_zones_load, Reason}),
+            {err, Reason}
+    end.
 
 %% Internal API
 %% @doc Get file name from env, or return default (copied from erldns_zone_loader.erl)
 filename() ->
-  case application:get_env(erldns, zones) of
-    {ok, Filename} -> Filename;
-    _ -> ?FILENAME
-  end.
+    case application:get_env(erldns, zones) of
+        {ok, Filename} ->
+            Filename;
+        _ ->
+            ?FILENAME
+    end.
 
 %% @doc This function retrieves the module name to be used for a given application or table
 %% (ex. erldns_storage_json...). Matched tables are always going to use ets because they are either
 %% cached, or functionality is optimal in ets.
 %% @end
 mod() ->
-  erldns_config:storage_type().
+    erldns_config:storage_type().
 
 mod(packet_cache) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(host_throttle) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(handler_registry) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(geolocation) ->
-  erldns_storage_mnesia;
+    erldns_storage_mnesia;
 mod(lookup_table) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(_Table) ->
-  erldns_config:storage_type().
+    erldns_config:storage_type().

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -19,7 +19,6 @@
 
 %% inter-module API
 -export([start_link/0]).
-
 %% API
 -export([create/1,
          insert/2,
@@ -35,7 +34,6 @@
          list_table/1,
          load_zones/0,
          load_zones/1]).
-
 %% gen_server callbacks
 -export([init/1,
          handle_call/3,
@@ -51,34 +49,33 @@
 
 %% Gen Server Callbacks
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% @doc Inits the module, and sends a "timeout" to handle_info to start the poller for table backup
 init([]) ->
-  %%This call to handle_info starts the timer to backup tables in the given interval.
-  {ok, #state{}, 0}.
+    %%This call to handle_info starts the timer to backup tables in the given interval.
+    {ok, #state{}, 0}.
 
 handle_call(_Request, _From, State) ->
-  {reply, ok, State, 0}.
+    {reply, ok, State, 0}.
 
 handle_cast(_Msg, State) ->
-  {noreply, State, 0}.
+    {noreply, State, 0}.
 
 %% @doc Backups the tables in the given period
 handle_info(timeout, State) ->
-  Before = erlang:timestamp(),
-  {error, not_implemented} = backup_tables(),
-  TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
-  {noreply, State, max((?POLL_WAIT_HOURS * 60000) - TimeSpentMs, 0)};
+    Before = erlang:timestamp(),
+    {error, not_implemented} = backup_tables(),
+    TimeSpentMs = timer:now_diff(erlang:timestamp(), Before) div 1000,
+    {noreply, State, max(?POLL_WAIT_HOURS * 60000 - TimeSpentMs, 0)};
 handle_info(_Info, State) ->
-  {noreply, State, 0}.
+    {noreply, State, 0}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
-
+    {ok, State}.
 
 %% Public API
 %% @doc API for a module's function calls. Please note that all crashes should be handled at the
@@ -88,125 +85,127 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Call to a module's create. Creates a new table.
 -spec create(atom()) -> ok | {error, Reason :: term()}.
 create(Table) ->
-  Module = mod(Table),
-  Module:create(Table).
+    Module = mod(Table),
+    Module:create(Table).
 
 %% @doc Call to a module's insert. Inserts a value into the table.
 -spec insert(atom(), tuple()) -> ok | {error, Reason :: term()}.
-insert(Table, Value)->
-  Module = mod(Table),
-  Module:insert(Table, Value).
+insert(Table, Value) ->
+    Module = mod(Table),
+    Module:insert(Table, Value).
 
 %% @doc Call to a module's delete_table. Deletes the entire table.
 -spec delete_table(atom()) -> ok | {error, Reason :: term()}.
-delete_table(Table)->
-  Module = mod(Table),
-  Module:delete_table(Table).
+delete_table(Table) ->
+    Module = mod(Table),
+    Module:delete_table(Table).
 
 %% @doc Call to a module's delete. Deletes a key value from a table.
 -spec delete(atom(), term()) -> ok | {error, Reason :: term()}.
 delete(Table, Key) ->
-  Module = mod(Table),
-  Module:delete(Table, Key).
+    Module = mod(Table),
+    Module:delete(Table, Key).
 
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-  Module = mod(Table),
-  Module:select_delete(Table, MatchSpec).
+    Module = mod(Table),
+    Module:select_delete(Table, MatchSpec).
 
 %% @doc Backup the table to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(Table)->
-  Module = mod(Table),
-  Module:backup_table(Table).
+backup_table(Table) ->
+    Module = mod(Table),
+    Module:backup_table(Table).
 
 %% @doc Backup the tables to the JSON file.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-  Module = mod(),
-  Module:backup_tables().
+    Module = mod(),
+    Module:backup_tables().
 
 %% @doc Call to a module's select. Uses table key pair, and can be considered a "lookup" in terms of ets.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-  Module = mod(Table),
-  Module:select(Table, Key).
+    Module = mod(Table),
+    Module:select(Table, Key).
 
 %% @doc Call to a module's select/3 Uses a matchspec to generate matches.
 -spec select(atom(), list(), infinite | integer()) -> [tuple()].
 select(Table, MatchSpec, Limit) ->
-  Module = mod(Table),
-  Module:select(Table, MatchSpec, Limit).
+    Module = mod(Table),
+    Module:select(Table, MatchSpec, Limit).
 
 %% @doc Call to a module's foldl.
--spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-  Module = mod(Table),
-  Module:foldl(Fun, Acc, Table).
+    Module = mod(Table),
+    Module:foldl(Fun, Acc, Table).
 
 %% @doc This function emptys the specified table of all values.
 -spec empty_table(atom()) -> ok | {error, Reason :: term()}.
 empty_table(Table) ->
-  Module = mod(Table),
-  Module:empty_table(Table).
+    Module = mod(Table),
+    Module:empty_table(Table).
 
 %% @doc List all elements in a table.
 -spec list_table(atom()) -> [] | term() | {error, term()}.
 list_table(TableName) ->
-  Module = mod(TableName),
-  Module:list_table(TableName).
+    Module = mod(TableName),
+    Module:list_table(TableName).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones() -> {ok, integer()} | {err,  atom()}.
+-spec load_zones() -> {ok, integer()} | {err, atom()}.
 load_zones() ->
-  load_zones(filename()).
+    load_zones(filename()).
 
 %% @doc Load zones from a file. The default file name is "zones.json".(copied from erldns_zone_loader.erl)
--spec load_zones(list()) -> {ok, integer()} | {err,  atom()}.
+-spec load_zones(list()) -> {ok, integer()} | {err, atom()}.
 load_zones(Filename) when is_list(Filename) ->
-  case file:read_file(Filename) of
-    {ok, Binary} ->
-      lager:debug("Parsing zones JSON"),
-      JsonZones = jsx:decode(Binary),
-      lager:debug("Putting zones into cache"),
-      lists:foreach(
-        fun(JsonZone) ->
-            Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-            ok = erldns_zone_cache:put_zone(Zone)
-        end, JsonZones),
-      lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
-      {ok, length(JsonZones)};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, failed_zones_load, Reason}),
-      {err, Reason}
-  end.
+    case file:read_file(Filename) of
+        {ok, Binary} ->
+            lager:debug("Parsing zones JSON"),
+            JsonZones = jsx:decode(Binary),
+            lager:debug("Putting zones into cache"),
+            lists:foreach(fun(JsonZone) ->
+                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+                             ok = erldns_zone_cache:put_zone(Zone)
+                          end,
+                          JsonZones),
+            lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
+            {ok, length(JsonZones)};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, failed_zones_load, Reason}),
+            {err, Reason}
+    end.
 
 %% Internal API
 %% @doc Get file name from env, or return default (copied from erldns_zone_loader.erl)
 filename() ->
-  case application:get_env(erldns, zones) of
-    {ok, Filename} -> Filename;
-    _ -> ?FILENAME
-  end.
+    case application:get_env(erldns, zones) of
+        {ok, Filename} ->
+            Filename;
+        _ ->
+            ?FILENAME
+    end.
 
 %% @doc This function retrieves the module name to be used for a given application or table
 %% (ex. erldns_storage_json...). Matched tables are always going to use ets because they are either
 %% cached, or functionality is optimal in ets.
 %% @end
 mod() ->
-  erldns_config:storage_type().
+    erldns_config:storage_type().
 
 mod(packet_cache) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(host_throttle) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(handler_registry) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(geolocation) ->
-  erldns_storage_mnesia;
+    erldns_storage_mnesia;
 mod(lookup_table) ->
-  erldns_storage_json;
+    erldns_storage_json;
 mod(_Table) ->
-  erldns_config:storage_type().
+    erldns_config:storage_type().

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -1,4 +1,5 @@
 %% Copyright (c) 2015, SiftLogic LLC
+%% Copyright (c) 2015-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -32,105 +32,104 @@
 %% @doc Create ets table wrapper. Use match cases for adding different options to the table.
 -spec create(atom()) -> ok | not_implemented | {error, Reason :: term()}.
 create(schema) ->
-    not_implemented;
+  not_implemented;
 create(Name = zones) ->
-    create_ets_table(Name, set);
+  create_ets_table(Name, set);
 create(Name = zone_records_typed) ->
-    create_ets_table(Name, ordered_set);
+  create_ets_table(Name, ordered_set);
 create(Name = authorities) ->
-    create_ets_table(Name, set);
+  create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality
 create(Name = packet_cache) ->
-    create_ets_table(Name, set);
+  create_ets_table(Name, set);
 create(Name = host_throttle) ->
-    create_ets_table(Name, set);
+  create_ets_table(Name, set);
 create(Name = lookup_table) ->
-    create_ets_table(Name, bag);
+  create_ets_table(Name, bag);
 create(Name = handler_registry) ->
-    create_ets_table(Name, set);
+  create_ets_table(Name, set);
 create(Name = sync_counters) ->
-    create_ets_table(Name, set).
+  create_ets_table(Name, set).
 
 %% @doc Insert value in ets table.
 -spec insert(atom(), tuple()) -> ok.
-insert(Table, Value) ->
-    true = ets:insert(Table, Value),
-    ok.
+insert(Table, Value)->
+  true = ets:insert(Table, Value),
+  ok.
 
 %% @doc Delete entire ets table.
 -spec delete_table(atom()) -> ok.
-delete_table(Table) ->
-    true = ets:delete(Table),
-    ok.
+delete_table(Table)->
+  true = ets:delete(Table),
+  ok.
 
 %% @doc Delete an entry in the ets table.Ets always returns true for this function.
 -spec delete(atom(), term()) -> ok.
 delete(Table, Key) ->
-    ets:delete(Table, Key),
-    ok.
+  ets:delete(Table, Key),
+  ok.
 
 %% @doc Delete entries in the ets table that match the provided spec.
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-    Count = ets:select_delete(Table, MatchSpec),
-    {ok, Count}.
+  Count = ets:select_delete(Table, MatchSpec),
+  {ok, Count}.
 
 %% @doc Backup a specific ets table.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(_Table) ->
-    {error, not_implemented}.
+backup_table(_Table)->
+  {error, not_implemented}.
 
 %% @doc Should backup all ets tables.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-    {error, not_implemented}.
+  {error, not_implemented}.
 
 %% @doc Select from ets using key, value.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-    ets:lookup(Table, Key).
+  ets:lookup(Table, Key).
 
 %% #doc Select from ets using match specs.
 -spec select(atom(), list(), integer() | infinite) -> tuple() | '$end_of_table'.
 select(Table, MatchSpec, infinite) ->
-    ets:select(Table, MatchSpec);
+  ets:select(Table, MatchSpec);
 select(Table, MatchSpec, Limit) ->
-    ets:select(Table, MatchSpec, Limit).
+  ets:select(Table, MatchSpec, Limit).
 
 %% @doc Wrapper for foldl in ets.
--spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-    ets:foldl(Fun, Acc, Table).
+  ets:foldl(Fun, Acc, Table).
 
 %% @doc Empty ets table. Ets always returns true for this function.
 -spec empty_table(atom()) -> ok.
 empty_table(Table) ->
-    ets:delete_all_objects(Table),
-    ok.
+  ets:delete_all_objects(Table),
+  ok.
 
 %% @doc Lists the ets table
 -spec list_table(atom()) -> term() | {error, term()}.
 list_table(TableName) ->
-    try
-        ets:tab2list(TableName)
-    catch
-        error:R ->
-            {error, R}
-    end.
+  try ets:tab2list(TableName)
+  catch
+    error:R ->
+      {error, R}
+  end.
 
 %% Internal methods
 -spec create_ets_table(ets:tab(), ets:type()) -> ok | {error, Reason :: term()}.
 create_ets_table(Name, Type) ->
-    case ets:info(Name) of
-        undefined ->
-            case ets:new(Name, [Type, public, named_table]) of
-                Name ->
-                    ok;
-                Error ->
-                    {error, Error}
-            end;
-        _InfoList ->
-            ok
-    end.
+  case ets:info(Name) of
+    undefined ->
+      case ets:new(Name, [Type, public, named_table]) of
+        Name ->
+          ok;
+        Error ->
+          {error, Error}
+      end;
+    _InfoList ->
+      ok
+  end.

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -33,104 +33,105 @@
 %% @doc Create ets table wrapper. Use match cases for adding different options to the table.
 -spec create(atom()) -> ok | not_implemented | {error, Reason :: term()}.
 create(schema) ->
-  not_implemented;
+    not_implemented;
 create(Name = zones) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = zone_records_typed) ->
-  create_ets_table(Name, ordered_set);
+    create_ets_table(Name, ordered_set);
 create(Name = authorities) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality
 create(Name = packet_cache) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = host_throttle) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = lookup_table) ->
-  create_ets_table(Name, bag);
+    create_ets_table(Name, bag);
 create(Name = handler_registry) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = sync_counters) ->
-  create_ets_table(Name, set).
+    create_ets_table(Name, set).
 
 %% @doc Insert value in ets table.
 -spec insert(atom(), tuple()) -> ok.
-insert(Table, Value)->
-  true = ets:insert(Table, Value),
-  ok.
+insert(Table, Value) ->
+    true = ets:insert(Table, Value),
+    ok.
 
 %% @doc Delete entire ets table.
 -spec delete_table(atom()) -> ok.
-delete_table(Table)->
-  true = ets:delete(Table),
-  ok.
+delete_table(Table) ->
+    true = ets:delete(Table),
+    ok.
 
 %% @doc Delete an entry in the ets table.Ets always returns true for this function.
 -spec delete(atom(), term()) -> ok.
 delete(Table, Key) ->
-  ets:delete(Table, Key),
-  ok.
+    ets:delete(Table, Key),
+    ok.
 
 %% @doc Delete entries in the ets table that match the provided spec.
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-  Count = ets:select_delete(Table, MatchSpec),
-  {ok, Count}.
+    Count = ets:select_delete(Table, MatchSpec),
+    {ok, Count}.
 
 %% @doc Backup a specific ets table.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(_Table)->
-  {error, not_implemented}.
+backup_table(_Table) ->
+    {error, not_implemented}.
 
 %% @doc Should backup all ets tables.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-  {error, not_implemented}.
+    {error, not_implemented}.
 
 %% @doc Select from ets using key, value.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-  ets:lookup(Table, Key).
+    ets:lookup(Table, Key).
 
 %% #doc Select from ets using match specs.
 -spec select(atom(), list(), integer() | infinite) -> tuple() | '$end_of_table'.
 select(Table, MatchSpec, infinite) ->
-  ets:select(Table, MatchSpec);
+    ets:select(Table, MatchSpec);
 select(Table, MatchSpec, Limit) ->
-  ets:select(Table, MatchSpec, Limit).
+    ets:select(Table, MatchSpec, Limit).
 
 %% @doc Wrapper for foldl in ets.
--spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-  ets:foldl(Fun, Acc, Table).
+    ets:foldl(Fun, Acc, Table).
 
 %% @doc Empty ets table. Ets always returns true for this function.
 -spec empty_table(atom()) -> ok.
 empty_table(Table) ->
-  ets:delete_all_objects(Table),
-  ok.
+    ets:delete_all_objects(Table),
+    ok.
 
 %% @doc Lists the ets table
 -spec list_table(atom()) -> term() | {error, term()}.
 list_table(TableName) ->
-  try ets:tab2list(TableName)
-  catch
-    error:R ->
-      {error, R}
-  end.
+    try
+        ets:tab2list(TableName)
+    catch
+        error:R ->
+            {error, R}
+    end.
 
 %% Internal methods
 -spec create_ets_table(ets:tab(), ets:type()) -> ok | {error, Reason :: term()}.
 create_ets_table(Name, Type) ->
-  case ets:info(Name) of
-    undefined ->
-      case ets:new(Name, [Type, public, named_table]) of
-        Name ->
-          ok;
-        Error ->
-          {error, Error}
-      end;
-    _InfoList ->
-      ok
-  end.
+    case ets:info(Name) of
+        undefined ->
+            case ets:new(Name, [Type, public, named_table]) of
+                Name ->
+                    ok;
+                Error ->
+                    {error, Error}
+            end;
+        _InfoList ->
+            ok
+    end.

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -32,104 +32,105 @@
 %% @doc Create ets table wrapper. Use match cases for adding different options to the table.
 -spec create(atom()) -> ok | not_implemented | {error, Reason :: term()}.
 create(schema) ->
-  not_implemented;
+    not_implemented;
 create(Name = zones) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = zone_records_typed) ->
-  create_ets_table(Name, ordered_set);
+    create_ets_table(Name, ordered_set);
 create(Name = authorities) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 %% These tables should always use ets. Due to their functionality
 create(Name = packet_cache) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = host_throttle) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = lookup_table) ->
-  create_ets_table(Name, bag);
+    create_ets_table(Name, bag);
 create(Name = handler_registry) ->
-  create_ets_table(Name, set);
+    create_ets_table(Name, set);
 create(Name = sync_counters) ->
-  create_ets_table(Name, set).
+    create_ets_table(Name, set).
 
 %% @doc Insert value in ets table.
 -spec insert(atom(), tuple()) -> ok.
-insert(Table, Value)->
-  true = ets:insert(Table, Value),
-  ok.
+insert(Table, Value) ->
+    true = ets:insert(Table, Value),
+    ok.
 
 %% @doc Delete entire ets table.
 -spec delete_table(atom()) -> ok.
-delete_table(Table)->
-  true = ets:delete(Table),
-  ok.
+delete_table(Table) ->
+    true = ets:delete(Table),
+    ok.
 
 %% @doc Delete an entry in the ets table.Ets always returns true for this function.
 -spec delete(atom(), term()) -> ok.
 delete(Table, Key) ->
-  ets:delete(Table, Key),
-  ok.
+    ets:delete(Table, Key),
+    ok.
 
 %% @doc Delete entries in the ets table that match the provided spec.
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
 select_delete(Table, MatchSpec) ->
-  Count = ets:select_delete(Table, MatchSpec),
-  {ok, Count}.
+    Count = ets:select_delete(Table, MatchSpec),
+    {ok, Count}.
 
 %% @doc Backup a specific ets table.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(_Table)->
-  {error, not_implemented}.
+backup_table(_Table) ->
+    {error, not_implemented}.
 
 %% @doc Should backup all ets tables.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
 backup_tables() ->
-  {error, not_implemented}.
+    {error, not_implemented}.
 
 %% @doc Select from ets using key, value.
 -spec select(atom(), term()) -> [tuple()].
 select(Table, Key) ->
-  ets:lookup(Table, Key).
+    ets:lookup(Table, Key).
 
 %% #doc Select from ets using match specs.
 -spec select(atom(), list(), integer() | infinite) -> tuple() | '$end_of_table'.
 select(Table, MatchSpec, infinite) ->
-  ets:select(Table, MatchSpec);
+    ets:select(Table, MatchSpec);
 select(Table, MatchSpec, Limit) ->
-  ets:select(Table, MatchSpec, Limit).
+    ets:select(Table, MatchSpec, Limit).
 
 %% @doc Wrapper for foldl in ets.
--spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
 foldl(Fun, Acc, Table) ->
-  ets:foldl(Fun, Acc, Table).
+    ets:foldl(Fun, Acc, Table).
 
 %% @doc Empty ets table. Ets always returns true for this function.
 -spec empty_table(atom()) -> ok.
 empty_table(Table) ->
-  ets:delete_all_objects(Table),
-  ok.
+    ets:delete_all_objects(Table),
+    ok.
 
 %% @doc Lists the ets table
 -spec list_table(atom()) -> term() | {error, term()}.
 list_table(TableName) ->
-  try ets:tab2list(TableName)
-  catch
-    error:R ->
-      {error, R}
-  end.
+    try
+        ets:tab2list(TableName)
+    catch
+        error:R ->
+            {error, R}
+    end.
 
 %% Internal methods
 -spec create_ets_table(ets:tab(), ets:type()) -> ok | {error, Reason :: term()}.
 create_ets_table(Name, Type) ->
-  case ets:info(Name) of
-    undefined ->
-      case ets:new(Name, [Type, public, named_table]) of
-        Name ->
-          ok;
-        Error ->
-          {error, Error}
-      end;
-    _InfoList ->
-      ok
-  end.
+    case ets:info(Name) of
+        undefined ->
+            case ets:new(Name, [Type, public, named_table]) of
+                Name ->
+                    ok;
+                Error ->
+                    {error, Error}
+            end;
+        _InfoList ->
+            ok
+    end.

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -1,4 +1,5 @@
 %% Copyright (c) 2015, SiftLogic LLC
+%% Copyright (c) 2015-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -38,291 +38,282 @@
 %% if schema is created, or if it already exists.
 %% @end
 create(schema) ->
-    ok = ensure_mnesia_started(),
+  ok = ensure_mnesia_started(),
     case erldns_config:storage_dir() of
-        undefined ->
-            lager:error("You need to add a directory for mnesia in erldns.config");
-        Dir ->
-            ok = filelib:ensure_dir(Dir),
-            ok = application:set_env(mnesia, dir, Dir)
+	undefined ->
+	    lager:error("You need to add a directory for mnesia in erldns.config");
+	Dir ->
+	    ok = filelib:ensure_dir(Dir),
+	    ok = application:set_env(mnesia, dir, Dir)
     end,
+
     Connected = nodes(),
     lager:debug("Creating schema ~p", [Connected]),
     case Connected of
-        [] ->
-            application:stop(mnesia),
-            case mnesia:create_schema([node()]) of
-                {error, {_, {already_exists, _}}} ->
-                    lager:warning("The schema already exists (node: ~p)", [node()]),
-                    ok;
-                ok ->
-                    lager:debug("Created the schema on this node ~p", [mnesia:system_info()]),
-                    ok
-            end;
-        _ ->
-            lager:debug("Adding extra db_nodes ~p", [Connected]),
-            mnesia:change_config(extra_db_nodes, Connected),
-            lager:debug("Waiting for tables"),
-            WaitResult = mnesia:wait_for_tables([zones, zone_records_typed, authorities], 5000),
-            lager:debug("Wait result ~p", [WaitResult]),
-            Tables = mnesia:system_info(tables),
-            lager:debug("Current tables ~p", [Tables]),
-            case Tables of
-                [] ->
-                    application:stop(mnesia),
-                    case mnesia:create_schema([node()]) of
-                        {error, {_, {already_exists, _}}} ->
-                            lager:warning("The schema already exists (node: ~p)", [node()]),
-                            ok;
-                        ok ->
-                            lager:debug("Created the schema on this node with other connected nodes ~p", [mnesia:system_info()]),
-                            ok
-                    end;
-                _ ->
-                    Schema = mnesia:change_table_copy_type(schema, node(), disc_copies),
-                    Copy = lists:foldl(fun(Table, Acc) -> Acc ++ [mnesia:add_table_copy(Table, node(), disc_copies)] end, [], Tables -- [schema]),
-                    lager:debug("Copy done Schema= ~p, Others=~p", [Schema, Copy])
-            end
+	[] ->
+	    application:stop(mnesia),
+	    case mnesia:create_schema([node()]) of
+		{error, {_, {already_exists, _}}} ->
+		    lager:warning("The schema already exists (node: ~p)", [node()]),
+		    ok;
+		ok ->
+		    lager:debug("Created the schema on this node ~p", [mnesia:system_info()]),
+		    ok
+	    end;
+	_ ->	    
+	    lager:debug("Adding extra db_nodes ~p", [Connected]),
+	    mnesia:change_config(extra_db_nodes, Connected),
+	    lager:debug("Waiting for tables"),
+	    WaitResult = mnesia:wait_for_tables([zones, zone_records_typed, authorities], 5000),
+	    lager:debug("Wait result ~p", [WaitResult]),
+	    Tables = mnesia:system_info(tables),
+	    lager:debug("Current tables ~p", [Tables]),
+	    case Tables of
+		[] ->
+		    application:stop(mnesia),
+		    case mnesia:create_schema([node()]) of
+			{error, {_, {already_exists, _}}} ->
+			    lager:warning("The schema already exists (node: ~p)", [node()]),
+			    ok;
+			ok ->
+			    lager:debug("Created the schema on this node with other connected nodes ~p", [mnesia:system_info()]),
+			    ok
+		    end;
+		_ ->
+		    Schema = mnesia:change_table_copy_type(schema, node(), disc_copies),
+		    Copy = lists:foldl(fun(Table, Acc) ->
+					       Acc ++ [mnesia:add_table_copy(Table, node(), disc_copies)]
+				       end, [], Tables --[schema]),
+		    lager:debug("Copy done Schema= ~p, Others=~p", [Schema, Copy])
+	    end
     end,
     ok = ensure_mnesia_started();
+
 %% @doc Match the table names for every create. This enables different records to be used and
 %% attributes to be sent to the tables.
 %% @end
+
 %% @doc Zones table has a discrepancy between record name, and table name. Be sure to use necesssary
 %% functions for this difference.
 %% @end
 create(zones) ->
-    ok = ensure_mnesia_started(),
-    case mnesia:create_table(zones, [{attributes, record_info(fields, zone)}, {record_name, zone}, {type, set}, {disc_copies, [node()]}]) of
-        {aborted, {already_exists, zones}} ->
-            lager:warning("The zone table already exists (node: ~p)", [node()]),
-            ok;
-        {atomic, ok} ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+  ok = ensure_mnesia_started(),
+  case mnesia:create_table(zones,
+                           [{attributes, record_info(fields, zone)},
+                            {record_name, zone},
+			    {type, set},
+                            {disc_copies, [node()]}]) of
+    {aborted, {already_exists, zones}} ->
+      lager:warning("The zone table already exists (node: ~p)", [node()]),
+      ok;
+    {atomic, ok} ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 create(zone_records_typed) ->
-    case mnesia:create_table(zone_records_typed, [{attributes, record_info(fields, zone_records_typed)}, {disc_copies, [node()]}, {type, bag}]) of
-        {aborted, {already_exists, zone_records_typed}} ->
-            lager:warning("The zone records typed table already exists (node: ~p)", [node()]),
-            ok;
-        {atomic, ok} ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+  case mnesia:create_table(zone_records_typed,
+                           [{attributes, record_info(fields, zone_records_typed)},
+                            {disc_copies, [node()]},
+			    {type, bag}
+			   ]) of
+    {aborted, {already_exists, zone_records_typed}} ->
+      lager:warning("The zone records typed table already exists (node: ~p)", [node()]),
+      ok;
+    {atomic, ok} ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 create(authorities) ->
-    ok = ensure_mnesia_started(),
-    case mnesia:create_table(authorities, [{attributes, record_info(fields, authorities)}, {disc_copies, [node()]}]) of
-        {aborted, {already_exists, authorities}} ->
-            lager:warning("The authority table already exists (node: ~p)", [node()]),
-            ok;
-        {atomic, ok} ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+  ok = ensure_mnesia_started(),
+  case mnesia:create_table(authorities,
+                           [{attributes, record_info(fields, authorities)},
+                            {disc_copies, [node()]}]) of
+    {aborted, {already_exists, authorities}} ->
+      lager:warning("The authority table already exists (node: ~p)", [node()]),
+      ok;
+    {atomic, ok} ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 create(sync_counters) ->
-    ok = ensure_mnesia_started(),
-    case mnesia:create_table(sync_counters, [{attributes, record_info(fields, sync_counters)}, {disc_copies, [node()]}]) of
-        {aborted, {already_exists, sync_counters}} ->
-            lager:warning("The sync_counters table already exists (node: ~p)", [node()]),
-            ok;
-        {atomic, ok} ->
-            ok;
-        Error ->
-            {error, Error}
-    end.
+  ok = ensure_mnesia_started(),
+  case mnesia:create_table(sync_counters,
+                           [{attributes, record_info(fields, sync_counters)},
+                            {disc_copies, [node()]}]) of
+    {aborted, {already_exists, sync_counters}} ->
+      lager:warning("The sync_counters table already exists (node: ~p)", [node()]),
+      ok;
+    {atomic, ok} ->
+      ok;
+    Error ->
+      {error, Error}
+  end.
 
 %% @doc Insert into specified table. zone_cache calls this by {name, #zone{}}
 -spec insert(atom(), any()) -> any().
-insert(zones, #zone{} = Zone) ->
-    Write = fun() -> mnesia:write(zones, Zone, write) end,
-    case mnesia:activity(transaction, Write) of
-        ok ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
-insert(zones, {_N, #zone{} = Zone}) ->
-    Write = fun() -> mnesia:write(zones, Zone, write) end,
-    case mnesia:activity(transaction, Write) of
-        ok ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+insert(zones, #zone{} = Zone)->
+  Write = fun() -> mnesia:write(zones, Zone, write) end,
+  case mnesia:activity(transaction, Write) of
+    ok ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
+insert(zones, {_N, #zone{} = Zone})->
+  Write = fun() -> mnesia:write(zones, Zone, write) end,
+  case mnesia:activity(transaction, Write) of
+    ok ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 insert(zone_records_typed, {{ZoneName, Fqdn, Type}, Records}) ->
-    Write =
-        fun() ->
-           mnesia:write(zone_records_typed,
-                        #zone_records_typed{zone_name = ZoneName,
-                                            fqdn = Fqdn,
-                                            records = Records,
-                                            type = Type},
-                        write)
-        end,
-    case mnesia:activity(transaction, Write) of
-        ok ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+  Write = fun() -> mnesia:write(zone_records_typed, #zone_records_typed{zone_name = ZoneName, fqdn = Fqdn, records = Records, type = Type}, write) end,
+  case mnesia:activity(transaction, Write) of
+    ok ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 insert(authorities, #authorities{} = Auth) ->
-    Write = fun() -> mnesia:write(authorities, Auth, write) end,
-    case mnesia:activity(transaction, Write) of
-        ok ->
-            ok;
-        Error ->
-            {error, Error}
-    end;
+  Write = fun() -> mnesia:write(authorities, Auth, write) end,
+  case mnesia:activity(transaction, Write) of
+    ok ->
+      ok;
+    Error ->
+      {error, Error}
+  end;
 insert(sync_counters, {counter, Counter}) ->
-    Write = fun() -> mnesia:write(sync_counters, {counter, Counter}, write) end,
-    case mnesia:activity(transaction, Write) of
-        ok ->
-            ok;
-        Error ->
-            {error, Error}
-    end.
+  Write = fun() -> mnesia:write(sync_counters, {counter, Counter}, write) end,
+  case mnesia:activity(transaction, Write) of
+    ok ->
+      ok;
+    Error ->
+      {error, Error}
+  end.
 
 %% @doc delete the entire table.
 -spec delete_table(atom()) -> ok | {aborted, any()}.
 delete_table(Table) ->
-    case mnesia:delete_table(Table) of
-        {atomic, ok} ->
-            ok;
-        {aborted, Reason} ->
-            {error, Reason}
-    end.
+  case mnesia:delete_table(Table) of
+    {atomic, ok} ->
+      ok;
+    {aborted, Reason} ->
+      {error, Reason}
+  end.
 
 %% @doc Delete a mnesia record, have to do things different for zones since we specified {record_name, zone}
 %% in the table creation.
 -spec delete(Table :: atom(), Key :: term()) -> ok | any().
-delete(zones, Key) ->
-    mnesia:dirty_delete({zones, Key});
-delete(Table, Key) ->
-    case mnesia:is_transaction() of
-        true ->
-            Delete = fun() -> mnesia:delete({Table, Key}) end,
-            mnesia:activity(transaction, Delete);
-        false ->
-            mnesia:dirty_delete({Table, Key})
-    end.
+delete(zones, Key)->
+  mnesia:dirty_delete({zones, Key});
+delete(Table, Key)->
+  case mnesia:is_transaction() of
+    true ->
+      Delete = fun() -> mnesia:delete({Table, Key}) end,
+      mnesia:activity(transaction, Delete);
+    false ->
+      mnesia:dirty_delete({Table, Key})
+  end.
 
 %% @doc Delete all zone records or zone records typed based on the match spec. The match spec
 %% is given as an ETS match spec, thus it needs to be converted to a record match spec for
 %% Mnesia.
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
-select_delete(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}]) ->
-    SelectDelete =
-        fun() ->
-           Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write),
-           lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
-           {ok, length(Records)}
-        end,
-    mnesia:activity(transaction, SelectDelete).
+select_delete(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}])->
+  SelectDelete = fun() ->
+                     Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write),
+                     lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
+                     {ok, length(Records)}
+                 end,
+  mnesia:activity(transaction, SelectDelete).
 
 %%
 %% @doc Should backup the tables in the schema.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(_Table) ->
-    Backup = fun() -> mnesia:backup(mnesia:schema()) end,
-    mnesia:activity(transaction, Backup).
+backup_table(_Table)->
+  Backup = fun() -> mnesia:backup(mnesia:schema()) end,
+  mnesia:activity(transaction, Backup).
 
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
-backup_tables() ->
-    {error, not_implemented}.
+backup_tables()->
+  {error, not_implemented}.
 
 %% @doc Select based on key value.
 -spec select(Table :: atom(), Key :: term()) -> [tuple()].
-select(Table, Key) ->
-    Select =
-        fun() ->
-           case mnesia:read({Table, Key}) of
-               [Record] -> [{Key, Record}];
-               _ -> []
-           end
-        end,
-    mnesia:activity(transaction, Select).
+select(Table, Key)->
+  Select = fun () ->
+               case mnesia:read({Table, Key}) of
+                 [Record] -> [{Key,Record}];
+                 _ -> []
+               end
+           end,
+  mnesia:activity(transaction, Select).
 
 %% @doc Select using ETS match spec converted to Mnesia's match_object pattern
 -spec select(atom(), list(), infinite | integer()) -> [tuple()].
 select(Table, [{{{ZoneName, Fqdn}, _}, _, _}], _Limit) ->
-    SelectFun =
-        fun() ->
-           Records = mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, read),
-           [Record || {_, _, _, Record} <- Records]
-        end,
-    mnesia:activity(transaction, SelectFun);
+  SelectFun = fun() ->
+    Records  = mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, read),
+    [Record || {_, _, _, Record} <- Records] 
+  end,
+  mnesia:activity(transaction, SelectFun);
 select(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}], _Limit) ->
-    SelectFun =
-        fun() ->
-           Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
-           [Record || {_, _, _, _, Record} <- Records]
-        end,
-    mnesia:activity(transaction, SelectFun).
+  SelectFun = fun() ->
+     Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
+     [Record || {_, _, _, _, Record} <- Records] 
+  end,
+  mnesia:activity(transaction, SelectFun).
 
 %% @doc Wrapper for foldl.
--spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
 foldl(Iterator, _Acc, Table) ->
-    Exec = fun() -> mnesia:foldl(Iterator, [], Table) end,
-    case mnesia:is_transaction() of
-        true ->
-            Exec();
-        false ->
-            mnesia:activity(transaction, Exec)
-    end.
+  Exec = fun() -> mnesia:foldl(Iterator, [], Table) end,
+  case mnesia:is_transaction() of
+    true ->
+      Exec();
+    false ->
+      mnesia:activity(transaction, Exec)
+  end.
 
 %% @doc Clear all objects from given table in mnesia DB.
 -spec empty_table(atom()) -> ok | {aborted, term()}.
 empty_table(Table) ->
-    case mnesia:clear_table(Table) of
-        {atomic, ok} ->
-            ok;
-        {aborted, Reason} ->
-            {error, Reason}
-    end.
+  case mnesia:clear_table(Table) of
+    {atomic, ok} ->
+      ok;
+    {aborted, Reason} ->
+      {error, Reason}
+  end.
 
 %% @doc Lists the contents of the given table.
--spec list_table(atom()) -> [] | [#zone{}] | [#authorities{}] | [tuple()] | {error, doesnt_exist}.
+-spec list_table(atom()) ->
+  [] | [#zone{}] | [#authorities{}] | [tuple()] | {error, doesnt_exist}.
 list_table(zones) ->
-    Pattern =
-        #zone{name = '_',
-              version = '_',
-              authority = '_',
-              record_count = '_',
-              records = '_',
-              records_by_name = '_',
-              records_by_type = '_'},
-    mnesia:dirty_match_object(zones, Pattern);
+  Pattern = #zone{name ='_', version = '_', authority = '_', record_count = '_',
+                  records = '_', records_by_name = '_', records_by_type = '_'},
+  mnesia:dirty_match_object(zones, Pattern);
 list_table(authorities) ->
-    Pattern =
-        #authorities{owner_name = '_',
-                     ttl = '_',
-                     class = '_',
-                     name_server = '_',
-                     email_addr = '_',
-                     serial_num = '_',
-                     refresh = '_',
-                     retry = '_',
-                     expiry = '_',
-                     nxdomain = '_'},
-    select(authorities, Pattern, 0);
+  Pattern = #authorities{owner_name = '_', ttl = '_', class = '_', name_server = '_', email_addr = '_',
+                         serial_num = '_', refresh = '_', retry = '_', expiry = '_', nxdomain = '_'},
+  select(authorities, Pattern, 0);
 list_table(_Name) ->
-    {error, doesnt_exist}.
+  {error, doesnt_exist}.
 
 %% Private
 %% @doc Checks if mnesia is started, if not if starts mnesia.
 -spec ensure_mnesia_started() -> ok | {error, any()}.
 ensure_mnesia_started() ->
-    case application:start(mnesia) of
-        ok ->
-            ok;
-        {error, {already_started, mnesia}} ->
-            ok;
-        {error, Reason} ->
-            {error, Reason}
-    end.
+  case application:start(mnesia) of
+    ok ->
+      ok;
+    {error,{already_started, mnesia}} ->
+      ok;
+    {error, Reason} ->
+      {error, Reason}
+  end.

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -39,282 +39,292 @@
 %% if schema is created, or if it already exists.
 %% @end
 create(schema) ->
-  ok = ensure_mnesia_started(),
+    ok = ensure_mnesia_started(),
     case erldns_config:storage_dir() of
-	undefined ->
-	    lager:error("You need to add a directory for mnesia in erldns.config");
-	Dir ->
-	    ok = filelib:ensure_dir(Dir),
-	    ok = application:set_env(mnesia, dir, Dir)
+        undefined ->
+            lager:error("You need to add a directory for mnesia in erldns.config");
+        Dir ->
+            ok = filelib:ensure_dir(Dir),
+            ok = application:set_env(mnesia, dir, Dir)
     end,
 
     Connected = nodes(),
     lager:debug("Creating schema ~p", [Connected]),
     case Connected of
-	[] ->
-	    application:stop(mnesia),
-	    case mnesia:create_schema([node()]) of
-		{error, {_, {already_exists, _}}} ->
-		    lager:warning("The schema already exists (node: ~p)", [node()]),
-		    ok;
-		ok ->
-		    lager:debug("Created the schema on this node ~p", [mnesia:system_info()]),
-		    ok
-	    end;
-	_ ->	    
-	    lager:debug("Adding extra db_nodes ~p", [Connected]),
-	    mnesia:change_config(extra_db_nodes, Connected),
-	    lager:debug("Waiting for tables"),
-	    WaitResult = mnesia:wait_for_tables([zones, zone_records_typed, authorities], 5000),
-	    lager:debug("Wait result ~p", [WaitResult]),
-	    Tables = mnesia:system_info(tables),
-	    lager:debug("Current tables ~p", [Tables]),
-	    case Tables of
-		[] ->
-		    application:stop(mnesia),
-		    case mnesia:create_schema([node()]) of
-			{error, {_, {already_exists, _}}} ->
-			    lager:warning("The schema already exists (node: ~p)", [node()]),
-			    ok;
-			ok ->
-			    lager:debug("Created the schema on this node with other connected nodes ~p", [mnesia:system_info()]),
-			    ok
-		    end;
-		_ ->
-		    Schema = mnesia:change_table_copy_type(schema, node(), disc_copies),
-		    Copy = lists:foldl(fun(Table, Acc) ->
-					       Acc ++ [mnesia:add_table_copy(Table, node(), disc_copies)]
-				       end, [], Tables --[schema]),
-		    lager:debug("Copy done Schema= ~p, Others=~p", [Schema, Copy])
-	    end
+        [] ->
+            application:stop(mnesia),
+            case mnesia:create_schema([node()]) of
+                {error, {_, {already_exists, _}}} ->
+                    lager:warning("The schema already exists (node: ~p)", [node()]),
+                    ok;
+                ok ->
+                    lager:debug("Created the schema on this node ~p", [mnesia:system_info()]),
+                    ok
+            end;
+        _ ->
+            lager:debug("Adding extra db_nodes ~p", [Connected]),
+            mnesia:change_config(extra_db_nodes, Connected),
+            lager:debug("Waiting for tables"),
+            WaitResult = mnesia:wait_for_tables([zones, zone_records_typed, authorities], 5000),
+            lager:debug("Wait result ~p", [WaitResult]),
+            Tables = mnesia:system_info(tables),
+            lager:debug("Current tables ~p", [Tables]),
+            case Tables of
+                [] ->
+                    application:stop(mnesia),
+                    case mnesia:create_schema([node()]) of
+                        {error, {_, {already_exists, _}}} ->
+                            lager:warning("The schema already exists (node: ~p)", [node()]),
+                            ok;
+                        ok ->
+                            lager:debug("Created the schema on this node with other connected nodes ~p", [mnesia:system_info()]),
+                            ok
+                    end;
+                _ ->
+                    Schema = mnesia:change_table_copy_type(schema, node(), disc_copies),
+                    Copy = lists:foldl(fun(Table, Acc) -> Acc ++ [mnesia:add_table_copy(Table, node(), disc_copies)] end, [], Tables -- [schema]),
+                    lager:debug("Copy done Schema= ~p, Others=~p", [Schema, Copy])
+            end
     end,
     ok = ensure_mnesia_started();
-
 %% @doc Match the table names for every create. This enables different records to be used and
 %% attributes to be sent to the tables.
 %% @end
-
 %% @doc Zones table has a discrepancy between record name, and table name. Be sure to use necesssary
 %% functions for this difference.
 %% @end
 create(zones) ->
-  ok = ensure_mnesia_started(),
-  case mnesia:create_table(zones,
-                           [{attributes, record_info(fields, zone)},
-                            {record_name, zone},
-			    {type, set},
-                            {disc_copies, [node()]}]) of
-    {aborted, {already_exists, zones}} ->
-      lager:warning("The zone table already exists (node: ~p)", [node()]),
-      ok;
-    {atomic, ok} ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+    ok = ensure_mnesia_started(),
+    case mnesia:create_table(zones, [{attributes, record_info(fields, zone)}, {record_name, zone}, {type, set}, {disc_copies, [node()]}]) of
+        {aborted, {already_exists, zones}} ->
+            lager:warning("The zone table already exists (node: ~p)", [node()]),
+            ok;
+        {atomic, ok} ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 create(zone_records_typed) ->
-  case mnesia:create_table(zone_records_typed,
-                           [{attributes, record_info(fields, zone_records_typed)},
-                            {disc_copies, [node()]},
-			    {type, bag}
-			   ]) of
-    {aborted, {already_exists, zone_records_typed}} ->
-      lager:warning("The zone records typed table already exists (node: ~p)", [node()]),
-      ok;
-    {atomic, ok} ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+    case mnesia:create_table(zone_records_typed, [{attributes, record_info(fields, zone_records_typed)}, {disc_copies, [node()]}, {type, bag}]) of
+        {aborted, {already_exists, zone_records_typed}} ->
+            lager:warning("The zone records typed table already exists (node: ~p)", [node()]),
+            ok;
+        {atomic, ok} ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 create(authorities) ->
-  ok = ensure_mnesia_started(),
-  case mnesia:create_table(authorities,
-                           [{attributes, record_info(fields, authorities)},
-                            {disc_copies, [node()]}]) of
-    {aborted, {already_exists, authorities}} ->
-      lager:warning("The authority table already exists (node: ~p)", [node()]),
-      ok;
-    {atomic, ok} ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+    ok = ensure_mnesia_started(),
+    case mnesia:create_table(authorities, [{attributes, record_info(fields, authorities)}, {disc_copies, [node()]}]) of
+        {aborted, {already_exists, authorities}} ->
+            lager:warning("The authority table already exists (node: ~p)", [node()]),
+            ok;
+        {atomic, ok} ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 create(sync_counters) ->
-  ok = ensure_mnesia_started(),
-  case mnesia:create_table(sync_counters,
-                           [{attributes, record_info(fields, sync_counters)},
-                            {disc_copies, [node()]}]) of
-    {aborted, {already_exists, sync_counters}} ->
-      lager:warning("The sync_counters table already exists (node: ~p)", [node()]),
-      ok;
-    {atomic, ok} ->
-      ok;
-    Error ->
-      {error, Error}
-  end.
+    ok = ensure_mnesia_started(),
+    case mnesia:create_table(sync_counters, [{attributes, record_info(fields, sync_counters)}, {disc_copies, [node()]}]) of
+        {aborted, {already_exists, sync_counters}} ->
+            lager:warning("The sync_counters table already exists (node: ~p)", [node()]),
+            ok;
+        {atomic, ok} ->
+            ok;
+        Error ->
+            {error, Error}
+    end.
 
 %% @doc Insert into specified table. zone_cache calls this by {name, #zone{}}
 -spec insert(atom(), any()) -> any().
-insert(zones, #zone{} = Zone)->
-  Write = fun() -> mnesia:write(zones, Zone, write) end,
-  case mnesia:activity(transaction, Write) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
-insert(zones, {_N, #zone{} = Zone})->
-  Write = fun() -> mnesia:write(zones, Zone, write) end,
-  case mnesia:activity(transaction, Write) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+insert(zones, #zone{} = Zone) ->
+    Write = fun() -> mnesia:write(zones, Zone, write) end,
+    case mnesia:activity(transaction, Write) of
+        ok ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
+insert(zones, {_N, #zone{} = Zone}) ->
+    Write = fun() -> mnesia:write(zones, Zone, write) end,
+    case mnesia:activity(transaction, Write) of
+        ok ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 insert(zone_records_typed, {{ZoneName, Fqdn, Type}, Records}) ->
-  Write = fun() -> mnesia:write(zone_records_typed, #zone_records_typed{zone_name = ZoneName, fqdn = Fqdn, records = Records, type = Type}, write) end,
-  case mnesia:activity(transaction, Write) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+    Write =
+        fun() ->
+           mnesia:write(zone_records_typed,
+                        #zone_records_typed{zone_name = ZoneName,
+                                            fqdn = Fqdn,
+                                            records = Records,
+                                            type = Type},
+                        write)
+        end,
+    case mnesia:activity(transaction, Write) of
+        ok ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 insert(authorities, #authorities{} = Auth) ->
-  Write = fun() -> mnesia:write(authorities, Auth, write) end,
-  case mnesia:activity(transaction, Write) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+    Write = fun() -> mnesia:write(authorities, Auth, write) end,
+    case mnesia:activity(transaction, Write) of
+        ok ->
+            ok;
+        Error ->
+            {error, Error}
+    end;
 insert(sync_counters, {counter, Counter}) ->
-  Write = fun() -> mnesia:write(sync_counters, {counter, Counter}, write) end,
-  case mnesia:activity(transaction, Write) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end.
+    Write = fun() -> mnesia:write(sync_counters, {counter, Counter}, write) end,
+    case mnesia:activity(transaction, Write) of
+        ok ->
+            ok;
+        Error ->
+            {error, Error}
+    end.
 
 %% @doc delete the entire table.
 -spec delete_table(atom()) -> ok | {aborted, any()}.
 delete_table(Table) ->
-  case mnesia:delete_table(Table) of
-    {atomic, ok} ->
-      ok;
-    {aborted, Reason} ->
-      {error, Reason}
-  end.
+    case mnesia:delete_table(Table) of
+        {atomic, ok} ->
+            ok;
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
 
 %% @doc Delete a mnesia record, have to do things different for zones since we specified {record_name, zone}
 %% in the table creation.
 -spec delete(Table :: atom(), Key :: term()) -> ok | any().
-delete(zones, Key)->
-  mnesia:dirty_delete({zones, Key});
-delete(Table, Key)->
-  case mnesia:is_transaction() of
-    true ->
-      Delete = fun() -> mnesia:delete({Table, Key}) end,
-      mnesia:activity(transaction, Delete);
-    false ->
-      mnesia:dirty_delete({Table, Key})
-  end.
+delete(zones, Key) ->
+    mnesia:dirty_delete({zones, Key});
+delete(Table, Key) ->
+    case mnesia:is_transaction() of
+        true ->
+            Delete = fun() -> mnesia:delete({Table, Key}) end,
+            mnesia:activity(transaction, Delete);
+        false ->
+            mnesia:dirty_delete({Table, Key})
+    end.
 
 %% @doc Delete all zone records or zone records typed based on the match spec. The match spec
 %% is given as an ETS match spec, thus it needs to be converted to a record match spec for
 %% Mnesia.
 -spec select_delete(atom(), list()) -> {ok, Count :: integer()} | {error, Reason :: term()}.
-select_delete(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}])->
-  SelectDelete = fun() ->
-                     Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write),
-                     lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
-                     {ok, length(Records)}
-                 end,
-  mnesia:activity(transaction, SelectDelete).
+select_delete(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}]) ->
+    SelectDelete =
+        fun() ->
+           Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, write),
+           lists:foreach(fun(R) -> mnesia:dirty_delete_object(R) end, Records),
+           {ok, length(Records)}
+        end,
+    mnesia:activity(transaction, SelectDelete).
 
 %%
 %% @doc Should backup the tables in the schema.
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_table(atom()) -> ok | {error, Reason :: term()}.
-backup_table(_Table)->
-  Backup = fun() -> mnesia:backup(mnesia:schema()) end,
-  mnesia:activity(transaction, Backup).
+backup_table(_Table) ->
+    Backup = fun() -> mnesia:backup(mnesia:schema()) end,
+    mnesia:activity(transaction, Backup).
 
 %% @see https://github.com/SiftLogic/erl-dns/issues/3
 -spec backup_tables() -> ok | {error, Reason :: term()}.
-backup_tables()->
-  {error, not_implemented}.
+backup_tables() ->
+    {error, not_implemented}.
 
 %% @doc Select based on key value.
 -spec select(Table :: atom(), Key :: term()) -> [tuple()].
-select(Table, Key)->
-  Select = fun () ->
-               case mnesia:read({Table, Key}) of
-                 [Record] -> [{Key,Record}];
-                 _ -> []
-               end
-           end,
-  mnesia:activity(transaction, Select).
+select(Table, Key) ->
+    Select =
+        fun() ->
+           case mnesia:read({Table, Key}) of
+               [Record] -> [{Key, Record}];
+               _ -> []
+           end
+        end,
+    mnesia:activity(transaction, Select).
 
 %% @doc Select using ETS match spec converted to Mnesia's match_object pattern
 -spec select(atom(), list(), infinite | integer()) -> [tuple()].
 select(Table, [{{{ZoneName, Fqdn}, _}, _, _}], _Limit) ->
-  SelectFun = fun() ->
-    Records  = mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, read),
-    [Record || {_, _, _, Record} <- Records] 
-  end,
-  mnesia:activity(transaction, SelectFun);
+    SelectFun =
+        fun() ->
+           Records = mnesia:match_object(Table, {zone_records, ZoneName, Fqdn, '_'}, read),
+           [Record || {_, _, _, Record} <- Records]
+        end,
+    mnesia:activity(transaction, SelectFun);
 select(Table, [{{{ZoneName, Fqdn, Type}, _}, _, _}], _Limit) ->
-  SelectFun = fun() ->
-     Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
-     [Record || {_, _, _, _, Record} <- Records] 
-  end,
-  mnesia:activity(transaction, SelectFun).
+    SelectFun =
+        fun() ->
+           Records = mnesia:match_object(Table, {zone_records_typed, ZoneName, Fqdn, Type, '_'}, read),
+           [Record || {_, _, _, _, Record} <- Records]
+        end,
+    mnesia:activity(transaction, SelectFun).
 
 %% @doc Wrapper for foldl.
--spec foldl(fun(), list(), atom())  -> Acc :: term() | {error, Reason :: term()}.
+-spec foldl(fun(), list(), atom()) -> Acc :: term() | {error, Reason :: term()}.
 foldl(Iterator, _Acc, Table) ->
-  Exec = fun() -> mnesia:foldl(Iterator, [], Table) end,
-  case mnesia:is_transaction() of
-    true ->
-      Exec();
-    false ->
-      mnesia:activity(transaction, Exec)
-  end.
+    Exec = fun() -> mnesia:foldl(Iterator, [], Table) end,
+    case mnesia:is_transaction() of
+        true ->
+            Exec();
+        false ->
+            mnesia:activity(transaction, Exec)
+    end.
 
 %% @doc Clear all objects from given table in mnesia DB.
 -spec empty_table(atom()) -> ok | {aborted, term()}.
 empty_table(Table) ->
-  case mnesia:clear_table(Table) of
-    {atomic, ok} ->
-      ok;
-    {aborted, Reason} ->
-      {error, Reason}
-  end.
+    case mnesia:clear_table(Table) of
+        {atomic, ok} ->
+            ok;
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
 
 %% @doc Lists the contents of the given table.
--spec list_table(atom()) ->
-  [] | [#zone{}] | [#authorities{}] | [tuple()] | {error, doesnt_exist}.
+-spec list_table(atom()) -> [] | [#zone{}] | [#authorities{}] | [tuple()] | {error, doesnt_exist}.
 list_table(zones) ->
-  Pattern = #zone{name ='_', version = '_', authority = '_', record_count = '_',
-                  records = '_', records_by_name = '_', records_by_type = '_'},
-  mnesia:dirty_match_object(zones, Pattern);
+    Pattern =
+        #zone{name = '_',
+              version = '_',
+              authority = '_',
+              record_count = '_',
+              records = '_',
+              records_by_name = '_',
+              records_by_type = '_'},
+    mnesia:dirty_match_object(zones, Pattern);
 list_table(authorities) ->
-  Pattern = #authorities{owner_name = '_', ttl = '_', class = '_', name_server = '_', email_addr = '_',
-                         serial_num = '_', refresh = '_', retry = '_', expiry = '_', nxdomain = '_'},
-  select(authorities, Pattern, 0);
+    Pattern =
+        #authorities{owner_name = '_',
+                     ttl = '_',
+                     class = '_',
+                     name_server = '_',
+                     email_addr = '_',
+                     serial_num = '_',
+                     refresh = '_',
+                     retry = '_',
+                     expiry = '_',
+                     nxdomain = '_'},
+    select(authorities, Pattern, 0);
 list_table(_Name) ->
-  {error, doesnt_exist}.
+    {error, doesnt_exist}.
 
 %% Private
 %% @doc Checks if mnesia is started, if not if starts mnesia.
 -spec ensure_mnesia_started() -> ok | {error, any()}.
 ensure_mnesia_started() ->
-  case application:start(mnesia) of
-    ok ->
-      ok;
-    {error,{already_started, mnesia}} ->
-      ok;
-    {error, Reason} ->
-      {error, Reason}
-  end.
+    case application:start(mnesia) of
+        ok ->
+            ok;
+        {error, {already_started, mnesia}} ->
+            ok;
+        {error, Reason} ->
+            {error, Reason}
+    end.

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -15,52 +15,71 @@
 %% @doc Application supervisor. Supervises everything except the UDP and TCP
 %% listeners and the zone checker.
 -module(erldns_sup).
-
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
--export([gc/0,
+
+-export([
+         gc/0,
          gc_registered/0,
-         gc_registered/1]).
+         gc_registered/1
+        ]).
+
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
+
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 -spec start_link() -> any().
 start_link() ->
-    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 %% @doc Garbage collect all processes.
 -spec gc() -> integer().
 gc() ->
-    length(lists:map(fun(Pid) -> garbage_collect(Pid) end, processes())).
+  length(
+    lists:map(
+      fun(Pid) ->
+          garbage_collect(Pid)
+      end,
+      processes())
+   ).
 
 %% @doc Garbage collect all registered processes.
 -spec gc_registered() -> integer().
 gc_registered() ->
-    length(lists:map(fun(ProcessName) -> gc_registered(ProcessName) end, registered())).
+  length(
+    lists:map(
+      fun(ProcessName) ->
+          gc_registered(ProcessName)
+      end,
+      registered())
+   ).
 
 %% @doc Garbage collect a named process.
 -spec gc_registered(atom()) -> ok.
 gc_registered(ProcessName) ->
-    Pid = whereis(ProcessName),
-    garbage_collect(Pid),
-    ok.
+  Pid = whereis(ProcessName),
+  garbage_collect(Pid),
+  ok.
+
 
 %% Callbacks
 init(_Args) ->
-    SysProcs =
-        [?CHILD(erldns_events, worker, []),
-         ?CHILD(erldns_zone_cache, worker, []),
-         ?CHILD(erldns_zone_parser, worker, []),
-         ?CHILD(erldns_zone_encoder, worker, []),
-         ?CHILD(erldns_packet_cache, worker, []),
-         ?CHILD(erldns_query_throttle, worker, []),
-         ?CHILD(erldns_handler, worker, []),
-         ?CHILD(sample_custom_handler, worker, [])],
-    {ok, {{one_for_one, 20, 10}, SysProcs}}.
+  SysProcs = [
+              ?CHILD(erldns_events, worker, []),
+              ?CHILD(erldns_zone_cache, worker, []),
+              ?CHILD(erldns_zone_parser, worker, []),
+              ?CHILD(erldns_zone_encoder, worker, []),
+              ?CHILD(erldns_packet_cache, worker, []),
+              ?CHILD(erldns_query_throttle, worker, []),
+              ?CHILD(erldns_handler, worker, []),
+              ?CHILD(sample_custom_handler, worker, [])
+             ],
+
+  {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -15,71 +15,53 @@
 %% @doc Application supervisor. Supervises everything except the UDP and TCP
 %% listeners and the zone checker.
 -module(erldns_sup).
+
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
-
--export([
-         gc/0,
+-export([gc/0,
          gc_registered/0,
-         gc_registered/1
-        ]).
-
+         gc_registered/1]).
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
-
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 -spec start_link() -> any().
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 %% @doc Garbage collect all processes.
 -spec gc() -> integer().
 gc() ->
-  length(
-    lists:map(
-      fun(Pid) ->
-          garbage_collect(Pid)
-      end,
-      processes())
-   ).
+    length(lists:map(fun(Pid) -> garbage_collect(Pid) end, processes())).
 
 %% @doc Garbage collect all registered processes.
 -spec gc_registered() -> integer().
 gc_registered() ->
-  length(
-    lists:map(
-      fun(ProcessName) ->
-          gc_registered(ProcessName)
-      end,
-      registered())
-   ).
+    length(lists:map(fun(ProcessName) -> gc_registered(ProcessName) end, registered())).
 
 %% @doc Garbage collect a named process.
 -spec gc_registered(atom()) -> ok.
 gc_registered(ProcessName) ->
-  Pid = whereis(ProcessName),
-  garbage_collect(Pid),
-  ok.
-
+    Pid = whereis(ProcessName),
+    garbage_collect(Pid),
+    ok.
 
 %% Callbacks
 init(_Args) ->
-  SysProcs = [
-              ?CHILD(erldns_events, worker, []),
-              ?CHILD(erldns_zone_cache, worker, []),
-              ?CHILD(erldns_zone_parser, worker, []),
-              ?CHILD(erldns_zone_encoder, worker, []),
-              ?CHILD(erldns_packet_cache, worker, []),
-              ?CHILD(erldns_query_throttle, worker, []),
-              ?CHILD(erldns_handler, worker, []),
-              ?CHILD(sample_custom_handler, worker, [])
-             ],
+    SysProcs =
+        [?CHILD(erldns_events, worker, []),
+         ?CHILD(erldns_zone_cache, worker, []),
+         ?CHILD(erldns_zone_parser, worker, []),
+         ?CHILD(erldns_zone_encoder, worker, []),
+         ?CHILD(erldns_packet_cache, worker, []),
+         ?CHILD(erldns_query_throttle, worker, []),
+         ?CHILD(erldns_handler, worker, []),
+         ?CHILD(sample_custom_handler, worker, [])],
 
-  {ok, {{one_for_one, 20, 10}, SysProcs}}.
+    {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -15,71 +15,52 @@
 %% @doc Application supervisor. Supervises everything except the UDP and TCP
 %% listeners and the zone checker.
 -module(erldns_sup).
+
 -behavior(supervisor).
 
 % API
 -export([start_link/0]).
-
--export([
-         gc/0,
+-export([gc/0,
          gc_registered/0,
-         gc_registered/1
-        ]).
-
+         gc_registered/1]).
 % Supervisor hooks
 -export([init/1]).
 
 -define(SUPERVISOR, ?MODULE).
-
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% Public API
 -spec start_link() -> any().
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 %% @doc Garbage collect all processes.
 -spec gc() -> integer().
 gc() ->
-  length(
-    lists:map(
-      fun(Pid) ->
-          garbage_collect(Pid)
-      end,
-      processes())
-   ).
+    length(lists:map(fun(Pid) -> garbage_collect(Pid) end, processes())).
 
 %% @doc Garbage collect all registered processes.
 -spec gc_registered() -> integer().
 gc_registered() ->
-  length(
-    lists:map(
-      fun(ProcessName) ->
-          gc_registered(ProcessName)
-      end,
-      registered())
-   ).
+    length(lists:map(fun(ProcessName) -> gc_registered(ProcessName) end, registered())).
 
 %% @doc Garbage collect a named process.
 -spec gc_registered(atom()) -> ok.
 gc_registered(ProcessName) ->
-  Pid = whereis(ProcessName),
-  garbage_collect(Pid),
-  ok.
-
+    Pid = whereis(ProcessName),
+    garbage_collect(Pid),
+    ok.
 
 %% Callbacks
 init(_Args) ->
-  SysProcs = [
-              ?CHILD(erldns_events, worker, []),
-              ?CHILD(erldns_zone_cache, worker, []),
-              ?CHILD(erldns_zone_parser, worker, []),
-              ?CHILD(erldns_zone_encoder, worker, []),
-              ?CHILD(erldns_packet_cache, worker, []),
-              ?CHILD(erldns_query_throttle, worker, []),
-              ?CHILD(erldns_handler, worker, []),
-              ?CHILD(sample_custom_handler, worker, [])
-             ],
-
-  {ok, {{one_for_one, 20, 10}, SysProcs}}.
+    SysProcs =
+        [?CHILD(erldns_events, worker, []),
+         ?CHILD(erldns_zone_cache, worker, []),
+         ?CHILD(erldns_zone_parser, worker, []),
+         ?CHILD(erldns_zone_encoder, worker, []),
+         ?CHILD(erldns_packet_cache, worker, []),
+         ?CHILD(erldns_query_throttle, worker, []),
+         ?CHILD(erldns_handler, worker, []),
+         ?CHILD(sample_custom_handler, worker, [])],
+    {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -14,11 +14,11 @@
 
 %% @doc Handles DNS questions arriving via TCP.
 -module(erldns_tcp_server).
-
 -behavior(gen_nb_server).
 
 % API
 -export([start_link/2, start_link/4]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
@@ -27,7 +27,9 @@
          terminate/2,
          sock_opts/0,
          new_connection/2,
-         code_change/3]).
+         code_change/3
+        ]).
+
 % Internal API
 -export([handle_request/3]).
 
@@ -38,65 +40,56 @@
 %% Public API
 -spec start_link(atom(), inet | inet6) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, Family) ->
-    start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
+  start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
 
 -spec start_link(atom(), inet | inet6, inet:ip_address(), inet:port_number()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(_Name, Family, Address, Port) ->
-    lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
-    gen_nb_server:start_link(?MODULE, Address, Port, []).
+  lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
+  gen_nb_server:start_link(?MODULE, Address, Port, []).
 
 %% gen_server hooks
 init([]) ->
-    {ok, #state{workers = make_workers(queue:new())}}.
-
+  {ok, #state{workers = make_workers(queue:new())}}.
 handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
-
+  {reply, ok, State}.
 handle_cast(_Message, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 handle_info({tcp, Socket, Bin}, State) ->
-    Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
-    Response;
+  Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
+  Response;
 handle_info(_Message, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 terminate(_Reason, _State) ->
-    ok.
-
+  ok.
 sock_opts() ->
-    [binary, {reuseaddr, true}].
-
+  [binary, {reuseaddr, true}].
 new_connection(Socket, State) ->
-    inet:setopts(Socket, [{active, once}]),
-    {ok, State}.
-
+  inet:setopts(Socket, [{active, once}]),
+  {ok, State}.
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 handle_request(Socket, Bin, State) ->
-    case queue:out(State#state.workers) of
-        {{value, Worker}, Queue} ->
-            gen_server:cast(Worker, {tcp_query, Socket, Bin}),
-            {noreply, State#state{workers = queue:in(Worker, Queue)}};
-        {empty, _Queue} ->
-            folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
-            folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
-            lager:info("Queue is empty, dropping packet"),
-            {noreply, State}
-    end.
+  case queue:out(State#state.workers) of
+    {{value, Worker}, Queue} ->
+      gen_server:cast(Worker, {tcp_query, Socket, Bin}),
+      {noreply, State#state{workers = queue:in(Worker, Queue)}};
+    {empty, _Queue} ->
+      folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
+      folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
+      lager:info("Queue is empty, dropping packet"),
+      {noreply, State}
+  end.
 
 make_workers(Queue) ->
-    make_workers(Queue, erldns_config:get_num_workers()).
-
+  make_workers(Queue, erldns_config:get_num_workers()).
 make_workers(Queue, NumWorkers) ->
-    make_workers(Queue, NumWorkers, 1).
-
+  make_workers(Queue, NumWorkers, 1).
 make_workers(Queue, NumWorkers, N) ->
-    case N < NumWorkers of
-        true ->
-            {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
-            make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
-        false ->
-            Queue
-    end.
+  case N < NumWorkers of
+    true ->
+      {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
+      make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
+    false ->
+      Queue
+  end.

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -14,11 +14,11 @@
 
 %% @doc Handles DNS questions arriving via TCP.
 -module(erldns_tcp_server).
+
 -behavior(gen_nb_server).
 
 % API
 -export([start_link/2, start_link/4]).
-
 % Gen server hooks
 -export([init/1,
          handle_call/3,
@@ -27,9 +27,7 @@
          terminate/2,
          sock_opts/0,
          new_connection/2,
-         code_change/3
-        ]).
-
+         code_change/3]).
 % Internal API
 -export([handle_request/3]).
 
@@ -40,56 +38,65 @@
 %% Public API
 -spec start_link(atom(), inet | inet6) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, Family) ->
-  start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
+    start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
 
 -spec start_link(atom(), inet | inet6, inet:ip_address(), inet:port_number()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(_Name, Family, Address, Port) ->
-  lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
-  gen_nb_server:start_link(?MODULE, Address, Port, []).
+    lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
+    gen_nb_server:start_link(?MODULE, Address, Port, []).
 
 %% gen_server hooks
 init([]) ->
-  {ok, #state{workers = make_workers(queue:new())}}.
+    {ok, #state{workers = make_workers(queue:new())}}.
+
 handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
+    {reply, ok, State}.
+
 handle_cast(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info({tcp, Socket, Bin}, State) ->
-  Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
-  Response;
+    Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
+    Response;
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_Reason, _State) ->
-  ok.
+    ok.
+
 sock_opts() ->
-  [binary, {reuseaddr, true}].
+    [binary, {reuseaddr, true}].
+
 new_connection(Socket, State) ->
-  inet:setopts(Socket, [{active, once}]),
-  {ok, State}.
+    inet:setopts(Socket, [{active, once}]),
+    {ok, State}.
+
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 handle_request(Socket, Bin, State) ->
-  case queue:out(State#state.workers) of
-    {{value, Worker}, Queue} ->
-      gen_server:cast(Worker, {tcp_query, Socket, Bin}),
-      {noreply, State#state{workers = queue:in(Worker, Queue)}};
-    {empty, _Queue} ->
-      folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
-      folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
-      lager:info("Queue is empty, dropping packet"),
-      {noreply, State}
-  end.
+    case queue:out(State#state.workers) of
+        {{value, Worker}, Queue} ->
+            gen_server:cast(Worker, {tcp_query, Socket, Bin}),
+            {noreply, State#state{workers = queue:in(Worker, Queue)}};
+        {empty, _Queue} ->
+            folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
+            folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
+            lager:info("Queue is empty, dropping packet"),
+            {noreply, State}
+    end.
 
 make_workers(Queue) ->
-  make_workers(Queue, erldns_config:get_num_workers()).
+    make_workers(Queue, erldns_config:get_num_workers()).
+
 make_workers(Queue, NumWorkers) ->
-  make_workers(Queue, NumWorkers, 1).
+    make_workers(Queue, NumWorkers, 1).
+
 make_workers(Queue, NumWorkers, N) ->
-  case N < NumWorkers of
-    true ->
-      {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
-      make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
-    false ->
-      Queue
-  end.
+    case N < NumWorkers of
+        true ->
+            {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
+            make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
+        false ->
+            Queue
+    end.

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -18,8 +18,7 @@
 -behavior(gen_nb_server).
 
 % API
--export([start_link/2,
-         start_link/4]).
+-export([start_link/2, start_link/4]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -18,7 +18,8 @@
 -behavior(gen_nb_server).
 
 % API
--export([start_link/2, start_link/4]).
+-export([start_link/2,
+         start_link/4]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -14,11 +14,12 @@
 
 %% @doc Handles DNS questions arriving via TCP.
 -module(erldns_tcp_server).
+
 -behavior(gen_nb_server).
 
 % API
--export([start_link/2, start_link/4]).
-
+-export([start_link/2,
+         start_link/4]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
@@ -27,9 +28,7 @@
          terminate/2,
          sock_opts/0,
          new_connection/2,
-         code_change/3
-        ]).
-
+         code_change/3]).
 % Internal API
 -export([handle_request/3]).
 
@@ -40,56 +39,65 @@
 %% Public API
 -spec start_link(atom(), inet | inet6) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, Family) ->
-  start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
+    start_link(Name, Family, erldns_config:get_address(Family), erldns_config:get_port()).
 
 -spec start_link(atom(), inet | inet6, inet:ip_address(), inet:port_number()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(_Name, Family, Address, Port) ->
-  lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
-  gen_nb_server:start_link(?MODULE, Address, Port, []).
+    lager:info("Starting TCP server for ~p on address ~p port ~p", [Family, Address, Port]),
+    gen_nb_server:start_link(?MODULE, Address, Port, []).
 
 %% gen_server hooks
 init([]) ->
-  {ok, #state{workers = make_workers(queue:new())}}.
+    {ok, #state{workers = make_workers(queue:new())}}.
+
 handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
+    {reply, ok, State}.
+
 handle_cast(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info({tcp, Socket, Bin}, State) ->
-  Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
-  Response;
+    Response = folsom_metrics:histogram_timed_update(tcp_handoff_histogram, ?MODULE, handle_request, [Socket, Bin, State]),
+    Response;
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_Reason, _State) ->
-  ok.
+    ok.
+
 sock_opts() ->
-  [binary, {reuseaddr, true}].
+    [binary, {reuseaddr, true}].
+
 new_connection(Socket, State) ->
-  inet:setopts(Socket, [{active, once}]),
-  {ok, State}.
+    inet:setopts(Socket, [{active, once}]),
+    {ok, State}.
+
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 handle_request(Socket, Bin, State) ->
-  case queue:out(State#state.workers) of
-    {{value, Worker}, Queue} ->
-      gen_server:cast(Worker, {tcp_query, Socket, Bin}),
-      {noreply, State#state{workers = queue:in(Worker, Queue)}};
-    {empty, _Queue} ->
-      folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
-      folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
-      lager:info("Queue is empty, dropping packet"),
-      {noreply, State}
-  end.
+    case queue:out(State#state.workers) of
+        {{value, Worker}, Queue} ->
+            gen_server:cast(Worker, {tcp_query, Socket, Bin}),
+            {noreply, State#state{workers = queue:in(Worker, Queue)}};
+        {empty, _Queue} ->
+            folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
+            folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
+            lager:info("Queue is empty, dropping packet"),
+            {noreply, State}
+    end.
 
 make_workers(Queue) ->
-  make_workers(Queue, erldns_config:get_num_workers()).
+    make_workers(Queue, erldns_config:get_num_workers()).
+
 make_workers(Queue, NumWorkers) ->
-  make_workers(Queue, NumWorkers, 1).
+    make_workers(Queue, NumWorkers, 1).
+
 make_workers(Queue, NumWorkers, N) ->
-  case N < NumWorkers of
-    true ->
-      {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
-      make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
-    false ->
-      Queue
-  end.
+    case N < NumWorkers of
+        true ->
+            {ok, WorkerPid} = erldns_worker:start_link([{tcp, N}]),
+            make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
+        false ->
+            Queue
+    end.

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_txt.erl
+++ b/src/erldns_txt.erl
@@ -22,8 +22,10 @@
 -define(MAX_TXT_SIZE, 255).
 
 -ifdef(TEST).
+
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 % Public API
@@ -31,138 +33,142 @@
 %% @doc Parse a string into a collection of bit strings, each no longer than
 %% 255 characters.
 -spec parse(binary() | string()) -> [] | [[binary()]].
-parse(Binary) when is_binary(Binary) -> parse(binary_to_list(Binary));
-parse([]) -> [];
-parse([C|Rest]) -> parse_char([C|Rest], C, Rest, [], false).
+parse(Binary) when is_binary(Binary) ->
+    parse(binary_to_list(Binary));
+parse([]) ->
+    [];
+parse([C | Rest]) ->
+    parse_char([C | Rest], C, Rest, [], false).
 
 -spec parse(String :: string(), Rest :: string(), Tokens :: [[binary()]], Escaped :: boolean()) -> [binary()] | [[binary()]].
-parse(String, [], [], _) -> [split(String)];
-parse(_, [], Tokens, _) -> Tokens;
-parse(String, [C|Rest], Tokens, Escaped) -> parse_char(String, C, Rest, Tokens, Escaped).
-parse(_, [], Tokens, CurrentToken, true) -> Tokens ++ [CurrentToken]; % Last character is escaped
-parse(String, [C|Rest], Tokens, CurrentToken, Escaped) -> parse_char(String, C, Rest, Tokens, CurrentToken, Escaped).
+parse(String, [], [], _) ->
+    [split(String)];
+parse(_, [], Tokens, _) ->
+    Tokens;
+parse(String, [C | Rest], Tokens, Escaped) ->
+    parse_char(String, C, Rest, Tokens, Escaped).
+
+parse(_, [], Tokens, CurrentToken, true) ->
+    Tokens ++ [CurrentToken]; % Last character is escaped
+parse(String, [C | Rest], Tokens, CurrentToken, Escaped) ->
+    parse_char(String, C, Rest, Tokens, CurrentToken, Escaped).
 
 %% @doc Do something with the given character. The rules are as follows:
 %% * A quote starts/ends a token.
 %% * Any other character is considered part of the current token.
 -spec parse_char(string(), char(), string(), [string()], boolean()) -> any().
-parse_char(String, $", Rest, Tokens, _) -> parse(String, Rest, Tokens, [], false);
-parse_char(String, _, Rest, Tokens, _) -> parse(String, Rest, Tokens, false).
+parse_char(String, $", Rest, Tokens, _) ->
+    parse(String, Rest, Tokens, [], false);
+parse_char(String, _, Rest, Tokens, _) ->
+    parse(String, Rest, Tokens, false).
 
-parse_char(String, $", Rest, Tokens, CurrentToken, false) -> parse(String, Rest, Tokens ++ [split(CurrentToken)], false);
-parse_char(String, $", Rest, Tokens, CurrentToken, true) -> parse(String, Rest, Tokens, CurrentToken ++ [$"], false);
-parse_char(String, $\\, Rest, Tokens, CurrentToken, false) -> parse(String, Rest, Tokens, CurrentToken, true);
-parse_char(String, $\\, Rest, Tokens, CurrentToken, true) -> parse(String, Rest, Tokens, CurrentToken ++ [$\\], false);
-parse_char(String, C, Rest, Tokens, CurrentToken, _) -> parse(String, Rest, Tokens, CurrentToken ++ [C], false).
+parse_char(String, $", Rest, Tokens, CurrentToken, false) ->
+    parse(String, Rest, Tokens ++ [split(CurrentToken)], false);
+parse_char(String, $", Rest, Tokens, CurrentToken, true) ->
+    parse(String, Rest, Tokens, CurrentToken ++ [$"], false);
+parse_char(String, $\\, Rest, Tokens, CurrentToken, false) ->
+    parse(String, Rest, Tokens, CurrentToken, true);
+parse_char(String, $\\, Rest, Tokens, CurrentToken, true) ->
+    parse(String, Rest, Tokens, CurrentToken ++ [$\\], false);
+parse_char(String, C, Rest, Tokens, CurrentToken, _) ->
+    parse(String, Rest, Tokens, CurrentToken ++ [C], false).
 
 %% @doc Split the given string into a list of bit strings, with each element
 %% limited to 255 characters or less.
 -spec split(string()) -> [binary()].
-split(Data) -> split(Data, []).
+split(Data) ->
+    split(Data, []).
 
 %% Internal recursive split function.
 -spec split(string(), [binary()]) -> [binary()].
 split(Data, Parts) ->
-  case byte_size(list_to_binary(Data)) > ?MAX_TXT_SIZE of
-    true ->
-      First = list_to_binary(string:substr(Data, 1, ?MAX_TXT_SIZE)),
-      Rest = string:substr(Data, ?MAX_TXT_SIZE + 1),
-      case Rest of
-        [] -> Parts ++ [First];
-        _ -> split(Rest, Parts ++ [First])
-      end;
-    false ->
-      Parts ++ [list_to_binary(Data)]
-  end.
-
+    case byte_size(list_to_binary(Data)) > ?MAX_TXT_SIZE of
+        true ->
+            First = list_to_binary(string:substr(Data, 1, ?MAX_TXT_SIZE)),
+            Rest = string:substr(Data, ?MAX_TXT_SIZE + 1),
+            case Rest of
+                [] ->
+                    Parts ++ [First];
+                _ ->
+                    split(Rest, Parts ++ [First])
+            end;
+        false ->
+            Parts ++ [list_to_binary(Data)]
+    end.
 
 -ifdef(TEST).
-
 
 %% Known failure cases:
 %% \
 %% "
 %% "\"
 parse_test() ->
-  ?assertEqual([], parse("")),
-  ?assertEqual([[<<"test">>]], parse("test")),
-  ?assertEqual([[list_to_binary(lists:duplicate(255, "x")), list_to_binary(lists:duplicate(15, "x"))]], parse(lists:duplicate(270, "x"))),
-  ?assertEqual([[<<"test">>]], parse(<<"test">>)),
-  ?assertEqual([[<<"test">>], [<<"test">>]], parse("\"test\" \"test\"")),
-  ?assertEqual([[<<"\\">>]], parse("\\")),
-  ?assertEqual([[<<"test\\;">>]], parse("test\\;")),
-  ?assertEqual([[<<"test\\">>]], parse("test\\")).
+    ?assertEqual([], parse("")),
+    ?assertEqual([[<<"test">>]], parse("test")),
+    ?assertEqual([[list_to_binary(lists:duplicate(255, "x")), list_to_binary(lists:duplicate(15, "x"))]], parse(lists:duplicate(270, "x"))),
+    ?assertEqual([[<<"test">>]], parse(<<"test">>)),
+    ?assertEqual([[<<"test">>], [<<"test">>]], parse("\"test\" \"test\"")),
+    ?assertEqual([[<<"\\">>]], parse("\\")),
+    ?assertEqual([[<<"test\\;">>]], parse("test\\;")),
+    ?assertEqual([[<<"test\\">>]], parse("test\\")).
+
 %?assertEqual(parse("\"test\"\""), [[<<"test\"">>]]).
 
 proper_test_() ->
-  [] = proper:module(?MODULE, [{to_file, user}, {numtests, 1000}]).
+    [] = proper:module(?MODULE, [{to_file, user}, {numtests, 1000}]).
 
 check_bblist([]) ->
-  true;
-check_bblist([[Binary]|Rest]) when is_binary(Binary) andalso size(Binary) =< ?MAX_TXT_SIZE ->
-  check_bblist(Rest);
+    true;
+check_bblist([[Binary] | Rest]) when is_binary(Binary) andalso size(Binary) =< ?MAX_TXT_SIZE ->
+    check_bblist(Rest);
 check_bblist(_) ->
-  false.
+    false.
 
 %% ASCII Strings without " nor end in \
 quoteless_ascii_string1() ->
-  list(oneof([integer(0, 33), integer(35, 255)])).
+    list(oneof([integer(0, 33), integer(35, 255)])).
+
 quoteless_ascii_string() ->
-  ?SUCHTHAT(
-     String,
-     quoteless_ascii_string1(),
-     begin
-       case lists:reverse(String) of
-         [92|_] ->
-           false;
-         _ ->
-           true
-       end
-     end
-    ).
+    ?SUCHTHAT(String,
+              quoteless_ascii_string1(),
+              begin
+                  case lists:reverse(String) of
+                      [92 | _] ->
+                          false;
+                      _ ->
+                          true
+                  end
+              end).
 
 quoted_ascii_string1() ->
-  %% " has character code 34.
-  ?LET(
-     String,
-     quoteless_ascii_string(),
-     [34] ++ String ++ [34]
-    ).
+    %% " has character code 34.
+    ?LET(String, quoteless_ascii_string(), [34] ++ String ++ [34]).
 
 quoted_ascii_string() ->
-  ?SUCHTHAT(
-     String,
-     quoted_ascii_string1(),
-     begin
-       case lists:reverse(String) of
-         % "\
-         [34, 92|_] ->
-           false;
-         _ ->
-           true
-       end
-     end
-    ).
+    ?SUCHTHAT(String,
+              quoted_ascii_string1(),
+              begin
+                  case lists:reverse(String) of
+                      % "\
+                      [34, 92 | _] ->
+                          false;
+                      _ ->
+                          true
+                  end
+              end).
 
 quoted_and_unquoted_ascii_string_unflattened() ->
-  list(
-    oneof([quoted_ascii_string(), quoteless_ascii_string()])
-   ).
+    list(oneof([quoted_ascii_string(), quoteless_ascii_string()])).
+
 quoted_and_unquoted_ascii_string() ->
-  ?LET(
-     StringList,
-     quoted_and_unquoted_ascii_string_unflattened(),
-     lists:flatten(StringList)
-    ).
+    ?LET(StringList, quoted_and_unquoted_ascii_string_unflattened(), lists:flatten(StringList)).
 
 prop_parse_holds_type() ->
-  ?FORALL(
-     ASCIIString,
-     quoted_and_unquoted_ascii_string(),
-     begin
-       BinaryOfBinaryList = parse(ASCIIString),
-       check_bblist(BinaryOfBinaryList)
-     end
-    ).
+    ?FORALL(ASCIIString,
+            quoted_and_unquoted_ascii_string(),
+            begin
+                BinaryOfBinaryList = parse(ASCIIString),
+                check_bblist(BinaryOfBinaryList)
+            end).
 
 -endif.

--- a/src/erldns_txt.erl
+++ b/src/erldns_txt.erl
@@ -22,10 +22,8 @@
 -define(MAX_TXT_SIZE, 255).
 
 -ifdef(TEST).
-
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
 % Public API
@@ -33,142 +31,138 @@
 %% @doc Parse a string into a collection of bit strings, each no longer than
 %% 255 characters.
 -spec parse(binary() | string()) -> [] | [[binary()]].
-parse(Binary) when is_binary(Binary) ->
-    parse(binary_to_list(Binary));
-parse([]) ->
-    [];
-parse([C | Rest]) ->
-    parse_char([C | Rest], C, Rest, [], false).
+parse(Binary) when is_binary(Binary) -> parse(binary_to_list(Binary));
+parse([]) -> [];
+parse([C|Rest]) -> parse_char([C|Rest], C, Rest, [], false).
 
 -spec parse(String :: string(), Rest :: string(), Tokens :: [[binary()]], Escaped :: boolean()) -> [binary()] | [[binary()]].
-parse(String, [], [], _) ->
-    [split(String)];
-parse(_, [], Tokens, _) ->
-    Tokens;
-parse(String, [C | Rest], Tokens, Escaped) ->
-    parse_char(String, C, Rest, Tokens, Escaped).
-
-parse(_, [], Tokens, CurrentToken, true) ->
-    Tokens ++ [CurrentToken]; % Last character is escaped
-parse(String, [C | Rest], Tokens, CurrentToken, Escaped) ->
-    parse_char(String, C, Rest, Tokens, CurrentToken, Escaped).
+parse(String, [], [], _) -> [split(String)];
+parse(_, [], Tokens, _) -> Tokens;
+parse(String, [C|Rest], Tokens, Escaped) -> parse_char(String, C, Rest, Tokens, Escaped).
+parse(_, [], Tokens, CurrentToken, true) -> Tokens ++ [CurrentToken]; % Last character is escaped
+parse(String, [C|Rest], Tokens, CurrentToken, Escaped) -> parse_char(String, C, Rest, Tokens, CurrentToken, Escaped).
 
 %% @doc Do something with the given character. The rules are as follows:
 %% * A quote starts/ends a token.
 %% * Any other character is considered part of the current token.
 -spec parse_char(string(), char(), string(), [string()], boolean()) -> any().
-parse_char(String, $", Rest, Tokens, _) ->
-    parse(String, Rest, Tokens, [], false);
-parse_char(String, _, Rest, Tokens, _) ->
-    parse(String, Rest, Tokens, false).
+parse_char(String, $", Rest, Tokens, _) -> parse(String, Rest, Tokens, [], false);
+parse_char(String, _, Rest, Tokens, _) -> parse(String, Rest, Tokens, false).
 
-parse_char(String, $", Rest, Tokens, CurrentToken, false) ->
-    parse(String, Rest, Tokens ++ [split(CurrentToken)], false);
-parse_char(String, $", Rest, Tokens, CurrentToken, true) ->
-    parse(String, Rest, Tokens, CurrentToken ++ [$"], false);
-parse_char(String, $\\, Rest, Tokens, CurrentToken, false) ->
-    parse(String, Rest, Tokens, CurrentToken, true);
-parse_char(String, $\\, Rest, Tokens, CurrentToken, true) ->
-    parse(String, Rest, Tokens, CurrentToken ++ [$\\], false);
-parse_char(String, C, Rest, Tokens, CurrentToken, _) ->
-    parse(String, Rest, Tokens, CurrentToken ++ [C], false).
+parse_char(String, $", Rest, Tokens, CurrentToken, false) -> parse(String, Rest, Tokens ++ [split(CurrentToken)], false);
+parse_char(String, $", Rest, Tokens, CurrentToken, true) -> parse(String, Rest, Tokens, CurrentToken ++ [$"], false);
+parse_char(String, $\\, Rest, Tokens, CurrentToken, false) -> parse(String, Rest, Tokens, CurrentToken, true);
+parse_char(String, $\\, Rest, Tokens, CurrentToken, true) -> parse(String, Rest, Tokens, CurrentToken ++ [$\\], false);
+parse_char(String, C, Rest, Tokens, CurrentToken, _) -> parse(String, Rest, Tokens, CurrentToken ++ [C], false).
 
 %% @doc Split the given string into a list of bit strings, with each element
 %% limited to 255 characters or less.
 -spec split(string()) -> [binary()].
-split(Data) ->
-    split(Data, []).
+split(Data) -> split(Data, []).
 
 %% Internal recursive split function.
 -spec split(string(), [binary()]) -> [binary()].
 split(Data, Parts) ->
-    case byte_size(list_to_binary(Data)) > ?MAX_TXT_SIZE of
-        true ->
-            First = list_to_binary(string:substr(Data, 1, ?MAX_TXT_SIZE)),
-            Rest = string:substr(Data, ?MAX_TXT_SIZE + 1),
-            case Rest of
-                [] ->
-                    Parts ++ [First];
-                _ ->
-                    split(Rest, Parts ++ [First])
-            end;
-        false ->
-            Parts ++ [list_to_binary(Data)]
-    end.
+  case byte_size(list_to_binary(Data)) > ?MAX_TXT_SIZE of
+    true ->
+      First = list_to_binary(string:substr(Data, 1, ?MAX_TXT_SIZE)),
+      Rest = string:substr(Data, ?MAX_TXT_SIZE + 1),
+      case Rest of
+        [] -> Parts ++ [First];
+        _ -> split(Rest, Parts ++ [First])
+      end;
+    false ->
+      Parts ++ [list_to_binary(Data)]
+  end.
+
 
 -ifdef(TEST).
+
 
 %% Known failure cases:
 %% \
 %% "
 %% "\"
 parse_test() ->
-    ?assertEqual([], parse("")),
-    ?assertEqual([[<<"test">>]], parse("test")),
-    ?assertEqual([[list_to_binary(lists:duplicate(255, "x")), list_to_binary(lists:duplicate(15, "x"))]], parse(lists:duplicate(270, "x"))),
-    ?assertEqual([[<<"test">>]], parse(<<"test">>)),
-    ?assertEqual([[<<"test">>], [<<"test">>]], parse("\"test\" \"test\"")),
-    ?assertEqual([[<<"\\">>]], parse("\\")),
-    ?assertEqual([[<<"test\\;">>]], parse("test\\;")),
-    ?assertEqual([[<<"test\\">>]], parse("test\\")).
-
+  ?assertEqual([], parse("")),
+  ?assertEqual([[<<"test">>]], parse("test")),
+  ?assertEqual([[list_to_binary(lists:duplicate(255, "x")), list_to_binary(lists:duplicate(15, "x"))]], parse(lists:duplicate(270, "x"))),
+  ?assertEqual([[<<"test">>]], parse(<<"test">>)),
+  ?assertEqual([[<<"test">>], [<<"test">>]], parse("\"test\" \"test\"")),
+  ?assertEqual([[<<"\\">>]], parse("\\")),
+  ?assertEqual([[<<"test\\;">>]], parse("test\\;")),
+  ?assertEqual([[<<"test\\">>]], parse("test\\")).
 %?assertEqual(parse("\"test\"\""), [[<<"test\"">>]]).
 
 proper_test_() ->
-    [] = proper:module(?MODULE, [{to_file, user}, {numtests, 1000}]).
+  [] = proper:module(?MODULE, [{to_file, user}, {numtests, 1000}]).
 
 check_bblist([]) ->
-    true;
-check_bblist([[Binary] | Rest]) when is_binary(Binary) andalso size(Binary) =< ?MAX_TXT_SIZE ->
-    check_bblist(Rest);
+  true;
+check_bblist([[Binary]|Rest]) when is_binary(Binary) andalso size(Binary) =< ?MAX_TXT_SIZE ->
+  check_bblist(Rest);
 check_bblist(_) ->
-    false.
+  false.
 
 %% ASCII Strings without " nor end in \
 quoteless_ascii_string1() ->
-    list(oneof([integer(0, 33), integer(35, 255)])).
-
+  list(oneof([integer(0, 33), integer(35, 255)])).
 quoteless_ascii_string() ->
-    ?SUCHTHAT(String,
-              quoteless_ascii_string1(),
-              begin
-                  case lists:reverse(String) of
-                      [92 | _] ->
-                          false;
-                      _ ->
-                          true
-                  end
-              end).
+  ?SUCHTHAT(
+     String,
+     quoteless_ascii_string1(),
+     begin
+       case lists:reverse(String) of
+         [92|_] ->
+           false;
+         _ ->
+           true
+       end
+     end
+    ).
 
 quoted_ascii_string1() ->
-    %% " has character code 34.
-    ?LET(String, quoteless_ascii_string(), [34] ++ String ++ [34]).
+  %% " has character code 34.
+  ?LET(
+     String,
+     quoteless_ascii_string(),
+     [34] ++ String ++ [34]
+    ).
 
 quoted_ascii_string() ->
-    ?SUCHTHAT(String,
-              quoted_ascii_string1(),
-              begin
-                  case lists:reverse(String) of
-                      % "\
-                      [34, 92 | _] ->
-                          false;
-                      _ ->
-                          true
-                  end
-              end).
+  ?SUCHTHAT(
+     String,
+     quoted_ascii_string1(),
+     begin
+       case lists:reverse(String) of
+         % "\
+         [34, 92|_] ->
+           false;
+         _ ->
+           true
+       end
+     end
+    ).
 
 quoted_and_unquoted_ascii_string_unflattened() ->
-    list(oneof([quoted_ascii_string(), quoteless_ascii_string()])).
-
+  list(
+    oneof([quoted_ascii_string(), quoteless_ascii_string()])
+   ).
 quoted_and_unquoted_ascii_string() ->
-    ?LET(StringList, quoted_and_unquoted_ascii_string_unflattened(), lists:flatten(StringList)).
+  ?LET(
+     StringList,
+     quoted_and_unquoted_ascii_string_unflattened(),
+     lists:flatten(StringList)
+    ).
 
 prop_parse_holds_type() ->
-    ?FORALL(ASCIIString,
-            quoted_and_unquoted_ascii_string(),
-            begin
-                BinaryOfBinaryList = parse(ASCIIString),
-                check_bblist(BinaryOfBinaryList)
-            end).
+  ?FORALL(
+     ASCIIString,
+     quoted_and_unquoted_ascii_string(),
+     begin
+       BinaryOfBinaryList = parse(ASCIIString),
+       check_bblist(BinaryOfBinaryList)
+     end
+    ).
 
 -endif.

--- a/src/erldns_txt.erl
+++ b/src/erldns_txt.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -14,21 +14,20 @@
 
 %% @doc Handles DNS questions arriving via UDP.
 -module(erldns_udp_server).
-
 -behavior(gen_server).
 
 % API
--export([start_link/2,
-         start_link/4,
-         start_link/5,
-         is_running/0]).
+-export([start_link/2, start_link/4, start_link/5, is_running/0]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
+
 % Internal API
 -export([handle_request/5]).
 
@@ -42,126 +41,108 @@
 %% @doc Start the UDP server process
 -spec start_link(atom(), inet | inet6) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, InetFamily) ->
-    gen_server:start_link({local, Name}, ?MODULE, [InetFamily], []).
+  gen_server:start_link({local, Name}, ?MODULE, [InetFamily], []).
 
 -spec start_link(atom(), inet | inet6, inet:ip_address(), inet:port_number()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, InetFamily, Address, Port) ->
-    gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port], []).
+  gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port], []).
 
 start_link(Name, InetFamily, Address, Port, SocketOpts) ->
-    gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port, SocketOpts], []).
+  gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port, SocketOpts], []).
 
 %% @doc Return true if the UDP server process is running
 -spec is_running() -> boolean().
 is_running() ->
-    try sys:get_state(udp_inet) of
-        _ ->
-            true
-    catch
-        _ ->
-            false
-    end.
+  try sys:get_state(udp_inet) of
+    _ -> true
+  catch
+    _ -> false
+  end.
+
 
 %% gen_server hooks
 init([InetFamily]) ->
-    Port = erldns_config:get_port(),
-    {ok, Socket} = start(Port, InetFamily),
-    {ok,
-     #state{port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}};
+  Port = erldns_config:get_port(),
+  {ok, Socket} = start(Port, InetFamily),
+  {ok, #state{port = Port, socket = Socket, workers = make_workers(queue:new())}};
 init([InetFamily, Address, Port]) ->
-    {ok, Socket} = start(Address, Port, InetFamily),
-    {ok,
-     #state{address = Address,
-            port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}};
+  {ok, Socket} = start(Address, Port, InetFamily),
+  {ok, #state{address = Address, port = Port, socket = Socket, workers = make_workers(queue:new())}};
 init([InetFamily, Address, Port, SocketOpts]) ->
-    {ok, Socket} = start(Address, Port, InetFamily, SocketOpts),
-    {ok,
-     #state{address = Address,
-            port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}}.
+  {ok, Socket} = start(Address, Port, InetFamily, SocketOpts),
+  {ok, #state{address = Address, port = Port, socket = Socket, workers = make_workers(queue:new())}}.
 
 handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
-
+  {reply, ok, State}.
 handle_cast(_Message, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 handle_info(timeout, State) ->
-    {noreply, State};
+  {noreply, State};
 handle_info({udp, Socket, Host, Port, Bin}, State) ->
-    % lager:debug("Received request: ~p", [Bin]),
-    Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
-    inet:setopts(State#state.socket, [{active, 100}]),
-    Response;
+  % lager:debug("Received request: ~p", [Bin]),
+  Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
+  inet:setopts(State#state.socket, [{active, 100}]),
+  Response;
 handle_info(_Message, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 terminate(_Reason, _State) ->
-    ok.
-
+  ok.
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% Internal functions
 %% Start a UDP server.
 start(Port, InetFamily) ->
-    start(erldns_config:get_address(InetFamily), Port, InetFamily).
+  start(erldns_config:get_address(InetFamily), Port, InetFamily).
 
 start(Address, Port, InetFamily) ->
-    lager:info("Starting UDP server (family: ~p, address: ~p, port: ~p)", [InetFamily, Address, Port]),
-    case gen_udp:open(Port, [binary, {active, 100}, {reuseaddr, true}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily]) of
-        {ok, Socket} ->
-            lager:info("UDP server (family: ~p, address: ~p, socket: ~p)", [InetFamily, Address, Socket]),
-            {ok, Socket};
-        {error, eacces} ->
-            lager:error("Failed to open UDP socket. Need to run as sudo?"),
-            {error, eacces}
-    end.
+  lager:info("Starting UDP server (family: ~p, address: ~p, port: ~p)", [InetFamily, Address, Port]),
+  case gen_udp:open(Port, [binary, {active, 100}, {reuseaddr, true},
+                           {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily]) of
+    {ok, Socket} -> 
+      lager:info("UDP server (family: ~p, address: ~p, socket: ~p)", [InetFamily, Address, Socket]),
+      {ok, Socket};
+    {error, eacces} ->
+      lager:error("Failed to open UDP socket. Need to run as sudo?"),
+      {error, eacces}
+  end.
 
 start(Address, Port, InetFamily, SocketOpts) ->
-    lager:info("Starting UDP server (family: ~p, address: ~p, port ~p, sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
-    case gen_udp:open(Port,
-                      [{reuseaddr, true}, binary, {active, 100}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily | SocketOpts])
-    of
-        {ok, Socket} ->
-            lager:info("UDP server (family: ~p, address: ~p, socket: ~p, sockopts: ~p)", [InetFamily, Address, Socket, SocketOpts]),
-            {ok, Socket};
-        {error, eacces} ->
-            lager:error("Failed to open UDP socket. Need to run as sudo?"),
-            {error, eacces}
-    end.
+  lager:info("Starting UDP server (family: ~p, address: ~p, port ~p, sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
+  case gen_udp:open(Port, [{reuseaddr, true}, binary, {active, 100},
+                           {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily|SocketOpts]) of
+    {ok, Socket} -> 
+      lager:info("UDP server (family: ~p, address: ~p, socket: ~p, sockopts: ~p)", [InetFamily, Address, Socket, SocketOpts]),
+      {ok, Socket};
+    {error, eacces} ->
+      lager:error("Failed to open UDP socket. Need to run as sudo?"),
+      {error, eacces}
+  end.
 
 %% This function executes in a single process and thus
 %% must return very fast. The execution time of this function
 %% will determine the overall QPS of the system.
 handle_request(Socket, Host, Port, Bin, State) ->
-    case queue:out(State#state.workers) of
-        {{value, Worker}, Queue} ->
-            gen_server:cast(Worker, {udp_query, Socket, Host, Port, Bin}),
-            {noreply, State#state{workers = queue:in(Worker, Queue)}};
-        {empty, _Queue} ->
-            folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
-            folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
-            lager:info("Queue is empty, dropping packet"),
-            {noreply, State}
-    end.
+  case queue:out(State#state.workers) of
+    {{value, Worker}, Queue} ->
+      gen_server:cast(Worker, {udp_query, Socket, Host, Port, Bin}),
+      {noreply, State#state{workers = queue:in(Worker, Queue)}};
+    {empty, _Queue} ->
+      folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
+      folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
+      lager:info("Queue is empty, dropping packet"),
+      {noreply, State}
+  end.
 
 make_workers(Queue) ->
-    make_workers(Queue, erldns_config:get_num_workers()).
-
+  make_workers(Queue, erldns_config:get_num_workers()).
 make_workers(Queue, NumWorkers) ->
-    make_workers(Queue, NumWorkers, 1).
-
+  make_workers(Queue, NumWorkers, 1).
 make_workers(Queue, NumWorkers, N) ->
-    case N < NumWorkers of
-        true ->
-            {ok, WorkerPid} = erldns_worker:start_link([{udp, N}]),
-            make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
-        false ->
-            Queue
-    end.
+  case N < NumWorkers of
+    true ->
+      {ok, WorkerPid} = erldns_worker:start_link([{udp, N}]),
+      make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
+    false ->
+      Queue
+  end.

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -14,20 +14,21 @@
 
 %% @doc Handles DNS questions arriving via UDP.
 -module(erldns_udp_server).
+
 -behavior(gen_server).
 
 % API
--export([start_link/2, start_link/4, start_link/5, is_running/0]).
-
+-export([start_link/2,
+         start_link/4,
+         start_link/5,
+         is_running/0]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
-
+         code_change/3]).
 % Internal API
 -export([handle_request/5]).
 
@@ -41,108 +42,126 @@
 %% @doc Start the UDP server process
 -spec start_link(atom(), inet | inet6) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, InetFamily) ->
-  gen_server:start_link({local, Name}, ?MODULE, [InetFamily], []).
+    gen_server:start_link({local, Name}, ?MODULE, [InetFamily], []).
 
 -spec start_link(atom(), inet | inet6, inet:ip_address(), inet:port_number()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Name, InetFamily, Address, Port) ->
-  gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port], []).
+    gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port], []).
 
 start_link(Name, InetFamily, Address, Port, SocketOpts) ->
-  gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port, SocketOpts], []).
+    gen_server:start_link({local, Name}, ?MODULE, [InetFamily, Address, Port, SocketOpts], []).
 
 %% @doc Return true if the UDP server process is running
 -spec is_running() -> boolean().
 is_running() ->
-  try sys:get_state(udp_inet) of
-    _ -> true
-  catch
-    _ -> false
-  end.
-
+    try sys:get_state(udp_inet) of
+        _ ->
+            true
+    catch
+        _ ->
+            false
+    end.
 
 %% gen_server hooks
 init([InetFamily]) ->
-  Port = erldns_config:get_port(),
-  {ok, Socket} = start(Port, InetFamily),
-  {ok, #state{port = Port, socket = Socket, workers = make_workers(queue:new())}};
+    Port = erldns_config:get_port(),
+    {ok, Socket} = start(Port, InetFamily),
+    {ok,
+     #state{port = Port,
+            socket = Socket,
+            workers = make_workers(queue:new())}};
 init([InetFamily, Address, Port]) ->
-  {ok, Socket} = start(Address, Port, InetFamily),
-  {ok, #state{address = Address, port = Port, socket = Socket, workers = make_workers(queue:new())}};
+    {ok, Socket} = start(Address, Port, InetFamily),
+    {ok,
+     #state{address = Address,
+            port = Port,
+            socket = Socket,
+            workers = make_workers(queue:new())}};
 init([InetFamily, Address, Port, SocketOpts]) ->
-  {ok, Socket} = start(Address, Port, InetFamily, SocketOpts),
-  {ok, #state{address = Address, port = Port, socket = Socket, workers = make_workers(queue:new())}}.
+    {ok, Socket} = start(Address, Port, InetFamily, SocketOpts),
+    {ok,
+     #state{address = Address,
+            port = Port,
+            socket = Socket,
+            workers = make_workers(queue:new())}}.
 
 handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
+    {reply, ok, State}.
+
 handle_cast(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info(timeout, State) ->
-  {noreply, State};
+    {noreply, State};
 handle_info({udp, Socket, Host, Port, Bin}, State) ->
-  % lager:debug("Received request: ~p", [Bin]),
-  Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
-  inet:setopts(State#state.socket, [{active, 100}]),
-  Response;
+    % lager:debug("Received request: ~p", [Bin]),
+    Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
+    inet:setopts(State#state.socket, [{active, 100}]),
+    Response;
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_Reason, _State) ->
-  ok.
+    ok.
+
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% Internal functions
 %% Start a UDP server.
 start(Port, InetFamily) ->
-  start(erldns_config:get_address(InetFamily), Port, InetFamily).
+    start(erldns_config:get_address(InetFamily), Port, InetFamily).
 
 start(Address, Port, InetFamily) ->
-  lager:info("Starting UDP server (family: ~p, address: ~p, port: ~p)", [InetFamily, Address, Port]),
-  case gen_udp:open(Port, [binary, {active, 100}, {reuseaddr, true},
-                           {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily]) of
-    {ok, Socket} -> 
-      lager:info("UDP server (family: ~p, address: ~p, socket: ~p)", [InetFamily, Address, Socket]),
-      {ok, Socket};
-    {error, eacces} ->
-      lager:error("Failed to open UDP socket. Need to run as sudo?"),
-      {error, eacces}
-  end.
+    lager:info("Starting UDP server (family: ~p, address: ~p, port: ~p)", [InetFamily, Address, Port]),
+    case gen_udp:open(Port, [binary, {active, 100}, {reuseaddr, true}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily]) of
+        {ok, Socket} ->
+            lager:info("UDP server (family: ~p, address: ~p, socket: ~p)", [InetFamily, Address, Socket]),
+            {ok, Socket};
+        {error, eacces} ->
+            lager:error("Failed to open UDP socket. Need to run as sudo?"),
+            {error, eacces}
+    end.
 
 start(Address, Port, InetFamily, SocketOpts) ->
-  lager:info("Starting UDP server (family: ~p, address: ~p, port ~p, sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
-  case gen_udp:open(Port, [{reuseaddr, true}, binary, {active, 100},
-                           {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily|SocketOpts]) of
-    {ok, Socket} -> 
-      lager:info("UDP server (family: ~p, address: ~p, socket: ~p, sockopts: ~p)", [InetFamily, Address, Socket, SocketOpts]),
-      {ok, Socket};
-    {error, eacces} ->
-      lager:error("Failed to open UDP socket. Need to run as sudo?"),
-      {error, eacces}
-  end.
+    lager:info("Starting UDP server (family: ~p, address: ~p, port ~p, sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
+    case gen_udp:open(Port,
+                      [{reuseaddr, true}, binary, {active, 100}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily | SocketOpts])
+    of
+        {ok, Socket} ->
+            lager:info("UDP server (family: ~p, address: ~p, socket: ~p, sockopts: ~p)", [InetFamily, Address, Socket, SocketOpts]),
+            {ok, Socket};
+        {error, eacces} ->
+            lager:error("Failed to open UDP socket. Need to run as sudo?"),
+            {error, eacces}
+    end.
 
 %% This function executes in a single process and thus
 %% must return very fast. The execution time of this function
 %% will determine the overall QPS of the system.
 handle_request(Socket, Host, Port, Bin, State) ->
-  case queue:out(State#state.workers) of
-    {{value, Worker}, Queue} ->
-      gen_server:cast(Worker, {udp_query, Socket, Host, Port, Bin}),
-      {noreply, State#state{workers = queue:in(Worker, Queue)}};
-    {empty, _Queue} ->
-      folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
-      folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
-      lager:info("Queue is empty, dropping packet"),
-      {noreply, State}
-  end.
+    case queue:out(State#state.workers) of
+        {{value, Worker}, Queue} ->
+            gen_server:cast(Worker, {udp_query, Socket, Host, Port, Bin}),
+            {noreply, State#state{workers = queue:in(Worker, Queue)}};
+        {empty, _Queue} ->
+            folsom_metrics:notify({packet_dropped_empty_queue_counter, {inc, 1}}),
+            folsom_metrics:notify({packet_dropped_empty_queue_meter, 1}),
+            lager:info("Queue is empty, dropping packet"),
+            {noreply, State}
+    end.
 
 make_workers(Queue) ->
-  make_workers(Queue, erldns_config:get_num_workers()).
+    make_workers(Queue, erldns_config:get_num_workers()).
+
 make_workers(Queue, NumWorkers) ->
-  make_workers(Queue, NumWorkers, 1).
+    make_workers(Queue, NumWorkers, 1).
+
 make_workers(Queue, NumWorkers, N) ->
-  case N < NumWorkers of
-    true ->
-      {ok, WorkerPid} = erldns_worker:start_link([{udp, N}]),
-      make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
-    false ->
-      Queue
-  end.
+    case N < NumWorkers of
+        true ->
+            {ok, WorkerPid} = erldns_worker:start_link([{udp, N}]),
+            make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
+        false ->
+            Queue
+    end.

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -29,157 +29,167 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -record(state, {worker_process_sup, worker_process}).
 
 start_link(Args) ->
-  gen_server:start_link(?MODULE, Args, []).
+    gen_server:start_link(?MODULE, Args, []).
 
 init([WorkerId]) ->
-  {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
-  WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
-  {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
+    {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
+    WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
+    {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
 
 handle_call(_Request, From, State) ->
-  lager:debug("Received unexpected call (from: ~p)", [From]),
-  {reply, ok, State}.
+    lager:debug("Received unexpected call (from: ~p)", [From]),
+    {reply, ok, State}.
 
 handle_cast({tcp_query, Socket, Bin}, State) ->
-  case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-    ok ->
-      {noreply, State};
-    {error, timeout, NewWorkerPid} ->
-      {Id, _, Type, Modules} = State#state.worker_process,
-      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-    Error ->
-      lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
-      {noreply, State}
-  end;
+    case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+        ok ->
+            {noreply, State};
+        {error, timeout, NewWorkerPid} ->
+            {Id, _, Type, Modules} = State#state.worker_process,
+            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+        Error ->
+            lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
+            {noreply, State}
+    end;
 handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
-  case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-    ok ->
-      {noreply, State};
-    {error, timeout, NewWorkerPid} ->
-      {Id, _, Type, Modules} = State#state.worker_process,
-      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-    Error ->
-      lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
-      {noreply, State}
-  end;
+    case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+        ok ->
+            {noreply, State};
+        {error, timeout, NewWorkerPid} ->
+            {Id, _, Type, Modules} = State#state.worker_process,
+            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+        Error ->
+            lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
+            {noreply, State}
+    end;
 handle_cast(_Msg, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info(_Info, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_Reason, _State) ->
-  ok.
+    ok.
+
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% @doc Handle DNS query that comes in over TCP
 -spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()}) -> ok | {error, timeout} | {error, timeout, pid()}.
 handle_tcp_dns_query(Socket, <<_Len:16, Bin/binary>>, {WorkerProcessSup, WorkerProcess}) ->
-  case inet:peername(Socket) of
-    {ok, {Address, _Port}} ->
-      erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
-      Result = case Bin of
-        <<>> -> ok;
-        _ ->
-          case erldns_decoder:decode_message(Bin) of
-            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-              lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-              % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
-            {Error, Message, _} ->
-              lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
-              % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-              ok;
-            DecodedMessage ->
-              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
-          end
-      end,
-      erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
-      gen_tcp:close(Socket),
-      Result;
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, tcp_error, Reason})
-  end;
-
+    case inet:peername(Socket) of
+        {ok, {Address, _Port}} ->
+            erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
+            Result =
+                case Bin of
+                    <<>> ->
+                        ok;
+                    _ ->
+                        case erldns_decoder:decode_message(Bin) of
+                            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+                                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
+                                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+                                % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
+                            {Error, Message, _} ->
+                                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)",
+                                            [?MODULE, decode_message_error, Error, Message]),
+                                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+                                ok;
+                            DecodedMessage ->
+                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
+                        end
+                end,
+            erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
+            gen_tcp:close(Socket),
+            Result;
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, tcp_error, Reason})
+    end;
 handle_tcp_dns_query(Socket, BadPacket, _) ->
-  lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
-  % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
-  gen_tcp:close(Socket).
+    lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
+    % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
+    gen_tcp:close(Socket).
 
 handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-  case DecodedMessage#dns_message.qr of
-    false ->
-      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
-        _ -> ok
-      catch
-        exit:{timeout, _} ->
-          erldns_events:notify({?MODULE, timeout}),
-          handle_timeout(WorkerProcessSup, WorkerProcessId);
-        Error:Reason ->
-          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
-          {error, {Error, Reason}}
-      end;
-    true ->
-      {error, not_a_question}
-  end.
-
+    case DecodedMessage#dns_message.qr of
+        false ->
+            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
+                _ ->
+                    ok
+            catch
+                exit:{timeout, _} ->
+                    erldns_events:notify({?MODULE, timeout}),
+                    handle_timeout(WorkerProcessSup, WorkerProcessId);
+                Error:Reason ->
+                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
+                                [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
+                    {error, {Error, Reason}}
+            end;
+        true ->
+            {error, not_a_question}
+    end.
 
 %% @doc Handle DNS query that comes in over UDP
--spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
+-spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) ->
+                              ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
-  erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
-  Result = case erldns_decoder:decode_message(Bin) of
-             {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-               lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-               %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
-             {Error, Message, _} ->
-               lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
-               % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-               ok;
-             DecodedMessage ->
-               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
-  end,
-  erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
-  Result.
+    erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
+    Result =
+        case erldns_decoder:decode_message(Bin) of
+            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
+                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+                %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
+            {Error, Message, _} ->
+                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
+                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+                ok;
+            DecodedMessage ->
+                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
+        end,
+    erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
+    Result.
 
 -spec handle_decoded_udp_message(dns:message(), gen_udp:socket(), gen_udp:ip(), inet:port_number(), {pid(), term()}) ->
-  ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
+                                    ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
 handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-  case DecodedMessage#dns_message.qr of
-    false ->
-      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
-        _ -> ok
-      catch
-        exit:{timeout, _} ->
-          lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
-          erldns_events:notify({?MODULE, timeout}),
-          handle_timeout(WorkerProcessSup, WorkerProcessId);
-        Error:Reason ->
-          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
-          % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
-          {error, {Error, Reason}}
-      end;
-    true ->
-      {error, not_a_question}
-  end.
+    case DecodedMessage#dns_message.qr of
+        false ->
+            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
+                _ ->
+                    ok
+            catch
+                exit:{timeout, _} ->
+                    lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
+                    erldns_events:notify({?MODULE, timeout}),
+                    handle_timeout(WorkerProcessSup, WorkerProcessId);
+                Error:Reason ->
+                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
+                                [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
+                    % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
+                    {error, {Error, Reason}}
+            end;
+        true ->
+            {error, not_a_question}
+    end.
 
 -spec handle_timeout(pid(), term()) -> {error, timeout, term()} | {error, timeout}.
 handle_timeout(WorkerProcessSup, WorkerProcessId) ->
-  TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
-  lager:debug("Terminate result: ~p", [TerminateResult]),
-
-  case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
-    {ok, NewChild} ->
-      {error, timeout, NewChild};
-    {ok, NewChild, _} ->
-      {error, timeout, NewChild};
-    {error, Error} ->
-      erldns_events:notify({?MODULE, restart_failed, {Error}}),
-      {error, timeout}
-  end.
+    TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
+    lager:debug("Terminate result: ~p", [TerminateResult]),
+    case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
+        {ok, NewChild} ->
+            {error, timeout, NewChild};
+        {ok, NewChild, _} ->
+            {error, timeout, NewChild};
+        {error, Error} ->
+            erldns_events:notify({?MODULE, restart_failed, {Error}}),
+            {error, timeout}
+    end.

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -29,167 +29,157 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -record(state, {worker_process_sup, worker_process}).
 
 start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, []).
+  gen_server:start_link(?MODULE, Args, []).
 
 init([WorkerId]) ->
-    {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
-    WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
-    {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
+  {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
+  WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
+  {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
 
 handle_call(_Request, From, State) ->
-    lager:debug("Received unexpected call (from: ~p)", [From]),
-    {reply, ok, State}.
+  lager:debug("Received unexpected call (from: ~p)", [From]),
+  {reply, ok, State}.
 
 handle_cast({tcp_query, Socket, Bin}, State) ->
-    case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-        ok ->
-            {noreply, State};
-        {error, timeout, NewWorkerPid} ->
-            {Id, _, Type, Modules} = State#state.worker_process,
-            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-        Error ->
-            lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
-            {noreply, State}
-    end;
+  case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+    ok ->
+      {noreply, State};
+    {error, timeout, NewWorkerPid} ->
+      {Id, _, Type, Modules} = State#state.worker_process,
+      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+    Error ->
+      lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
+      {noreply, State}
+  end;
 handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
-    case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-        ok ->
-            {noreply, State};
-        {error, timeout, NewWorkerPid} ->
-            {Id, _, Type, Modules} = State#state.worker_process,
-            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-        Error ->
-            lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
-            {noreply, State}
-    end;
+  case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+    ok ->
+      {noreply, State};
+    {error, timeout, NewWorkerPid} ->
+      {Id, _, Type, Modules} = State#state.worker_process,
+      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+    Error ->
+      lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
+      {noreply, State}
+  end;
 handle_cast(_Msg, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 handle_info(_Info, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 terminate(_Reason, _State) ->
-    ok.
-
+  ok.
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% @doc Handle DNS query that comes in over TCP
 -spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()}) -> ok | {error, timeout} | {error, timeout, pid()}.
 handle_tcp_dns_query(Socket, <<_Len:16, Bin/binary>>, {WorkerProcessSup, WorkerProcess}) ->
-    case inet:peername(Socket) of
-        {ok, {Address, _Port}} ->
-            erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
-            Result =
-                case Bin of
-                    <<>> ->
-                        ok;
-                    _ ->
-                        case erldns_decoder:decode_message(Bin) of
-                            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-                                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
-                                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-                                % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
-                            {Error, Message, _} ->
-                                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)",
-                                            [?MODULE, decode_message_error, Error, Message]),
-                                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-                                ok;
-                            DecodedMessage ->
-                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
-                        end
-                end,
-            erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
-            gen_tcp:close(Socket),
-            Result;
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, tcp_error, Reason})
-    end;
+  case inet:peername(Socket) of
+    {ok, {Address, _Port}} ->
+      erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
+      Result = case Bin of
+        <<>> -> ok;
+        _ ->
+          case erldns_decoder:decode_message(Bin) of
+            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+              lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+              % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
+            {Error, Message, _} ->
+              lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
+              % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+              ok;
+            DecodedMessage ->
+              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
+          end
+      end,
+      erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
+      gen_tcp:close(Socket),
+      Result;
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, tcp_error, Reason})
+  end;
+
 handle_tcp_dns_query(Socket, BadPacket, _) ->
-    lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
-    % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
-    gen_tcp:close(Socket).
+  lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
+  % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
+  gen_tcp:close(Socket).
 
 handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-    case DecodedMessage#dns_message.qr of
-        false ->
-            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
-                _ ->
-                    ok
-            catch
-                exit:{timeout, _} ->
-                    erldns_events:notify({?MODULE, timeout}),
-                    handle_timeout(WorkerProcessSup, WorkerProcessId);
-                Error:Reason ->
-                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
-                                [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
-                    {error, {Error, Reason}}
-            end;
-        true ->
-            {error, not_a_question}
-    end.
+  case DecodedMessage#dns_message.qr of
+    false ->
+      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
+        _ -> ok
+      catch
+        exit:{timeout, _} ->
+          erldns_events:notify({?MODULE, timeout}),
+          handle_timeout(WorkerProcessSup, WorkerProcessId);
+        Error:Reason ->
+          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
+          {error, {Error, Reason}}
+      end;
+    true ->
+      {error, not_a_question}
+  end.
+
 
 %% @doc Handle DNS query that comes in over UDP
--spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) ->
-                              ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
+-spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
-    erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
-    Result =
-        case erldns_decoder:decode_message(Bin) of
-            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
-                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-                %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
-            {Error, Message, _} ->
-                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
-                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-                ok;
-            DecodedMessage ->
-                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
-        end,
-    erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
-    Result.
+  erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
+  Result = case erldns_decoder:decode_message(Bin) of
+             {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+               lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+               %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
+             {Error, Message, _} ->
+               lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
+               % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+               ok;
+             DecodedMessage ->
+               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
+  end,
+  erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
+  Result.
 
 -spec handle_decoded_udp_message(dns:message(), gen_udp:socket(), gen_udp:ip(), inet:port_number(), {pid(), term()}) ->
-                                    ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
+  ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
 handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-    case DecodedMessage#dns_message.qr of
-        false ->
-            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
-                _ ->
-                    ok
-            catch
-                exit:{timeout, _} ->
-                    lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
-                    erldns_events:notify({?MODULE, timeout}),
-                    handle_timeout(WorkerProcessSup, WorkerProcessId);
-                Error:Reason ->
-                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
-                                [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
-                    % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
-                    {error, {Error, Reason}}
-            end;
-        true ->
-            {error, not_a_question}
-    end.
+  case DecodedMessage#dns_message.qr of
+    false ->
+      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
+        _ -> ok
+      catch
+        exit:{timeout, _} ->
+          lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
+          erldns_events:notify({?MODULE, timeout}),
+          handle_timeout(WorkerProcessSup, WorkerProcessId);
+        Error:Reason ->
+          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
+          % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
+          {error, {Error, Reason}}
+      end;
+    true ->
+      {error, not_a_question}
+  end.
 
 -spec handle_timeout(pid(), term()) -> {error, timeout, term()} | {error, timeout}.
 handle_timeout(WorkerProcessSup, WorkerProcessId) ->
-    TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
-    lager:debug("Terminate result: ~p", [TerminateResult]),
-    case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
-        {ok, NewChild} ->
-            {error, timeout, NewChild};
-        {ok, NewChild, _} ->
-            {error, timeout, NewChild};
-        {error, Error} ->
-            erldns_events:notify({?MODULE, restart_failed, {Error}}),
-            {error, timeout}
-    end.
+  TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
+  lager:debug("Terminate result: ~p", [TerminateResult]),
+
+  case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
+    {ok, NewChild} ->
+      {error, timeout, NewChild};
+    {ok, NewChild, _} ->
+      {error, timeout, NewChild};
+    {error, Error} ->
+      erldns_events:notify({?MODULE, restart_failed, {Error}}),
+      {error, timeout}
+  end.

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -29,157 +29,168 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -record(state, {worker_process_sup, worker_process}).
 
 start_link(Args) ->
-  gen_server:start_link(?MODULE, Args, []).
+    gen_server:start_link(?MODULE, Args, []).
 
 init([WorkerId]) ->
-  {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
-  WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
-  {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
+    {ok, WorkerProcessSup} = erldns_worker_process_sup:start_link([WorkerId]),
+    WorkerProcess = lists:last(supervisor:which_children(WorkerProcessSup)),
+    {ok, #state{worker_process_sup = WorkerProcessSup, worker_process = WorkerProcess}}.
 
 handle_call(_Request, From, State) ->
-  lager:debug("Received unexpected call (from: ~p)", [From]),
-  {reply, ok, State}.
+    lager:debug("Received unexpected call (from: ~p)", [From]),
+    {reply, ok, State}.
 
 handle_cast({tcp_query, Socket, Bin}, State) ->
-  case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-    ok ->
-      {noreply, State};
-    {error, timeout, NewWorkerPid} ->
-      {Id, _, Type, Modules} = State#state.worker_process,
-      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-    Error ->
-      lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
-      {noreply, State}
-  end;
+    case handle_tcp_dns_query(Socket, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+        ok ->
+            {noreply, State};
+        {error, timeout, NewWorkerPid} ->
+            {Id, _, Type, Modules} = State#state.worker_process,
+            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+        Error ->
+            lager:error("Error handling TCP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_tcp_query_error, Error]),
+            {noreply, State}
+    end;
 handle_cast({udp_query, Socket, Host, Port, Bin}, State) ->
-  case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
-    ok ->
-      {noreply, State};
-    {error, timeout, NewWorkerPid} ->
-      {Id, _, Type, Modules} = State#state.worker_process,
-      {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
-    Error ->
-      lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
-      {noreply, State}
-  end;
+    case handle_udp_dns_query(Socket, Host, Port, Bin, {State#state.worker_process_sup, State#state.worker_process}) of
+        ok ->
+            {noreply, State};
+        {error, timeout, NewWorkerPid} ->
+            {Id, _, Type, Modules} = State#state.worker_process,
+            {noreply, State#state{worker_process = {Id, NewWorkerPid, Type, Modules}}};
+        Error ->
+            lager:error("Error handling UDP query (module: ~p, event: ~p, error: ~p)", [?MODULE, handle_udp_query_error, Error]),
+            {noreply, State}
+    end;
 handle_cast(_Msg, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 handle_info(_Info, State) ->
-  {noreply, State}.
+    {noreply, State}.
+
 terminate(_Reason, _State) ->
-  ok.
+    ok.
+
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% @doc Handle DNS query that comes in over TCP
 -spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()}) -> ok | {error, timeout} | {error, timeout, pid()}.
 handle_tcp_dns_query(Socket, <<_Len:16, Bin/binary>>, {WorkerProcessSup, WorkerProcess}) ->
-  case inet:peername(Socket) of
-    {ok, {Address, _Port}} ->
-      erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
-      Result = case Bin of
-        <<>> -> ok;
-        _ ->
-          case erldns_decoder:decode_message(Bin) of
-            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-              lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-              % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
-            {Error, Message, _} ->
-              lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
-              % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-              ok;
-            DecodedMessage ->
-              handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
-          end
-      end,
-      erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
-      gen_tcp:close(Socket),
-      Result;
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, tcp_error, Reason})
-  end;
-
+    case inet:peername(Socket) of
+        {ok, {Address, _Port}} ->
+            erldns_events:notify({?MODULE, start_tcp, [{host, Address}]}),
+            Result =
+                case Bin of
+                    <<>> ->
+                        ok;
+                    _ ->
+                        case erldns_decoder:decode_message(Bin) of
+                            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+                                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
+                                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+                                % erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess});
+                            {Error, Message, _} ->
+                                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)",
+                                            [?MODULE, decode_message_error, Error, Message]),
+                                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+                                ok;
+                            DecodedMessage ->
+                                handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, WorkerProcess})
+                        end
+                end,
+            erldns_events:notify({?MODULE, end_tcp, [{host, Address}]}),
+            gen_tcp:close(Socket),
+            Result;
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, tcp_error, Reason})
+    end;
 handle_tcp_dns_query(Socket, BadPacket, _) ->
-  lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
-  % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
-  gen_tcp:close(Socket).
+    lager:error("Received bad packet (module: ~p, event: ~p, protocol: ~p, packet: ~p)", [?MODULE, bad_packet, tcp, BadPacket]),
+    % erldns_events:notify({?MODULE, bad_packet, {tcp, BadPacket}}),
+    gen_tcp:close(Socket).
 
 handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-  case DecodedMessage#dns_message.qr of
-    false ->
-      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
-        _ -> ok
-      catch
-        exit:{timeout, _} ->
-          erldns_events:notify({?MODULE, timeout}),
-          handle_timeout(WorkerProcessSup, WorkerProcessId);
-        Error:Reason ->
-          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
-          {error, {Error, Reason}}
-      end;
-    true ->
-      {error, not_a_question}
-  end.
-
+    case DecodedMessage#dns_message.qr of
+        false ->
+            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, {tcp, Address}}, _Timeout = ?DEFAULT_TCP_PROCESS_TIMEOUT) of
+                _ ->
+                    ok
+            catch
+                exit:{timeout, _} ->
+                    erldns_events:notify({?MODULE, timeout}),
+                    handle_timeout(WorkerProcessSup, WorkerProcessId);
+                Error:Reason ->
+                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
+                                [?MODULE, process_crashed, tcp, Error, Reason, DecodedMessage]),
+                    {error, {Error, Reason}}
+            end;
+        true ->
+            {error, not_a_question}
+    end.
 
 %% @doc Handle DNS query that comes in over UDP
--spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
+-spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) ->
+                              ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
-  erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
-  Result = case erldns_decoder:decode_message(Bin) of
-             {trailing_garbage, DecodedMessage, TrailingGarbage} ->
-               lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)", [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
-               %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
-               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
-             {Error, Message, _} ->
-               lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
-               % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
-               ok;
-             DecodedMessage ->
-               handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
-  end,
-  erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
-  Result.
+    erldns_events:notify({?MODULE, start_udp, [{host, Host}]}),
+    Result =
+        case erldns_decoder:decode_message(Bin) of
+            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+                lager:info("Decoded message included trailing garbage (module: ~p, event: ~p, message: ~p, garbage: ~p)",
+                           [?MODULE, decode_message_trailing_garbage, DecodedMessage, TrailingGarbage]),
+                %erldns_events:notify({?MODULE, decode_message_trailing_garbage, {DecodedMessage, TrailingGarbage}}),
+                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess});
+            {Error, Message, _} ->
+                lager:error("Error decoding message (module: ~p, event: ~p, error: ~p, message: ~p)", [?MODULE, decode_message_error, Error, Message]),
+                % erldns_events:notify({?MODULE, decode_message_error, {Error, Message}}),
+                ok;
+            DecodedMessage ->
+                handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, WorkerProcess})
+        end,
+    erldns_events:notify({?MODULE, end_udp, [{host, Host}]}),
+    Result.
 
 -spec handle_decoded_udp_message(dns:message(), gen_udp:socket(), gen_udp:ip(), inet:port_number(), {pid(), term()}) ->
-  ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
+                                    ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
 handle_decoded_udp_message(DecodedMessage, Socket, Host, Port, {WorkerProcessSup, {WorkerProcessId, WorkerProcessPid, _, _}}) ->
-  case DecodedMessage#dns_message.qr of
-    false ->
-      try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
-        _ -> ok
-      catch
-        exit:{timeout, _} ->
-          lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
-          erldns_events:notify({?MODULE, timeout}),
-          handle_timeout(WorkerProcessSup, WorkerProcessId);
-        Error:Reason ->
-          lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)", [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
-          % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
-          {error, {Error, Reason}}
-      end;
-    true ->
-      {error, not_a_question}
-  end.
+    case DecodedMessage#dns_message.qr of
+        false ->
+            try gen_server:call(WorkerProcessPid, {process, DecodedMessage, Socket, Port, {udp, Host}}, _Timeout = ?DEFAULT_UDP_PROCESS_TIMEOUT) of
+                _ ->
+                    ok
+            catch
+                exit:{timeout, _} ->
+                    lager:info("Worker timeout (module: ~p, event: ~p, protocol: ~p, message: ~p)", [?MODULE, timeout, udp, DecodedMessage]),
+                    erldns_events:notify({?MODULE, timeout}),
+                    handle_timeout(WorkerProcessSup, WorkerProcessId);
+                Error:Reason ->
+                    lager:error("Worker process crashed (module: ~p, event: ~p, protocol: ~p, error: ~p, reason: ~p, message: ~p)",
+                                [?MODULE, process_crashed, udp, Error, Reason, DecodedMessage]),
+                    % erldns_events:notify({?MODULE, process_crashed, {udp, Error, Reason, DecodedMessage}}),
+                    {error, {Error, Reason}}
+            end;
+        true ->
+            {error, not_a_question}
+    end.
 
 -spec handle_timeout(pid(), term()) -> {error, timeout, term()} | {error, timeout}.
 handle_timeout(WorkerProcessSup, WorkerProcessId) ->
-  TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
-  lager:debug("Terminate result: ~p", [TerminateResult]),
+    TerminateResult = supervisor:terminate_child(WorkerProcessSup, WorkerProcessId),
+    lager:debug("Terminate result: ~p", [TerminateResult]),
 
-  case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
-    {ok, NewChild} ->
-      {error, timeout, NewChild};
-    {ok, NewChild, _} ->
-      {error, timeout, NewChild};
-    {error, Error} ->
-      erldns_events:notify({?MODULE, restart_failed, {Error}}),
-      {error, timeout}
-  end.
+    case supervisor:restart_child(WorkerProcessSup, WorkerProcessId) of
+        {ok, NewChild} ->
+            {error, timeout, NewChild};
+        {ok, NewChild, _} ->
+            {error, timeout, NewChild};
+        {error, Error} ->
+            erldns_events:notify({?MODULE, restart_failed, {Error}}),
+            {error, timeout}
+    end.

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -25,96 +25,103 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(MAX_PACKET_SIZE, 512).
 -define(REDIRECT_TO_LOOPBACK, false).
 -define(LOOPBACK_DEST, {127, 0, 0, 10}).
 
 -if(?REDIRECT_TO_LOOPBACK).
+
 -define(DEST_HOST(_Host), ?LOOPBACK_DEST).
+
 -else.
+
 -define(DEST_HOST(Host), Host).
+
 -endif.
 
 -record(state, {}).
 
 start_link(Args) ->
-  gen_server:start_link(?MODULE, Args, []).
+    gen_server:start_link(?MODULE, Args, []).
 
 init(_Args) ->
-  {ok, #state{}}.
+    {ok, #state{}}.
 
 % Process a TCP request. Does not truncate the response.
 handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
-  % Uncomment this and the function implementation to simulate a timeout when
-  % querying www.example.com with the test zones
-  % simulate_timeout(DecodedMessage),  
-  
-  Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
-  EncodedMessage = erldns_encoder:encode_message(Response),
-  send_tcp_message(Socket, EncodedMessage),
-  {reply, ok, State}; 
-
+    % Uncomment this and the function implementation to simulate a timeout when
+    % querying www.example.com with the test zones
+    % simulate_timeout(DecodedMessage),
+    Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
+    EncodedMessage = erldns_encoder:encode_message(Response),
+    send_tcp_message(Socket, EncodedMessage),
+    {reply, ok, State};
 % Process a UDP request. May truncate the response.
 handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) ->
-  % Uncomment this and the function implementation to simulate a timeout when
-  % querying www.example.com with the test zones
-  % simulate_timeout(DecodedMessage),
-
-  Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
-  DestHost = ?DEST_HOST(Host),
-
-  case erldns_encoder:encode_message(Response, [{'max_size', max_payload_size(Response)}]) of
-    {false, EncodedMessage} ->
-      % lager:debug("Sending encoded response to ~p", [DestHost]),
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {true, EncodedMessage, Message} when is_record(Message, dns_message)->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {false, EncodedMessage, _TsigMac} ->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {true, EncodedMessage, _TsigMac, _Message} ->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage)
-  end,
-  {reply, ok, State}.
+    % Uncomment this and the function implementation to simulate a timeout when
+    % querying www.example.com with the test zones
+    % simulate_timeout(DecodedMessage),
+    Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
+    DestHost = ?DEST_HOST(Host),
+    case erldns_encoder:encode_message(Response, [{max_size, max_payload_size(Response)}]) of
+        {false, EncodedMessage} ->
+            % lager:debug("Sending encoded response to ~p", [DestHost]),
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {true, EncodedMessage, Message} when is_record(Message, dns_message) ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {false, EncodedMessage, _TsigMac} ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {true, EncodedMessage, _TsigMac, _Message} ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage)
+    end,
+    {reply, ok, State}.
 
 handle_cast(_Msg, State) ->
-  {noreply, State}.
-handle_info(_Info, State) ->
-  {noreply, State}.
-terminate(_Reason, _State) ->
-  ok.
-code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {noreply, State}.
 
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
 
 %% Internal private functions
 
 send_tcp_message(Socket, EncodedMessage) ->
-  BinLength = byte_size(EncodedMessage),
-  TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
-  gen_tcp:send(Socket, TcpEncodedMessage).
+    BinLength = byte_size(EncodedMessage),
+    TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
+    gen_tcp:send(Socket, TcpEncodedMessage).
 
 %% Determine the max payload size by looking for additional
 %% options passed by the client.
 max_payload_size(Message) ->
-  case Message#dns_message.additional of
-    [Opt|_] when is_record(Opt, dns_optrr) ->
-      case Opt#dns_optrr.udp_payload_size of
-        [] -> ?MAX_PACKET_SIZE;
-        _ -> Opt#dns_optrr.udp_payload_size
-      end;
-    _ -> ?MAX_PACKET_SIZE
-  end.
+    case Message#dns_message.additional of
+        [Opt | _] when is_record(Opt, dns_optrr) ->
+            case Opt#dns_optrr.udp_payload_size of
+                [] ->
+                    ?MAX_PACKET_SIZE;
+                _ ->
+                    Opt#dns_optrr.udp_payload_size
+            end;
+        _ ->
+            ?MAX_PACKET_SIZE
+    end.
 
 %simulate_timeout(DecodedMessage) ->
   %[Question] = DecodedMessage#dns_message.questions,
   %Name = Question#dns_query.name,
   %lager:info("qname: ~p", [Name]),
   %case Name of
+
     %<<"www.example.com">> ->
       %timer:sleep(3000);
+
     %_ ->
       %ok
+
   %end.

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -25,96 +25,104 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(MAX_PACKET_SIZE, 512).
 -define(REDIRECT_TO_LOOPBACK, false).
 -define(LOOPBACK_DEST, {127, 0, 0, 10}).
 
 -if(?REDIRECT_TO_LOOPBACK).
+
 -define(DEST_HOST(_Host), ?LOOPBACK_DEST).
+
 -else.
+
 -define(DEST_HOST(Host), Host).
+
 -endif.
 
 -record(state, {}).
 
 start_link(Args) ->
-  gen_server:start_link(?MODULE, Args, []).
+    gen_server:start_link(?MODULE, Args, []).
 
 init(_Args) ->
-  {ok, #state{}}.
+    {ok, #state{}}.
 
 % Process a TCP request. Does not truncate the response.
 handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
-  % Uncomment this and the function implementation to simulate a timeout when
-  % querying www.example.com with the test zones
-  % simulate_timeout(DecodedMessage),  
-  
-  Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
-  EncodedMessage = erldns_encoder:encode_message(Response),
-  send_tcp_message(Socket, EncodedMessage),
-  {reply, ok, State}; 
-
+    % Uncomment this and the function implementation to simulate a timeout when
+    % querying www.example.com with the test zones
+    % simulate_timeout(DecodedMessage),
+    Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
+    EncodedMessage = erldns_encoder:encode_message(Response),
+    send_tcp_message(Socket, EncodedMessage),
+    {reply, ok, State};
 % Process a UDP request. May truncate the response.
 handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) ->
-  % Uncomment this and the function implementation to simulate a timeout when
-  % querying www.example.com with the test zones
-  % simulate_timeout(DecodedMessage),
+    % Uncomment this and the function implementation to simulate a timeout when
+    % querying www.example.com with the test zones
+    % simulate_timeout(DecodedMessage),
+    Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
+    DestHost = ?DEST_HOST(Host),
 
-  Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
-  DestHost = ?DEST_HOST(Host),
-
-  case erldns_encoder:encode_message(Response, [{'max_size', max_payload_size(Response)}]) of
-    {false, EncodedMessage} ->
-      % lager:debug("Sending encoded response to ~p", [DestHost]),
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {true, EncodedMessage, Message} when is_record(Message, dns_message)->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {false, EncodedMessage, _TsigMac} ->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-    {true, EncodedMessage, _TsigMac, _Message} ->
-      gen_udp:send(Socket, DestHost, Port, EncodedMessage)
-  end,
-  {reply, ok, State}.
+    case erldns_encoder:encode_message(Response, [{max_size, max_payload_size(Response)}]) of
+        {false, EncodedMessage} ->
+            % lager:debug("Sending encoded response to ~p", [DestHost]),
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {true, EncodedMessage, Message} when is_record(Message, dns_message) ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {false, EncodedMessage, _TsigMac} ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+        {true, EncodedMessage, _TsigMac, _Message} ->
+            gen_udp:send(Socket, DestHost, Port, EncodedMessage)
+    end,
+    {reply, ok, State}.
 
 handle_cast(_Msg, State) ->
-  {noreply, State}.
-handle_info(_Info, State) ->
-  {noreply, State}.
-terminate(_Reason, _State) ->
-  ok.
-code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {noreply, State}.
 
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
 
 %% Internal private functions
 
 send_tcp_message(Socket, EncodedMessage) ->
-  BinLength = byte_size(EncodedMessage),
-  TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
-  gen_tcp:send(Socket, TcpEncodedMessage).
+    BinLength = byte_size(EncodedMessage),
+    TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
+    gen_tcp:send(Socket, TcpEncodedMessage).
 
 %% Determine the max payload size by looking for additional
 %% options passed by the client.
 max_payload_size(Message) ->
-  case Message#dns_message.additional of
-    [Opt|_] when is_record(Opt, dns_optrr) ->
-      case Opt#dns_optrr.udp_payload_size of
-        [] -> ?MAX_PACKET_SIZE;
-        _ -> Opt#dns_optrr.udp_payload_size
-      end;
-    _ -> ?MAX_PACKET_SIZE
-  end.
+    case Message#dns_message.additional of
+        [Opt | _] when is_record(Opt, dns_optrr) ->
+            case Opt#dns_optrr.udp_payload_size of
+                [] ->
+                    ?MAX_PACKET_SIZE;
+                _ ->
+                    Opt#dns_optrr.udp_payload_size
+            end;
+        _ ->
+            ?MAX_PACKET_SIZE
+    end.
 
 %simulate_timeout(DecodedMessage) ->
   %[Question] = DecodedMessage#dns_message.questions,
   %Name = Question#dns_query.name,
   %lager:info("qname: ~p", [Name]),
   %case Name of
+
     %<<"www.example.com">> ->
       %timer:sleep(3000);
+
     %_ ->
       %ok
+
   %end.

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -25,103 +25,96 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -define(MAX_PACKET_SIZE, 512).
 -define(REDIRECT_TO_LOOPBACK, false).
 -define(LOOPBACK_DEST, {127, 0, 0, 10}).
 
 -if(?REDIRECT_TO_LOOPBACK).
-
 -define(DEST_HOST(_Host), ?LOOPBACK_DEST).
-
 -else.
-
 -define(DEST_HOST(Host), Host).
-
 -endif.
 
 -record(state, {}).
 
 start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, []).
+  gen_server:start_link(?MODULE, Args, []).
 
 init(_Args) ->
-    {ok, #state{}}.
+  {ok, #state{}}.
 
 % Process a TCP request. Does not truncate the response.
 handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
-    % Uncomment this and the function implementation to simulate a timeout when
-    % querying www.example.com with the test zones
-    % simulate_timeout(DecodedMessage),
-    Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
-    EncodedMessage = erldns_encoder:encode_message(Response),
-    send_tcp_message(Socket, EncodedMessage),
-    {reply, ok, State};
+  % Uncomment this and the function implementation to simulate a timeout when
+  % querying www.example.com with the test zones
+  % simulate_timeout(DecodedMessage),  
+  
+  Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
+  EncodedMessage = erldns_encoder:encode_message(Response),
+  send_tcp_message(Socket, EncodedMessage),
+  {reply, ok, State}; 
+
 % Process a UDP request. May truncate the response.
 handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) ->
-    % Uncomment this and the function implementation to simulate a timeout when
-    % querying www.example.com with the test zones
-    % simulate_timeout(DecodedMessage),
-    Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
-    DestHost = ?DEST_HOST(Host),
-    case erldns_encoder:encode_message(Response, [{max_size, max_payload_size(Response)}]) of
-        {false, EncodedMessage} ->
-            % lager:debug("Sending encoded response to ~p", [DestHost]),
-            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-        {true, EncodedMessage, Message} when is_record(Message, dns_message) ->
-            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-        {false, EncodedMessage, _TsigMac} ->
-            gen_udp:send(Socket, DestHost, Port, EncodedMessage);
-        {true, EncodedMessage, _TsigMac, _Message} ->
-            gen_udp:send(Socket, DestHost, Port, EncodedMessage)
-    end,
-    {reply, ok, State}.
+  % Uncomment this and the function implementation to simulate a timeout when
+  % querying www.example.com with the test zones
+  % simulate_timeout(DecodedMessage),
+
+  Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
+  DestHost = ?DEST_HOST(Host),
+
+  case erldns_encoder:encode_message(Response, [{'max_size', max_payload_size(Response)}]) of
+    {false, EncodedMessage} ->
+      % lager:debug("Sending encoded response to ~p", [DestHost]),
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {true, EncodedMessage, Message} when is_record(Message, dns_message)->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {false, EncodedMessage, _TsigMac} ->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {true, EncodedMessage, _TsigMac, _Message} ->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage)
+  end,
+  {reply, ok, State}.
 
 handle_cast(_Msg, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 handle_info(_Info, State) ->
-    {noreply, State}.
-
+  {noreply, State}.
 terminate(_Reason, _State) ->
-    ok.
-
+  ok.
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
+
 
 %% Internal private functions
 
 send_tcp_message(Socket, EncodedMessage) ->
-    BinLength = byte_size(EncodedMessage),
-    TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
-    gen_tcp:send(Socket, TcpEncodedMessage).
+  BinLength = byte_size(EncodedMessage),
+  TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
+  gen_tcp:send(Socket, TcpEncodedMessage).
 
 %% Determine the max payload size by looking for additional
 %% options passed by the client.
 max_payload_size(Message) ->
-    case Message#dns_message.additional of
-        [Opt | _] when is_record(Opt, dns_optrr) ->
-            case Opt#dns_optrr.udp_payload_size of
-                [] ->
-                    ?MAX_PACKET_SIZE;
-                _ ->
-                    Opt#dns_optrr.udp_payload_size
-            end;
-        _ ->
-            ?MAX_PACKET_SIZE
-    end.
+  case Message#dns_message.additional of
+    [Opt|_] when is_record(Opt, dns_optrr) ->
+      case Opt#dns_optrr.udp_payload_size of
+        [] -> ?MAX_PACKET_SIZE;
+        _ -> Opt#dns_optrr.udp_payload_size
+      end;
+    _ -> ?MAX_PACKET_SIZE
+  end.
 
 %simulate_timeout(DecodedMessage) ->
   %[Question] = DecodedMessage#dns_message.questions,
   %Name = Question#dns_query.name,
   %lager:info("qname: ~p", [Name]),
   %case Name of
-
     %<<"www.example.com">> ->
       %timer:sleep(3000);
-
     %_ ->
       %ok
-
   %end.

--- a/src/erldns_worker_process_sup.erl
+++ b/src/erldns_worker_process_sup.erl
@@ -19,15 +19,14 @@
 -behavior(supervisor).
 
 -export([start_link/1]).
+
 -export([init/1]).
 
 start_link([WorkerId]) ->
-    % This supervisor is registered without a name. An alternative
-    % if a name is necessary is to create an atom() using the WorkerId
-    % value combined with the module name
-    supervisor:start_link(?MODULE, [WorkerId]).
+  % This supervisor is registered without a name. An alternative
+  % if a name is necessary is to create an atom() using the WorkerId
+  % value combined with the module name
+  supervisor:start_link(?MODULE, [WorkerId]).
 
 init(WorkerId) ->
-    {ok,
-     {{one_for_one, 20, 10},
-      [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}.
+  {ok, {{one_for_one, 20, 10}, [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}. 

--- a/src/erldns_worker_process_sup.erl
+++ b/src/erldns_worker_process_sup.erl
@@ -19,14 +19,15 @@
 -behavior(supervisor).
 
 -export([start_link/1]).
-
 -export([init/1]).
 
 start_link([WorkerId]) ->
-  % This supervisor is registered without a name. An alternative
-  % if a name is necessary is to create an atom() using the WorkerId
-  % value combined with the module name
-  supervisor:start_link(?MODULE, [WorkerId]).
+    % This supervisor is registered without a name. An alternative
+    % if a name is necessary is to create an atom() using the WorkerId
+    % value combined with the module name
+    supervisor:start_link(?MODULE, [WorkerId]).
 
 init(WorkerId) ->
-  {ok, {{one_for_one, 20, 10}, [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}. 
+    {ok,
+     {{one_for_one, 20, 10},
+      [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}.

--- a/src/erldns_worker_process_sup.erl
+++ b/src/erldns_worker_process_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -22,12 +22,13 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([start_link/0]).
+
 % Read APIs
--export([find_zone/1,
+-export([
+         find_zone/1,
          find_zone/2,
          get_zone/1,
          get_authority/1,
@@ -38,23 +39,32 @@
          in_zone/1,
          record_name_in_zone/2,
          zone_names_and_versions/0,
-         get_rrset_sync_counter/3]).
+	 get_rrset_sync_counter/3
+        ]).
+
 % Deprecated APIs
--export([get_zone_with_records/1]).
+-export([
+         get_zone_with_records/1
+        ]).
+
 % Write APIs
--export([put_zone/1,
+-export([
+         put_zone/1,
          put_zone/2,
          delete_zone/1,
          update_zone_records_and_digest/3,
-         put_zone_rrset/4,
-         delete_zone_rrset/5]).
+	 put_zone_rrset/4,
+	 delete_zone_rrset/5
+        ]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -define(SERVER, ?MODULE).
 
@@ -63,7 +73,7 @@
 %% @doc Start the zone cache process.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 % ----------------------------------------------------------------------------------------------------
 % Read API
@@ -71,194 +81,170 @@ start_link() ->
 %% @doc Find a zone for a given qname.
 -spec find_zone(dns:dname()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname) ->
-    find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
+  find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
 
 %% @doc Find a zone for a given qname.
--spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) ->
-                   #zone{} | {error, zone_not_found} | {error, not_authoritative}.
+-spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname, {error, _}) ->
-    find_zone(Qname, []);
+  find_zone(Qname, []);
 find_zone(Qname, {ok, Authority}) ->
-    find_zone(Qname, Authority);
+  find_zone(Qname, Authority);
 find_zone(_Qname, []) ->
-    {error, not_authoritative};
+  {error, not_authoritative};
 find_zone(Qname, Authorities) when is_list(Authorities) ->
-    find_zone(Qname, lists:last(Authorities));
+  find_zone(Qname, lists:last(Authorities));
 find_zone(Qname, Authority) when is_record(Authority, dns_rr) ->
-    Name = erldns:normalize_name(Qname),
-    case dns:dname_to_labels(Name) of
-        [] ->
-            {error, zone_not_found};
-        [_ | Labels] ->
-            case get_zone(Name) of
-                {ok, Zone} ->
-                    Zone;
-                {error, zone_not_found} ->
-                    case Name =:= Authority#dns_rr.name of
-                        true ->
-                            {error, zone_not_found};
-                        false ->
-                            find_zone(dns:labels_to_dname(Labels), Authority)
-                    end
-            end
-    end.
+  Name = erldns:normalize_name(Qname),
+  case dns:dname_to_labels(Name) of
+    [] -> {error, zone_not_found};
+    [_|Labels] ->
+      case get_zone(Name) of
+        {ok, Zone} -> Zone;
+        {error, zone_not_found} ->
+          case Name =:= Authority#dns_rr.name of
+            true -> {error, zone_not_found};
+            false -> find_zone(dns:labels_to_dname(Labels), Authority)
+          end
+      end
+  end.
 
 %% @doc Get a zone for the specific name. This function will not attempt to resolve
 %% the dname in any way, it will simply look up the name in the underlying data store.
 -spec get_zone(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone(Name) ->
-    NormalizedName = erldns:normalize_name(Name),
-    case erldns_storage:select(zones, NormalizedName) of
-        [{NormalizedName, Zone}] ->
-            {ok,
-             Zone#zone{name = NormalizedName,
-                       records = [],
-                       records_by_name = trimmed}};
-        _ ->
-            {error, zone_not_found}
-    end.
+  NormalizedName = erldns:normalize_name(Name),
+  case erldns_storage:select(zones, NormalizedName) of
+    [{NormalizedName, Zone}] -> {ok, Zone#zone{name = NormalizedName, records = [], records_by_name=trimmed}};
+    _ -> {error, zone_not_found}
+  end.
 
 %% @doc Get a zone for the specific name, including the records for the zone.
 %% @deprecated Use {@link erldns_zone_cache:get_zone/1} to get the zone meta data and
 %% {@link erldns_zone_cache:get_zone_records/1} to get the records for the zone.
 -spec get_zone_with_records(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone_with_records(Name) ->
-    NormalizedName = erldns:normalize_name(Name),
-    case erldns_storage:select(zones, NormalizedName) of
-        [{NormalizedName, Zone}] ->
-            {ok, Zone};
-        _ ->
-            {error, zone_not_found}
-    end.
+  NormalizedName = erldns:normalize_name(Name),
+  case erldns_storage:select(zones, NormalizedName) of
+    [{NormalizedName, Zone}] -> {ok, Zone};
+    _ -> {error, zone_not_found}
+  end.
 
 %% @doc Find the SOA record for the given DNS question.
 -spec get_authority(dns:message() | dns:dname()) -> {error, no_question} | {error, authority_not_found} | {ok, dns:authority()}.
 get_authority(Message) when is_record(Message, dns_message) ->
-    case Message#dns_message.questions of
-        [] ->
-            {error, no_question};
-        Questions ->
-            Question = lists:last(Questions),
-            get_authority(Question#dns_query.name)
-    end;
+  case Message#dns_message.questions of
+    [] -> {error, no_question};
+    Questions -> 
+      Question = lists:last(Questions),
+      get_authority(Question#dns_query.name)
+  end;
 get_authority(Name) ->
-    case find_zone_in_cache(erldns:normalize_name(Name)) of
-        {ok, Zone} ->
-            {ok, Zone#zone.authority};
-        _ ->
-            {error, authority_not_found}
-    end.
+  case find_zone_in_cache(erldns:normalize_name(Name)) of
+    {ok, Zone} -> {ok, Zone#zone.authority};
+    _ -> {error, authority_not_found}
+  end.
 
 %% @doc Get the list of NS and glue records for the given name. This function
 %% will always return a list, even if it is empty.
 -spec get_delegations(dns:dname()) -> [dns:rr()] | [].
 get_delegations(Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            Records =
-                lists:flatten(erldns_storage:select(zone_records_typed,
-                                                    [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
-                                                    infinite)),
-            lists:filter(erldns_records:match_delegation(Name), Records);
-        _ ->
-            []
-    end.
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      Records = lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'},[],['$$']}], infinite)),
+      lists:filter(erldns_records:match_delegation(Name), Records);
+    _ ->
+      []
+  end.
 
 %% @doc Get all records for the given zone.
 -spec get_zone_records(dns:dname()) -> [dns:rr()].
 get_zone_records(Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'}, [], ['$$']}], infinite));
-        _ ->
-            []
-    end.
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'},[],['$$']}], infinite));
+    _ ->
+      []
+  end.
 
 %% @doc Get all records for the given type and given name.
 -spec get_records_by_name_and_type(dns:dname(), dns:type()) -> [dns:rr()].
 get_records_by_name_and_type(Name, Type) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed,
-                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'}, [], ['$$']}],
-                                                infinite));
-        _ ->
-            []
-    end.
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'},[],['$$']}], infinite));
+    _ ->
+      []
+  end.
 
 %% @doc Get all DNSSEC records for zone
 -spec get_zone_dnskey_records(dns:dname()) -> [dns:rr()].
 get_zone_dnskey_records(Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, _Zone} ->
-            get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
-        _ ->
-            []
-    end.
+	case find_zone_in_cache(Name) of
+		{ok, _Zone} ->
+			get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
+		_ ->
+			[]
+	end.
 
 %% @doc Return the record set for the given dname.
 -spec get_records_by_name(dns:dname()) -> [dns:rr()].
 get_records_by_name(Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed,
-                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}],
-                                                infinite));
-        _ ->
-            []
-    end.
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      lists:flatten(erldns_storage:select(zone_records_typed,[{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite));
+    _ ->
+      []
+  end.
 
 %% @doc Check if the name is in a zone.
 -spec in_zone(binary()) -> boolean().
 in_zone(Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            is_name_in_zone(Name, Zone);
-        _ ->
-            false
-    end.
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      is_name_in_zone(Name, Zone);
+    _ ->
+      false
+  end.
 
 %% @doc Check if the record name is in the zone. Will also return true if a wildcard is present at the node.
 -spec record_name_in_zone(binary(), dns:dname()) -> boolean().
 record_name_in_zone(ZoneName, Name) ->
-    case find_zone_in_cache(Name) of
-        {ok, Zone} ->
-            case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
-                [] ->
-                    is_name_in_zone_with_wildcard(Name, Zone);
-                _ ->
-                    true
-            end;
+  case find_zone_in_cache(Name) of
+    {ok, Zone} ->
+      case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
+        [] ->
+         is_name_in_zone_with_wildcard(Name, Zone);
         _ ->
-            false
-    end.
+          true
+      end;
+    _ ->
+      false
+  end.
 
 %% @doc Return a list of tuples with each tuple as a name and the version SHA
 %% for the zone.
 -spec zone_names_and_versions() -> [{dns:dname(), binary()}].
 zone_names_and_versions() ->
-    % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
-    case erldns_config:storage_type() of
-        erldns_storage_json ->
-            erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
-        erldns_storage_mnesia ->
-            erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
-    end.
+  % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
+  case erldns_config:storage_type() of 
+    erldns_storage_json -> 
+	erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
+    erldns_storage_mnesia ->
+	erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
+  end.
 
 %% @doc Return current sync counter
 -spec get_rrset_sync_counter(dns:dname(), dns:dname(), dns:type()) -> integer().
 get_rrset_sync_counter(ZoneName, RRFqdn, Type) ->
-    case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite) of
-        [{ZoneName, RRFqdn, Type, Counter}] ->
-            Counter;
-        [] ->
-            0 % return default value of 0
-    end.
+	case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite)  of
+		[{ZoneName, RRFqdn, Type, Counter}] -> Counter;
+		[] -> 0 % return default value of 0
+  	end.
 
 -spec write_rrset_sync_counter({dns:dname(), dns:dname(), dns:type(), integer()}) -> ok.
 write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
-    erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
-
+  erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
+	
 % ----------------------------------------------------------------------------------------------------
 % Write API
 
@@ -267,147 +253,146 @@ write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
 %%
 %% This function will build the necessary Zone record before inserting.
 -spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()}
-    when Name :: binary(),
-         Sha :: binary(),
-         Records :: [dns:rr()],
-         Keys :: [erldns:keyset()].
+  when Name :: binary(), Sha :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()].
 put_zone({Name, Sha, Records}) ->
     put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
-    SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
-    NamedRecords = build_named_index(SignedZone#zone.records),
-    delete_zone_records(erldns:normalize_name(Name)),
-    case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
-        ok ->
-            put_zone_records(erldns:normalize_name(Name), NamedRecords);
-        {error, Reason} ->
-            {error, Reason}
-    end.
+  SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
+  NamedRecords = build_named_index(SignedZone#zone.records),
+  delete_zone_records(erldns:normalize_name(Name)),
+  case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
+    ok -> put_zone_records(erldns:normalize_name(Name), NamedRecords);
+    {error, Reason} -> {error, Reason}
+  end.
 
 %% @doc Put a zone into the cache and wait for a response.
 -spec put_zone(dns:name(), erldns:zone()) -> ok | {error, Reason :: term()}.
 put_zone(Name, Zone) ->
-    erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
+  erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
 
 -spec put_zone_records(dns:name(), map()) -> ok.
 put_zone_records(Name, RecordsByName) ->
-    put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
+  put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
 
 %% @doc Put zone RRSet
 %-spec put_zone_rrset(({Name, Digest, Records}, RRFqdn, Type, Counter) | ({Name, Digest, Records}, RRFqdn, Type, Counter)) -> ok | {error, Reason :: term()}
 %  when Name :: binary(), Digest :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()], RRFqdn :: binary(), Type :: binary(), Counter :: integer().
 put_zone_rrset({ZoneName, Digest, Records}, RRFqdn, Type, Counter) ->
-    put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
+  put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
 put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
-    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-        {ok, Zone} ->
-            % TODO: remove debug
-            lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
-            KeySets = Zone#zone.keysets,
-            DnsKeyRRs = get_zone_dnskey_records(ZoneName),
-            SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
-            RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
-            % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
-            TypedRecords = build_typed_index(Records ++ SignedRRSet ++ RRSigRecs),
-            % put zone_records_typed records first then create the records in zone_records
-            put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
-            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
-            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
-            lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
-            ok;
-        _ -> % if zone is not in cache, return error
-            {error, zone_not_found}
-    end.
+  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+     {ok, Zone} ->
+	  % TODO: remove debug
+	  lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
+	  KeySets = Zone#zone.keysets,
+	  DnsKeyRRs = get_zone_dnskey_records(ZoneName),
+	  SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
+	  RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
+
+	  % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
+	  TypedRecords = build_typed_index(Records ++ 
+					   SignedRRSet ++ 
+					   RRSigRecs),
+	  % put zone_records_typed records first then create the records in zone_records
+	  put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
+
+	  update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+
+	  write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
+
+	  lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
+	  ok;
+    _ -> % if zone is not in cache, return error
+      {error, zone_not_found}
+  end.
 
 put_zone_records_entry(_, none) ->
-    ok;
+  ok;
 put_zone_records_entry(Name, {K, V, I}) ->
-    put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
-    put_zone_records_entry(Name, maps:next(I)).
+  put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
+  put_zone_records_entry(Name, maps:next(I)).
 
 put_zone_records_typed_entry(_, _, none) ->
-    ok;
+  ok;
 put_zone_records_typed_entry(ZoneName, Fqdn, {K, V, I}) ->
-    erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
-    put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
+  erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
+  put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
 
 %% @doc Remove a zone from the cache without waiting for a response.
 -spec delete_zone(binary()) -> any().
 delete_zone(Name) ->
-    gen_server:cast(?SERVER, {delete, Name}).
+  gen_server:cast(?SERVER, {delete, Name}).
 
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
-    erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'}, [], [true]}]).
+  erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]).
 
 %% @doc Remove zone RRSet
 -spec delete_zone_rrset(binary(), binary(), binary(), integer(), integer()) -> any().
 delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
-    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-        {ok, Zone} ->
-            Zone,
-            CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
-            case Counter of
-                N when N =:= 0; CurrentCounter < N ->
-                    lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
-                    erldns_storage:select_delete(zone_records_typed,
-                                                 [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'}, [], [true]}]),
-                    % remove the RRSIG for the given record type
-                    {_RRSigsCovering, RRSigsNotCovering} =
-                        lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(ZoneName, ?DNS_TYPE_RRSIG_NUMBER)),
-                    erldns_storage:insert(zone_records_typed,
-                                          {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
-                    % only write counter if called explicitly with Counter value i.e. different than 0.
-                    % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
-                    case Counter of
-                        N when N > 0 ->
-                            % DELETE RRSet command has been sent
-                            % we need to update the zone digest as the zone content changes
-                            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
-                            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
-                        _ ->
-                            ok
-                    end;
-                N when CurrentCounter > N ->
-                    lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
-            end;
-        _ ->
-            {error, zone_not_found}
-    end.
+  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+    {ok, Zone} -> 
+      Zone,
+      CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
+      case Counter of
+        N when N =:= 0; CurrentCounter < N ->
+          lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
+
+          erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'},[],[true]}]),
+
+          % remove the RRSIG for the given record type
+          {_RRSigsCovering, RRSigsNotCovering} = lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(ZoneName, ?DNS_TYPE_RRSIG_NUMBER)),
+          erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
+
+          % only write counter if called explicitly with Counter value i.e. different than 0.
+          % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
+          case Counter of
+            N when N > 0 ->
+              % DELETE RRSet command has been sent
+              % we need to update the zone digest as the zone content changes
+              update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+
+              write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
+            _ ->
+              ok
+          end;
+        N when CurrentCounter > N ->
+          lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
+      end;
+    _ -> {error, zone_not_found}
+  end.
 
 %% @doc Given a zone name, list of records, and a digest, update the zone metadata in cache.
 -spec update_zone_records_and_digest(dns:dname(), [dns:rr()], binary()) -> ok | {error, Reason :: term()}.
 update_zone_records_and_digest(ZoneName, Records, Digest) ->
-    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-        {ok, Zone} ->
-            Zone,
-            UpdatedZone =
-                Zone#zone{version = Digest,
-                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
-                          record_count = length(Records),
-                          records_by_name = build_named_index(Records)},
-            put_zone(Zone#zone.name, UpdatedZone);
-        _ ->
-            {error, zone_not_found}
-    end.
+  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+    {ok, Zone} -> Zone,
+                  UpdatedZone = Zone#zone{version = Digest,
+                                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
+                                          record_count = length(Records),
+                                          records_by_name = build_named_index(Records)},
+                  put_zone(Zone#zone.name, UpdatedZone);
+    _ -> {error, zone_not_found}
+  end.
 
 %% @doc Filter RRSig records for FQDN, removing type covered.
 -spec filter_rrsig_records_with_type_covered(dns:dname(), dns:type()) -> [{{dns:dname(), dns:dname(), dns:type()}, [dns:rr()]} | []].
 filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
-    % guards below do not allow fun calls to prevent side effects
-    case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
-        {ok, _Zone} ->
-            lists:flatten(lists:foldl(fun(R, Records) ->
-                                         case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
-                                             true -> [R | Records];
-                                             false -> [Records]
-                                         end
-                                      end,
-                                      [],
-                                      get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER)));
-        _ ->
-            []
-    end.
+  % guards below do not allow fun calls to prevent side effects
+  case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
+    {ok, _Zone} ->
+      lists:flatten(
+        lists:foldl(
+          fun(R, Records) ->
+              case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
+                true -> [R | Records];  
+                false -> [Records]
+              end
+          end, [], get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER))
+       );
+    _ ->
+      []
+  end.
 
 % ----------------------------------------------------------------------------------------------------
 % Gen server init
@@ -415,203 +400,170 @@ filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
 %% @doc Initialize the zone cache.
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-    erldns_storage:create(schema),
-    erldns_storage:create(zones),
-    erldns_storage:create(zone_records_typed),
-    erldns_storage:create(authorities),
-    erldns_storage:create(sync_counters),
-    {ok, #state{parsers = []}}.
+  erldns_storage:create(schema),
+  erldns_storage:create(zones),
+  erldns_storage:create(zone_records_typed),
+  erldns_storage:create(authorities),
+  erldns_storage:create(sync_counters),
+  {ok, #state{parsers = []}}.
 
 % ----------------------------------------------------------------------------------------------------
 % gen_server callbacks
 
 handle_call(Message, _From, State) ->
-    lager:debug("Received unsupported call (message: ~p)", [Message]),
-    {reply, ok, State}.
+  lager:debug("Received unsupported call (message: ~p)", [Message]),
+  {reply, ok, State}.
 
 handle_cast({delete, Name}, State) ->
-    erldns_storage:delete(zones, erldns:normalize_name(Name)),
-    delete_zone_records(Name),
-    {noreply, State};
+  erldns_storage:delete(zones, erldns:normalize_name(Name)),
+  delete_zone_records(Name),
+  {noreply, State};
+
 handle_cast(Message, State) ->
-    lager:debug("Received unsupported cast (message: ~p)", [Message]),
-    {noreply, State}.
+  lager:debug("Received unsupported cast (message: ~p)", [Message]),
+  {noreply, State}.
 
 handle_info(_Message, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok.
+  ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
+
 
 % Internal API
 is_name_in_zone(Name, Zone) ->
-    ZoneName = erldns:normalize_name(Zone#zone.name),
-    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
-        [] ->
-            case dns:dname_to_labels(Name) of
-                [] ->
-                    false;
-                [_] ->
-                    false;
-                [_ | Labels] ->
-                    is_name_in_zone(dns:labels_to_dname(Labels), Zone)
-            end;
-        _ ->
-            true
-    end.
+  ZoneName = erldns:normalize_name(Zone#zone.name),
+  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
+    [] -> 
+      case dns:dname_to_labels(Name) of
+        [] -> false;
+        [_] -> false;
+        [_|Labels] -> is_name_in_zone(dns:labels_to_dname(Labels), Zone)
+      end;
+    _ -> true
+  end.
 
 is_name_in_zone_with_wildcard(Name, Zone) ->
-    ZoneName = erldns:normalize_name(Zone#zone.name),
-    WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
-    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'}, [], ['$$']}], infinite)) of
-        [] ->
-            case dns:dname_to_labels(Name) of
-                [] ->
-                    false;
-                [_] ->
-                    false;
-                [_ | Labels] ->
-                    is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
-            end;
-        _ ->
-            true
-    end.
+  ZoneName = erldns:normalize_name(Zone#zone.name),
+  WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
+  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'},[],['$$']}], infinite)) of
+    [] ->
+      case dns:dname_to_labels(Name) of
+        [] -> false;
+        [_] -> false;
+        [_|Labels] -> is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
+      end;
+    _ -> true
+  end.
 
 find_zone_in_cache(Qname) ->
-    Name = erldns:normalize_name(Qname),
-    find_zone_in_cache(Name, dns:dname_to_labels(Name)).
+  Name = erldns:normalize_name(Qname),
+  find_zone_in_cache(Name, dns:dname_to_labels(Name)).
 
 find_zone_in_cache(_Name, []) ->
-    {error, zone_not_found};
-find_zone_in_cache(Name, [_ | Labels]) ->
-    case erldns_storage:select(zones, Name) of
-        [{Name, Zone}] ->
-            {ok, Zone};
-        _ ->
-            case Labels of
-                [] ->
-                    {error, zone_not_found};
-                _ ->
-                    find_zone_in_cache(dns:labels_to_dname(Labels))
-            end
-    end.
+  {error, zone_not_found};
+find_zone_in_cache(Name, [_|Labels]) ->
+  case erldns_storage:select(zones, Name) of
+    [{Name, Zone}] -> {ok, Zone};
+    _ ->
+      case Labels of
+        [] -> {error, zone_not_found};
+        _ -> find_zone_in_cache(dns:labels_to_dname(Labels))
+      end
+  end.
 
 build_zone(Qname, Version, Records, Keys) ->
-    Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
-    #zone{name = Qname,
-          version = Version,
-          record_count = length(Records),
-          authority = Authorities,
-          records = Records,
-          records_by_name = trimmed,
-          keysets = Keys}.
+  Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
+  #zone{name = Qname, version = Version, record_count = length(Records), authority = Authorities, records = Records, records_by_name = trimmed, keysets = Keys}.
 
--spec build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}.
+-spec(build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}).
 build_named_index(Records) ->
-    NamedIndex =
-        lists:foldl(fun(R, Idx) ->
-                       Name = erldns:normalize_name(R#dns_rr.name),
-                       maps:update_with(Name, fun(RR) -> [R | RR] end, [R], Idx)
-                    end,
-                    #{},
-                    Records),
-    maps:map(fun(_K, V) -> lists:reverse(V) end, NamedIndex).
+  NamedIndex = lists:foldl(fun (R, Idx) ->
+                               Name = erldns:normalize_name(R#dns_rr.name),
+                               maps:update_with(Name, fun (RR) -> [R | RR] end, [R], Idx)
+                           end, #{}, Records),
+  maps:map(fun (_K, V) -> lists:reverse(V) end, NamedIndex).
 
--spec build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}.
+-spec(build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}).
 build_typed_index(Records) ->
-    TypedIndex = lists:foldl(fun(R, Idx) -> maps:update_with(R#dns_rr.type, fun(RR) -> [R | RR] end, [R], Idx) end, #{}, Records),
-    maps:map(fun(_K, V) -> lists:reverse(V) end, TypedIndex).
+  TypedIndex = lists:foldl(fun (R, Idx) ->
+                               maps:update_with(R#dns_rr.type, fun (RR) -> [R | RR] end, [R], Idx)
+                           end, #{}, Records),
+  maps:map(fun (_K, V) -> lists:reverse(V) end, TypedIndex).
 
--spec sign_zone(erldns:zone()) -> erldns:zone().
+-spec(sign_zone(erldns:zone()) -> erldns:zone()).
 sign_zone(Zone = #zone{keysets = []}) ->
-    Zone;
+  Zone;
 sign_zone(Zone) ->
-    % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
-    DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
-    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
-    Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
-    lager:debug("Zone verified: ~p", [Verify]),
-    % TODO: remove wildcard signatures as they will not be used but are taking up space
-    ZoneRRSigRecords =
-        lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name,
-                                                                lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end, Zone#zone.records)),
-                                Zone#zone.keysets)),
-    Records =
-        Zone#zone.records ++
-            KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
-    #zone{name = Zone#zone.name,
-          version = Zone#zone.version,
-          record_count = length(Records),
-          authority = Zone#zone.authority,
-          records = Records,
-          records_by_name = build_named_index(Records),
-          keysets = Zone#zone.keysets}.
+  % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
+  DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
+  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
+  Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
+  lager:debug("Zone verified: ~p", [Verify]),
+  % TODO: remove wildcard signatures as they will not be used but are taking up space
+  ZoneRRSigRecords = lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Zone#zone.records)), Zone#zone.keysets)),
+  Records = Zone#zone.records ++ KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
+  #zone{name = Zone#zone.name, version = Zone#zone.version, record_count = length(Records), authority = Zone#zone.authority, records = Records, records_by_name = build_named_index(Records), keysets = Zone#zone.keysets}.
 
--spec verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean().
+-spec(verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean()).
 verify_zone(_Zone, DnskeyRRs, KeyRRSigRecords) ->
-    % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
-    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
-        [] ->
-            false;
-        KSKs ->
-            % lager:debug("KSKs: ~p", [KSKs]),
-            KSKDnskey = lists:last(KSKs),
-            RRSig = lists:last(KeyRRSigRecords),
-            % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
-            VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
-            % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
-            VerifyResult
-    end.
+  % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
+  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
+    [] -> false;
+    KSKs -> 
+      % lager:debug("KSKs: ~p", [KSKs]),
+      KSKDnskey = lists:last(KSKs),
+      RRSig = lists:last(KeyRRSigRecords),
+      % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
+      VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
+      % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
+      VerifyResult
+  end.
 
 % Sign RRSet
--spec sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()].
+-spec(sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()]).
 sign_rrset(Name, Records, DnsKeyRRs, KeySets) ->
-    % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
-    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
-    ZoneRecords = get_zone_records(Name),
-    RRSigRecords =
-        rewrite_soa_rrsig_ttl(ZoneRecords,
-                              lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name,
-                                                                                      lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end,
-                                                                                                   Records)),
-                                                      KeySets))),
-    verify_rrset(DnsKeyRRs, KeyRRSigRecords),
-    RRSigRecords.
+  % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
+  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
+  ZoneRecords = get_zone_records(Name),
+  RRSigRecords = rewrite_soa_rrsig_ttl(ZoneRecords, lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Records)), KeySets))),
+  verify_rrset(DnsKeyRRs, KeyRRSigRecords),
+  RRSigRecords.
 
 % Verify RRSet
--spec verify_rrset([dns:rr()], [dns:rr()]) -> boolean().
+-spec(verify_rrset([dns:rr()], [dns:rr()]) -> boolean()).
 verify_rrset(DnsKeyRRs, KeyRRSigRecords) ->
-    % lager:debug("Verify RRSet"),
-    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
-        [] ->
-            false;
-        KSKs ->
-            case KeyRRSigRecords of
-                [] ->
-                    false;
-                _ ->
-                    % lager:debug("KSKs: ~p", [KSKs]),
-                    KSKDnskey = lists:last(KSKs),
-                    RRSig = lists:last(KeyRRSigRecords),
-                    VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
-                    VerifyResult
-            end
-    end.
+  % lager:debug("Verify RRSet"),
+  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
+    [] -> false;
+    KSKs -> 
+      case KeyRRSigRecords of
+        [] -> false;
+        _ ->
+          % lager:debug("KSKs: ~p", [KSKs]),
+          KSKDnskey = lists:last(KSKs),
+          RRSig = lists:last(KeyRRSigRecords),
+          VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
+          VerifyResult
+      end
+  end.
 
 % Rewrite the RRSIG TTL so it follows the same rewrite rules as the SOA TTL.
 rewrite_soa_rrsig_ttl(ZoneRecords, RRSigRecords) ->
-    SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
-    lists:map(fun(RR) ->
-                 case RR#dns_rr.type of
-                     ?DNS_TYPE_RRSIG ->
-                         case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
-                             ?DNS_TYPE_SOA -> erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
-                             _ -> RR
-                         end;
-                     _ -> RR
-                 end
-              end,
-              RRSigRecords).
+  SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
+  lists:map(
+    fun(RR) ->
+        case RR#dns_rr.type of
+          ?DNS_TYPE_RRSIG ->
+            case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
+              ?DNS_TYPE_SOA ->
+                erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
+              _ ->
+                RR
+            end;
+          _ -> RR
+        end
+    end, RRSigRecords).

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -341,7 +341,7 @@ delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
           erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'},[],[true]}]),
 
           % remove the RRSIG for the given record type
-          {_RRSigsCovering, RRSigsNotCovering} = lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(ZoneName, ?DNS_TYPE_RRSIG_NUMBER)),
+          {_RRSigsCovering, RRSigsNotCovering} = lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)),
           erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
 
           % only write counter if called explicitly with Counter value i.e. different than 0.

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -241,6 +241,7 @@ get_rrset_sync_counter(ZoneName, RRFqdn, Type) ->
 		[] -> 0 % return default value of 0
   	end.
 
+%% @doc Update the RRSet sync counter for the given RR set name and type in the given zone.
 -spec write_rrset_sync_counter({dns:dname(), dns:dname(), dns:type(), integer()}) -> ok.
 write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
   erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
@@ -275,8 +276,7 @@ put_zone_records(Name, RecordsByName) ->
   put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
 
 %% @doc Put zone RRSet
-%-spec put_zone_rrset(({Name, Digest, Records}, RRFqdn, Type, Counter) | ({Name, Digest, Records}, RRFqdn, Type, Counter)) -> ok | {error, Reason :: term()}
-%  when Name :: binary(), Digest :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()], RRFqdn :: binary(), Type :: binary(), Counter :: integer().
+-spec put_zone_rrset({dns:dname(), binary(), [dns:rr()]} | {dns:dname(), binary(), [dns:rr()], [any()]}, dns:dname(), dns:type(), integer()) -> ok | {error, Reason :: term()}.
 put_zone_rrset({ZoneName, Digest, Records}, RRFqdn, Type, Counter) ->
   put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
 put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -22,13 +22,12 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([start_link/0]).
-
 % Read APIs
--export([
-         find_zone/1,
+-export([find_zone/1,
          find_zone/2,
          get_zone/1,
          get_authority/1,
@@ -39,32 +38,23 @@
          in_zone/1,
          record_name_in_zone/2,
          zone_names_and_versions/0,
-	 get_rrset_sync_counter/3
-        ]).
-
+         get_rrset_sync_counter/3]).
 % Deprecated APIs
--export([
-         get_zone_with_records/1
-        ]).
-
+-export([get_zone_with_records/1]).
 % Write APIs
--export([
-         put_zone/1,
+-export([put_zone/1,
          put_zone/2,
          delete_zone/1,
          update_zone_records_and_digest/3,
-	 put_zone_rrset/4,
-	 delete_zone_rrset/5
-        ]).
-
+         put_zone_rrset/4,
+         delete_zone_rrset/5]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -73,7 +63,7 @@
 %% @doc Start the zone cache process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 % ----------------------------------------------------------------------------------------------------
 % Read API
@@ -81,170 +71,194 @@ start_link() ->
 %% @doc Find a zone for a given qname.
 -spec find_zone(dns:dname()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname) ->
-  find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
+    find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
 
 %% @doc Find a zone for a given qname.
--spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
+-spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) ->
+                   #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname, {error, _}) ->
-  find_zone(Qname, []);
+    find_zone(Qname, []);
 find_zone(Qname, {ok, Authority}) ->
-  find_zone(Qname, Authority);
+    find_zone(Qname, Authority);
 find_zone(_Qname, []) ->
-  {error, not_authoritative};
+    {error, not_authoritative};
 find_zone(Qname, Authorities) when is_list(Authorities) ->
-  find_zone(Qname, lists:last(Authorities));
+    find_zone(Qname, lists:last(Authorities));
 find_zone(Qname, Authority) when is_record(Authority, dns_rr) ->
-  Name = erldns:normalize_name(Qname),
-  case dns:dname_to_labels(Name) of
-    [] -> {error, zone_not_found};
-    [_|Labels] ->
-      case get_zone(Name) of
-        {ok, Zone} -> Zone;
-        {error, zone_not_found} ->
-          case Name =:= Authority#dns_rr.name of
-            true -> {error, zone_not_found};
-            false -> find_zone(dns:labels_to_dname(Labels), Authority)
-          end
-      end
-  end.
+    Name = erldns:normalize_name(Qname),
+    case dns:dname_to_labels(Name) of
+        [] ->
+            {error, zone_not_found};
+        [_ | Labels] ->
+            case get_zone(Name) of
+                {ok, Zone} ->
+                    Zone;
+                {error, zone_not_found} ->
+                    case Name =:= Authority#dns_rr.name of
+                        true ->
+                            {error, zone_not_found};
+                        false ->
+                            find_zone(dns:labels_to_dname(Labels), Authority)
+                    end
+            end
+    end.
 
 %% @doc Get a zone for the specific name. This function will not attempt to resolve
 %% the dname in any way, it will simply look up the name in the underlying data store.
 -spec get_zone(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone(Name) ->
-  NormalizedName = erldns:normalize_name(Name),
-  case erldns_storage:select(zones, NormalizedName) of
-    [{NormalizedName, Zone}] -> {ok, Zone#zone{name = NormalizedName, records = [], records_by_name=trimmed}};
-    _ -> {error, zone_not_found}
-  end.
+    NormalizedName = erldns:normalize_name(Name),
+    case erldns_storage:select(zones, NormalizedName) of
+        [{NormalizedName, Zone}] ->
+            {ok,
+             Zone#zone{name = NormalizedName,
+                       records = [],
+                       records_by_name = trimmed}};
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Get a zone for the specific name, including the records for the zone.
 %% @deprecated Use {@link erldns_zone_cache:get_zone/1} to get the zone meta data and
 %% {@link erldns_zone_cache:get_zone_records/1} to get the records for the zone.
 -spec get_zone_with_records(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone_with_records(Name) ->
-  NormalizedName = erldns:normalize_name(Name),
-  case erldns_storage:select(zones, NormalizedName) of
-    [{NormalizedName, Zone}] -> {ok, Zone};
-    _ -> {error, zone_not_found}
-  end.
+    NormalizedName = erldns:normalize_name(Name),
+    case erldns_storage:select(zones, NormalizedName) of
+        [{NormalizedName, Zone}] ->
+            {ok, Zone};
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Find the SOA record for the given DNS question.
 -spec get_authority(dns:message() | dns:dname()) -> {error, no_question} | {error, authority_not_found} | {ok, dns:authority()}.
 get_authority(Message) when is_record(Message, dns_message) ->
-  case Message#dns_message.questions of
-    [] -> {error, no_question};
-    Questions -> 
-      Question = lists:last(Questions),
-      get_authority(Question#dns_query.name)
-  end;
+    case Message#dns_message.questions of
+        [] ->
+            {error, no_question};
+        Questions ->
+            Question = lists:last(Questions),
+            get_authority(Question#dns_query.name)
+    end;
 get_authority(Name) ->
-  case find_zone_in_cache(erldns:normalize_name(Name)) of
-    {ok, Zone} -> {ok, Zone#zone.authority};
-    _ -> {error, authority_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(Name)) of
+        {ok, Zone} ->
+            {ok, Zone#zone.authority};
+        _ ->
+            {error, authority_not_found}
+    end.
 
 %% @doc Get the list of NS and glue records for the given name. This function
 %% will always return a list, even if it is empty.
 -spec get_delegations(dns:dname()) -> [dns:rr()] | [].
 get_delegations(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      Records = lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'},[],['$$']}], infinite)),
-      lists:filter(erldns_records:match_delegation(Name), Records);
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            Records =
+                lists:flatten(erldns_storage:select(zone_records_typed,
+                                                    [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
+                                                    infinite)),
+            lists:filter(erldns_records:match_delegation(Name), Records);
+        _ ->
+            []
+    end.
 
 %% @doc Get all records for the given zone.
 -spec get_zone_records(dns:dname()) -> [dns:rr()].
 get_zone_records(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'}, [], ['$$']}], infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Get all records for the given type and given name.
 -spec get_records_by_name_and_type(dns:dname(), dns:type()) -> [dns:rr()].
 get_records_by_name_and_type(Name, Type) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed,
+                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'}, [], ['$$']}],
+                                                infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Get all DNSSEC records for zone
 -spec get_zone_dnskey_records(dns:dname()) -> [dns:rr()].
 get_zone_dnskey_records(Name) ->
-	case find_zone_in_cache(Name) of
-		{ok, _Zone} ->
-			get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
-		_ ->
-			[]
-	end.
+    case find_zone_in_cache(Name) of
+        {ok, _Zone} ->
+            get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
+        _ ->
+            []
+    end.
 
 %% @doc Return the record set for the given dname.
 -spec get_records_by_name(dns:dname()) -> [dns:rr()].
 get_records_by_name(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed,[{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed,
+                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}],
+                                                infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Check if the name is in a zone.
 -spec in_zone(binary()) -> boolean().
 in_zone(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      is_name_in_zone(Name, Zone);
-    _ ->
-      false
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            is_name_in_zone(Name, Zone);
+        _ ->
+            false
+    end.
 
 %% @doc Check if the record name is in the zone. Will also return true if a wildcard is present at the node.
 -spec record_name_in_zone(binary(), dns:dname()) -> boolean().
 record_name_in_zone(ZoneName, Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
-        [] ->
-         is_name_in_zone_with_wildcard(Name, Zone);
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+                [] ->
+                    is_name_in_zone_with_wildcard(Name, Zone);
+                _ ->
+                    true
+            end;
         _ ->
-          true
-      end;
-    _ ->
-      false
-  end.
+            false
+    end.
 
 %% @doc Return a list of tuples with each tuple as a name and the version SHA
 %% for the zone.
 -spec zone_names_and_versions() -> [{dns:dname(), binary()}].
 zone_names_and_versions() ->
-  % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
-  case erldns_config:storage_type() of 
-    erldns_storage_json -> 
-	erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
-    erldns_storage_mnesia ->
-	erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
-  end.
+    % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
+    case erldns_config:storage_type() of
+        erldns_storage_json ->
+            erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
+        erldns_storage_mnesia ->
+            erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
+    end.
 
 %% @doc Return current sync counter
 -spec get_rrset_sync_counter(dns:dname(), dns:dname(), dns:type()) -> integer().
 get_rrset_sync_counter(ZoneName, RRFqdn, Type) ->
-	case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite)  of
-		[{ZoneName, RRFqdn, Type, Counter}] -> Counter;
-		[] -> 0 % return default value of 0
-  	end.
+    case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite) of
+        [{ZoneName, RRFqdn, Type, Counter}] ->
+            Counter;
+        [] ->
+            0 % return default value of 0
+    end.
 
 -spec write_rrset_sync_counter({dns:dname(), dns:dname(), dns:type(), integer()}) -> ok.
 write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
-  erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
-	
+    erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
+
 % ----------------------------------------------------------------------------------------------------
 % Write API
 
@@ -253,146 +267,147 @@ write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
 %%
 %% This function will build the necessary Zone record before inserting.
 -spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()}
-  when Name :: binary(), Sha :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()].
+    when Name :: binary(),
+         Sha :: binary(),
+         Records :: [dns:rr()],
+         Keys :: [erldns:keyset()].
 put_zone({Name, Sha, Records}) ->
     put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
-  SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
-  NamedRecords = build_named_index(SignedZone#zone.records),
-  delete_zone_records(erldns:normalize_name(Name)),
-  case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
-    ok -> put_zone_records(erldns:normalize_name(Name), NamedRecords);
-    {error, Reason} -> {error, Reason}
-  end.
+    SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
+    NamedRecords = build_named_index(SignedZone#zone.records),
+    delete_zone_records(erldns:normalize_name(Name)),
+    case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
+        ok ->
+            put_zone_records(erldns:normalize_name(Name), NamedRecords);
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %% @doc Put a zone into the cache and wait for a response.
 -spec put_zone(dns:name(), erldns:zone()) -> ok | {error, Reason :: term()}.
 put_zone(Name, Zone) ->
-  erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
+    erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
 
 -spec put_zone_records(dns:name(), map()) -> ok.
 put_zone_records(Name, RecordsByName) ->
-  put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
+    put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
 
 %% @doc Put zone RRSet
 %-spec put_zone_rrset(({Name, Digest, Records}, RRFqdn, Type, Counter) | ({Name, Digest, Records}, RRFqdn, Type, Counter)) -> ok | {error, Reason :: term()}
 %  when Name :: binary(), Digest :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()], RRFqdn :: binary(), Type :: binary(), Counter :: integer().
 put_zone_rrset({ZoneName, Digest, Records}, RRFqdn, Type, Counter) ->
-  put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
+    put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
 put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-     {ok, Zone} ->
-	  % TODO: remove debug
-	  lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
-	  KeySets = Zone#zone.keysets,
-	  DnsKeyRRs = get_zone_dnskey_records(ZoneName),
-	  SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
-	  RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
-
-	  % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
-	  TypedRecords = build_typed_index(Records ++ 
-					   SignedRRSet ++ 
-					   RRSigRecs),
-	  % put zone_records_typed records first then create the records in zone_records
-	  put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
-
-	  update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
-
-	  write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
-
-	  lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
-	  ok;
-    _ -> % if zone is not in cache, return error
-      {error, zone_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            % TODO: remove debug
+            lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
+            KeySets = Zone#zone.keysets,
+            DnsKeyRRs = get_zone_dnskey_records(ZoneName),
+            SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
+            RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
+            % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
+            TypedRecords = build_typed_index(Records ++ SignedRRSet ++ RRSigRecs),
+            % put zone_records_typed records first then create the records in zone_records
+            put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
+            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
+            lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
+            ok;
+        _ -> % if zone is not in cache, return error
+            {error, zone_not_found}
+    end.
 
 put_zone_records_entry(_, none) ->
-  ok;
+    ok;
 put_zone_records_entry(Name, {K, V, I}) ->
-  put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
-  put_zone_records_entry(Name, maps:next(I)).
+    put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
+    put_zone_records_entry(Name, maps:next(I)).
 
 put_zone_records_typed_entry(_, _, none) ->
-  ok;
+    ok;
 put_zone_records_typed_entry(ZoneName, Fqdn, {K, V, I}) ->
-  erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
-  put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
+    erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
+    put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
 
 %% @doc Remove a zone from the cache without waiting for a response.
 -spec delete_zone(binary()) -> any().
 delete_zone(Name) ->
-  gen_server:cast(?SERVER, {delete, Name}).
+    gen_server:cast(?SERVER, {delete, Name}).
 
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
-  erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]).
+    erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'}, [], [true]}]).
 
 %% @doc Remove zone RRSet
 -spec delete_zone_rrset(binary(), binary(), binary(), integer(), integer()) -> any().
 delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-    {ok, Zone} -> 
-      Zone,
-      CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
-      case Counter of
-        N when N =:= 0; CurrentCounter < N ->
-          lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
-
-          erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'},[],[true]}]),
-
-          % remove the RRSIG for the given record type
-          {_RRSigsCovering, RRSigsNotCovering} = lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(ZoneName, ?DNS_TYPE_RRSIG_NUMBER)),
-          erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
-
-          % only write counter if called explicitly with Counter value i.e. different than 0.
-          % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
-          case Counter of
-            N when N > 0 ->
-              % DELETE RRSet command has been sent
-              % we need to update the zone digest as the zone content changes
-              update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
-
-              write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
-            _ ->
-              ok
-          end;
-        N when CurrentCounter > N ->
-          lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
-      end;
-    _ -> {error, zone_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            Zone,
+            CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
+            case Counter of
+                N when N =:= 0; CurrentCounter < N ->
+                    lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
+                    erldns_storage:select_delete(zone_records_typed,
+                                                 [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'}, [], [true]}]),
+                    % remove the RRSIG for the given record type
+                    {_RRSigsCovering, RRSigsNotCovering} =
+                        lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(ZoneName, ?DNS_TYPE_RRSIG_NUMBER)),
+                    erldns_storage:insert(zone_records_typed,
+                                          {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
+                    % only write counter if called explicitly with Counter value i.e. different than 0.
+                    % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
+                    case Counter of
+                        N when N > 0 ->
+                            % DELETE RRSet command has been sent
+                            % we need to update the zone digest as the zone content changes
+                            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+                            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
+                        _ ->
+                            ok
+                    end;
+                N when CurrentCounter > N ->
+                    lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
+            end;
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Given a zone name, list of records, and a digest, update the zone metadata in cache.
 -spec update_zone_records_and_digest(dns:dname(), [dns:rr()], binary()) -> ok | {error, Reason :: term()}.
 update_zone_records_and_digest(ZoneName, Records, Digest) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-    {ok, Zone} -> Zone,
-                  UpdatedZone = Zone#zone{version = Digest,
-                                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
-                                          record_count = length(Records),
-                                          records_by_name = build_named_index(Records)},
-                  put_zone(Zone#zone.name, UpdatedZone);
-    _ -> {error, zone_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            Zone,
+            UpdatedZone =
+                Zone#zone{version = Digest,
+                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
+                          record_count = length(Records),
+                          records_by_name = build_named_index(Records)},
+            put_zone(Zone#zone.name, UpdatedZone);
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Filter RRSig records for FQDN, removing type covered.
 -spec filter_rrsig_records_with_type_covered(dns:dname(), dns:type()) -> [{{dns:dname(), dns:dname(), dns:type()}, [dns:rr()]} | []].
 filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
-  % guards below do not allow fun calls to prevent side effects
-  case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
-    {ok, _Zone} ->
-      lists:flatten(
-        lists:foldl(
-          fun(R, Records) ->
-              case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
-                true -> [R | Records];  
-                false -> [Records]
-              end
-          end, [], get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER))
-       );
-    _ ->
-      []
-  end.
+    % guards below do not allow fun calls to prevent side effects
+    case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
+        {ok, _Zone} ->
+            lists:flatten(lists:foldl(fun(R, Records) ->
+                                         case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
+                                             true -> [R | Records];
+                                             false -> [Records]
+                                         end
+                                      end,
+                                      [],
+                                      get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER)));
+        _ ->
+            []
+    end.
 
 % ----------------------------------------------------------------------------------------------------
 % Gen server init
@@ -400,170 +415,203 @@ filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
 %% @doc Initialize the zone cache.
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-  erldns_storage:create(schema),
-  erldns_storage:create(zones),
-  erldns_storage:create(zone_records_typed),
-  erldns_storage:create(authorities),
-  erldns_storage:create(sync_counters),
-  {ok, #state{parsers = []}}.
+    erldns_storage:create(schema),
+    erldns_storage:create(zones),
+    erldns_storage:create(zone_records_typed),
+    erldns_storage:create(authorities),
+    erldns_storage:create(sync_counters),
+    {ok, #state{parsers = []}}.
 
 % ----------------------------------------------------------------------------------------------------
 % gen_server callbacks
 
 handle_call(Message, _From, State) ->
-  lager:debug("Received unsupported call (message: ~p)", [Message]),
-  {reply, ok, State}.
+    lager:debug("Received unsupported call (message: ~p)", [Message]),
+    {reply, ok, State}.
 
 handle_cast({delete, Name}, State) ->
-  erldns_storage:delete(zones, erldns:normalize_name(Name)),
-  delete_zone_records(Name),
-  {noreply, State};
-
+    erldns_storage:delete(zones, erldns:normalize_name(Name)),
+    delete_zone_records(Name),
+    {noreply, State};
 handle_cast(Message, State) ->
-  lager:debug("Received unsupported cast (message: ~p)", [Message]),
-  {noreply, State}.
+    lager:debug("Received unsupported cast (message: ~p)", [Message]),
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
-
+    {ok, State}.
 
 % Internal API
 is_name_in_zone(Name, Zone) ->
-  ZoneName = erldns:normalize_name(Zone#zone.name),
-  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
-    [] -> 
-      case dns:dname_to_labels(Name) of
-        [] -> false;
-        [_] -> false;
-        [_|Labels] -> is_name_in_zone(dns:labels_to_dname(Labels), Zone)
-      end;
-    _ -> true
-  end.
+    ZoneName = erldns:normalize_name(Zone#zone.name),
+    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+        [] ->
+            case dns:dname_to_labels(Name) of
+                [] ->
+                    false;
+                [_] ->
+                    false;
+                [_ | Labels] ->
+                    is_name_in_zone(dns:labels_to_dname(Labels), Zone)
+            end;
+        _ ->
+            true
+    end.
 
 is_name_in_zone_with_wildcard(Name, Zone) ->
-  ZoneName = erldns:normalize_name(Zone#zone.name),
-  WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
-  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'},[],['$$']}], infinite)) of
-    [] ->
-      case dns:dname_to_labels(Name) of
-        [] -> false;
-        [_] -> false;
-        [_|Labels] -> is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
-      end;
-    _ -> true
-  end.
+    ZoneName = erldns:normalize_name(Zone#zone.name),
+    WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
+    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'}, [], ['$$']}], infinite)) of
+        [] ->
+            case dns:dname_to_labels(Name) of
+                [] ->
+                    false;
+                [_] ->
+                    false;
+                [_ | Labels] ->
+                    is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
+            end;
+        _ ->
+            true
+    end.
 
 find_zone_in_cache(Qname) ->
-  Name = erldns:normalize_name(Qname),
-  find_zone_in_cache(Name, dns:dname_to_labels(Name)).
+    Name = erldns:normalize_name(Qname),
+    find_zone_in_cache(Name, dns:dname_to_labels(Name)).
 
 find_zone_in_cache(_Name, []) ->
-  {error, zone_not_found};
-find_zone_in_cache(Name, [_|Labels]) ->
-  case erldns_storage:select(zones, Name) of
-    [{Name, Zone}] -> {ok, Zone};
-    _ ->
-      case Labels of
-        [] -> {error, zone_not_found};
-        _ -> find_zone_in_cache(dns:labels_to_dname(Labels))
-      end
-  end.
+    {error, zone_not_found};
+find_zone_in_cache(Name, [_ | Labels]) ->
+    case erldns_storage:select(zones, Name) of
+        [{Name, Zone}] ->
+            {ok, Zone};
+        _ ->
+            case Labels of
+                [] ->
+                    {error, zone_not_found};
+                _ ->
+                    find_zone_in_cache(dns:labels_to_dname(Labels))
+            end
+    end.
 
 build_zone(Qname, Version, Records, Keys) ->
-  Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
-  #zone{name = Qname, version = Version, record_count = length(Records), authority = Authorities, records = Records, records_by_name = trimmed, keysets = Keys}.
+    Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
+    #zone{name = Qname,
+          version = Version,
+          record_count = length(Records),
+          authority = Authorities,
+          records = Records,
+          records_by_name = trimmed,
+          keysets = Keys}.
 
--spec(build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}).
+-spec build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}.
 build_named_index(Records) ->
-  NamedIndex = lists:foldl(fun (R, Idx) ->
-                               Name = erldns:normalize_name(R#dns_rr.name),
-                               maps:update_with(Name, fun (RR) -> [R | RR] end, [R], Idx)
-                           end, #{}, Records),
-  maps:map(fun (_K, V) -> lists:reverse(V) end, NamedIndex).
+    NamedIndex =
+        lists:foldl(fun(R, Idx) ->
+                       Name = erldns:normalize_name(R#dns_rr.name),
+                       maps:update_with(Name, fun(RR) -> [R | RR] end, [R], Idx)
+                    end,
+                    #{},
+                    Records),
+    maps:map(fun(_K, V) -> lists:reverse(V) end, NamedIndex).
 
--spec(build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}).
+-spec build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}.
 build_typed_index(Records) ->
-  TypedIndex = lists:foldl(fun (R, Idx) ->
-                               maps:update_with(R#dns_rr.type, fun (RR) -> [R | RR] end, [R], Idx)
-                           end, #{}, Records),
-  maps:map(fun (_K, V) -> lists:reverse(V) end, TypedIndex).
+    TypedIndex = lists:foldl(fun(R, Idx) -> maps:update_with(R#dns_rr.type, fun(RR) -> [R | RR] end, [R], Idx) end, #{}, Records),
+    maps:map(fun(_K, V) -> lists:reverse(V) end, TypedIndex).
 
--spec(sign_zone(erldns:zone()) -> erldns:zone()).
+-spec sign_zone(erldns:zone()) -> erldns:zone().
 sign_zone(Zone = #zone{keysets = []}) ->
-  Zone;
+    Zone;
 sign_zone(Zone) ->
-  % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
-  DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
-  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
-  Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
-  lager:debug("Zone verified: ~p", [Verify]),
-  % TODO: remove wildcard signatures as they will not be used but are taking up space
-  ZoneRRSigRecords = lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Zone#zone.records)), Zone#zone.keysets)),
-  Records = Zone#zone.records ++ KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
-  #zone{name = Zone#zone.name, version = Zone#zone.version, record_count = length(Records), authority = Zone#zone.authority, records = Records, records_by_name = build_named_index(Records), keysets = Zone#zone.keysets}.
+    % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
+    DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
+    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
+    Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
+    lager:debug("Zone verified: ~p", [Verify]),
+    % TODO: remove wildcard signatures as they will not be used but are taking up space
+    ZoneRRSigRecords =
+        lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name,
+                                                                lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end, Zone#zone.records)),
+                                Zone#zone.keysets)),
+    Records =
+        Zone#zone.records ++
+            KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
+    #zone{name = Zone#zone.name,
+          version = Zone#zone.version,
+          record_count = length(Records),
+          authority = Zone#zone.authority,
+          records = Records,
+          records_by_name = build_named_index(Records),
+          keysets = Zone#zone.keysets}.
 
--spec(verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean()).
+-spec verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean().
 verify_zone(_Zone, DnskeyRRs, KeyRRSigRecords) ->
-  % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
-  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
-    [] -> false;
-    KSKs -> 
-      % lager:debug("KSKs: ~p", [KSKs]),
-      KSKDnskey = lists:last(KSKs),
-      RRSig = lists:last(KeyRRSigRecords),
-      % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
-      VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
-      % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
-      VerifyResult
-  end.
+    % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
+    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
+        [] ->
+            false;
+        KSKs ->
+            % lager:debug("KSKs: ~p", [KSKs]),
+            KSKDnskey = lists:last(KSKs),
+            RRSig = lists:last(KeyRRSigRecords),
+            % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
+            VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
+            % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
+            VerifyResult
+    end.
 
 % Sign RRSet
--spec(sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()]).
+-spec sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()].
 sign_rrset(Name, Records, DnsKeyRRs, KeySets) ->
-  % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
-  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
-  ZoneRecords = get_zone_records(Name),
-  RRSigRecords = rewrite_soa_rrsig_ttl(ZoneRecords, lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Records)), KeySets))),
-  verify_rrset(DnsKeyRRs, KeyRRSigRecords),
-  RRSigRecords.
+    % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
+    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
+    ZoneRecords = get_zone_records(Name),
+    RRSigRecords =
+        rewrite_soa_rrsig_ttl(ZoneRecords,
+                              lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name,
+                                                                                      lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end,
+                                                                                                   Records)),
+                                                      KeySets))),
+    verify_rrset(DnsKeyRRs, KeyRRSigRecords),
+    RRSigRecords.
 
 % Verify RRSet
--spec(verify_rrset([dns:rr()], [dns:rr()]) -> boolean()).
+-spec verify_rrset([dns:rr()], [dns:rr()]) -> boolean().
 verify_rrset(DnsKeyRRs, KeyRRSigRecords) ->
-  % lager:debug("Verify RRSet"),
-  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
-    [] -> false;
-    KSKs -> 
-      case KeyRRSigRecords of
-        [] -> false;
-        _ ->
-          % lager:debug("KSKs: ~p", [KSKs]),
-          KSKDnskey = lists:last(KSKs),
-          RRSig = lists:last(KeyRRSigRecords),
-          VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
-          VerifyResult
-      end
-  end.
+    % lager:debug("Verify RRSet"),
+    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
+        [] ->
+            false;
+        KSKs ->
+            case KeyRRSigRecords of
+                [] ->
+                    false;
+                _ ->
+                    % lager:debug("KSKs: ~p", [KSKs]),
+                    KSKDnskey = lists:last(KSKs),
+                    RRSig = lists:last(KeyRRSigRecords),
+                    VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
+                    VerifyResult
+            end
+    end.
 
 % Rewrite the RRSIG TTL so it follows the same rewrite rules as the SOA TTL.
 rewrite_soa_rrsig_ttl(ZoneRecords, RRSigRecords) ->
-  SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
-  lists:map(
-    fun(RR) ->
-        case RR#dns_rr.type of
-          ?DNS_TYPE_RRSIG ->
-            case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
-              ?DNS_TYPE_SOA ->
-                erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
-              _ ->
-                RR
-            end;
-          _ -> RR
-        end
-    end, RRSigRecords).
+    SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
+    lists:map(fun(RR) ->
+                 case RR#dns_rr.type of
+                     ?DNS_TYPE_RRSIG ->
+                         case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
+                             ?DNS_TYPE_SOA -> erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
+                             _ -> RR
+                         end;
+                     _ -> RR
+                 end
+              end,
+              RRSigRecords).

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -22,13 +22,12 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([start_link/0]).
-
 % Read APIs
--export([
-         find_zone/1,
+-export([find_zone/1,
          find_zone/2,
          get_zone/1,
          get_authority/1,
@@ -39,32 +38,23 @@
          in_zone/1,
          record_name_in_zone/2,
          zone_names_and_versions/0,
-	 get_rrset_sync_counter/3
-        ]).
-
+         get_rrset_sync_counter/3]).
 % Deprecated APIs
--export([
-         get_zone_with_records/1
-        ]).
-
+-export([get_zone_with_records/1]).
 % Write APIs
--export([
-         put_zone/1,
+-export([put_zone/1,
          put_zone/2,
          delete_zone/1,
          update_zone_records_and_digest/3,
-	 put_zone_rrset/4,
-	 delete_zone_rrset/5
-        ]).
-
+         put_zone_rrset/4,
+         delete_zone_rrset/5]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -73,7 +63,7 @@
 %% @doc Start the zone cache process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 % ----------------------------------------------------------------------------------------------------
 % Read API
@@ -81,171 +71,195 @@ start_link() ->
 %% @doc Find a zone for a given qname.
 -spec find_zone(dns:dname()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname) ->
-  find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
+    find_zone(erldns:normalize_name(Qname), get_authority(Qname)).
 
 %% @doc Find a zone for a given qname.
--spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) -> #zone{} | {error, zone_not_found} | {error, not_authoritative}.
+-spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) ->
+                   #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname, {error, _}) ->
-  find_zone(Qname, []);
+    find_zone(Qname, []);
 find_zone(Qname, {ok, Authority}) ->
-  find_zone(Qname, Authority);
+    find_zone(Qname, Authority);
 find_zone(_Qname, []) ->
-  {error, not_authoritative};
+    {error, not_authoritative};
 find_zone(Qname, Authorities) when is_list(Authorities) ->
-  find_zone(Qname, lists:last(Authorities));
+    find_zone(Qname, lists:last(Authorities));
 find_zone(Qname, Authority) when is_record(Authority, dns_rr) ->
-  Name = erldns:normalize_name(Qname),
-  case dns:dname_to_labels(Name) of
-    [] -> {error, zone_not_found};
-    [_|Labels] ->
-      case get_zone(Name) of
-        {ok, Zone} -> Zone;
-        {error, zone_not_found} ->
-          case Name =:= Authority#dns_rr.name of
-            true -> {error, zone_not_found};
-            false -> find_zone(dns:labels_to_dname(Labels), Authority)
-          end
-      end
-  end.
+    Name = erldns:normalize_name(Qname),
+    case dns:dname_to_labels(Name) of
+        [] ->
+            {error, zone_not_found};
+        [_ | Labels] ->
+            case get_zone(Name) of
+                {ok, Zone} ->
+                    Zone;
+                {error, zone_not_found} ->
+                    case Name =:= Authority#dns_rr.name of
+                        true ->
+                            {error, zone_not_found};
+                        false ->
+                            find_zone(dns:labels_to_dname(Labels), Authority)
+                    end
+            end
+    end.
 
 %% @doc Get a zone for the specific name. This function will not attempt to resolve
 %% the dname in any way, it will simply look up the name in the underlying data store.
 -spec get_zone(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone(Name) ->
-  NormalizedName = erldns:normalize_name(Name),
-  case erldns_storage:select(zones, NormalizedName) of
-    [{NormalizedName, Zone}] -> {ok, Zone#zone{name = NormalizedName, records = [], records_by_name=trimmed}};
-    _ -> {error, zone_not_found}
-  end.
+    NormalizedName = erldns:normalize_name(Name),
+    case erldns_storage:select(zones, NormalizedName) of
+        [{NormalizedName, Zone}] ->
+            {ok,
+             Zone#zone{name = NormalizedName,
+                       records = [],
+                       records_by_name = trimmed}};
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Get a zone for the specific name, including the records for the zone.
 %% @deprecated Use {@link erldns_zone_cache:get_zone/1} to get the zone meta data and
 %% {@link erldns_zone_cache:get_zone_records/1} to get the records for the zone.
 -spec get_zone_with_records(dns:dname()) -> {ok, #zone{}} | {error, zone_not_found}.
 get_zone_with_records(Name) ->
-  NormalizedName = erldns:normalize_name(Name),
-  case erldns_storage:select(zones, NormalizedName) of
-    [{NormalizedName, Zone}] -> {ok, Zone};
-    _ -> {error, zone_not_found}
-  end.
+    NormalizedName = erldns:normalize_name(Name),
+    case erldns_storage:select(zones, NormalizedName) of
+        [{NormalizedName, Zone}] ->
+            {ok, Zone};
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Find the SOA record for the given DNS question.
 -spec get_authority(dns:message() | dns:dname()) -> {error, no_question} | {error, authority_not_found} | {ok, dns:authority()}.
 get_authority(Message) when is_record(Message, dns_message) ->
-  case Message#dns_message.questions of
-    [] -> {error, no_question};
-    Questions -> 
-      Question = lists:last(Questions),
-      get_authority(Question#dns_query.name)
-  end;
+    case Message#dns_message.questions of
+        [] ->
+            {error, no_question};
+        Questions ->
+            Question = lists:last(Questions),
+            get_authority(Question#dns_query.name)
+    end;
 get_authority(Name) ->
-  case find_zone_in_cache(erldns:normalize_name(Name)) of
-    {ok, Zone} -> {ok, Zone#zone.authority};
-    _ -> {error, authority_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(Name)) of
+        {ok, Zone} ->
+            {ok, Zone#zone.authority};
+        _ ->
+            {error, authority_not_found}
+    end.
 
 %% @doc Get the list of NS and glue records for the given name. This function
 %% will always return a list, even if it is empty.
 -spec get_delegations(dns:dname()) -> [dns:rr()] | [].
 get_delegations(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      Records = lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'},[],['$$']}], infinite)),
-      lists:filter(erldns_records:match_delegation(Name), Records);
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            Records =
+                lists:flatten(erldns_storage:select(zone_records_typed,
+                                                    [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
+                                                    infinite)),
+            lists:filter(erldns_records:match_delegation(Name), Records);
+        _ ->
+            []
+    end.
 
 %% @doc Get all records for the given zone.
 -spec get_zone_records(dns:dname()) -> [dns:rr()].
 get_zone_records(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'}, [], ['$$']}], infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Get all records for the given type and given name.
 -spec get_records_by_name_and_type(dns:dname(), dns:type()) -> [dns:rr()].
 get_records_by_name_and_type(Name, Type) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed,
+                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'}, [], ['$$']}],
+                                                infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Get all DNSSEC records for zone
 -spec get_zone_dnskey_records(dns:dname()) -> [dns:rr()].
 get_zone_dnskey_records(Name) ->
-	case find_zone_in_cache(Name) of
-		{ok, _Zone} ->
-			get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
-		_ ->
-			[]
-	end.
+    case find_zone_in_cache(Name) of
+        {ok, _Zone} ->
+            get_records_by_name_and_type(Name, ?DNS_TYPE_DNSKEY);
+        _ ->
+            []
+    end.
 
 %% @doc Return the record set for the given dname.
 -spec get_records_by_name(dns:dname()) -> [dns:rr()].
 get_records_by_name(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      lists:flatten(erldns_storage:select(zone_records_typed,[{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite));
-    _ ->
-      []
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            lists:flatten(erldns_storage:select(zone_records_typed,
+                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}],
+                                                infinite));
+        _ ->
+            []
+    end.
 
 %% @doc Check if the name is in a zone.
 -spec in_zone(binary()) -> boolean().
 in_zone(Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      is_name_in_zone(Name, Zone);
-    _ ->
-      false
-  end.
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            is_name_in_zone(Name, Zone);
+        _ ->
+            false
+    end.
 
 %% @doc Check if the record name is in the zone. Will also return true if a wildcard is present at the node.
 -spec record_name_in_zone(binary(), dns:dname()) -> boolean().
 record_name_in_zone(ZoneName, Name) ->
-  case find_zone_in_cache(Name) of
-    {ok, Zone} ->
-      case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
-        [] ->
-         is_name_in_zone_with_wildcard(Name, Zone);
+    case find_zone_in_cache(Name) of
+        {ok, Zone} ->
+            case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+                [] ->
+                    is_name_in_zone_with_wildcard(Name, Zone);
+                _ ->
+                    true
+            end;
         _ ->
-          true
-      end;
-    _ ->
-      false
-  end.
+            false
+    end.
 
 %% @doc Return a list of tuples with each tuple as a name and the version SHA
 %% for the zone.
 -spec zone_names_and_versions() -> [{dns:dname(), binary()}].
 zone_names_and_versions() ->
-  % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
-  case erldns_config:storage_type() of 
-    erldns_storage_json -> 
-	erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
-    erldns_storage_mnesia ->
-	erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
-  end.
+    % ETS and Mnesia foldl/3 differ in return values -> Mnesia's version is missing key
+    case erldns_config:storage_type() of
+        erldns_storage_json ->
+            erldns_storage:foldl(fun({_, Zone}, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones);
+        erldns_storage_mnesia ->
+            erldns_storage:foldl(fun(Zone, NamesAndShas) -> NamesAndShas ++ [{Zone#zone.name, Zone#zone.version}] end, [], zones)
+    end.
 
 %% @doc Return current sync counter
 -spec get_rrset_sync_counter(dns:dname(), dns:dname(), dns:type()) -> integer().
 get_rrset_sync_counter(ZoneName, RRFqdn, Type) ->
-	case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite)  of
-		[{ZoneName, RRFqdn, Type, Counter}] -> Counter;
-		[] -> 0 % return default value of 0
-  	end.
+    case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite) of
+        [{ZoneName, RRFqdn, Type, Counter}] ->
+            Counter;
+        [] ->
+            0 % return default value of 0
+    end.
 
 %% @doc Update the RRSet sync counter for the given RR set name and type in the given zone.
 -spec write_rrset_sync_counter({dns:dname(), dns:dname(), dns:type(), integer()}) -> ok.
 write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
-  erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
-	
+    erldns_storage:insert(sync_counters, {ZoneName, RRFqdn, Type, Counter}).
+
 % ----------------------------------------------------------------------------------------------------
 % Write API
 
@@ -254,145 +268,155 @@ write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
 %%
 %% This function will build the necessary Zone record before inserting.
 -spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()}
-  when Name :: binary(), Sha :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()].
+    when Name :: binary(),
+         Sha :: binary(),
+         Records :: [dns:rr()],
+         Keys :: [erldns:keyset()].
 put_zone({Name, Sha, Records}) ->
     put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
-  SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
-  NamedRecords = build_named_index(SignedZone#zone.records),
-  delete_zone_records(erldns:normalize_name(Name)),
-  case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
-    ok -> put_zone_records(erldns:normalize_name(Name), NamedRecords);
-    {error, Reason} -> {error, Reason}
-  end.
+    SignedZone = sign_zone(build_zone(Name, Sha, Records, Keys)),
+    NamedRecords = build_named_index(SignedZone#zone.records),
+    delete_zone_records(erldns:normalize_name(Name)),
+    case put_zone(erldns:normalize_name(Name), SignedZone#zone{records = trimmed}) of
+        ok ->
+            put_zone_records(erldns:normalize_name(Name), NamedRecords);
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %% @doc Put a zone into the cache and wait for a response.
 -spec put_zone(dns:name(), erldns:zone()) -> ok | {error, Reason :: term()}.
 put_zone(Name, Zone) ->
-  erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
+    erldns_storage:insert(zones, {erldns:normalize_name(Name), Zone}).
 
 -spec put_zone_records(dns:name(), map()) -> ok.
 put_zone_records(Name, RecordsByName) ->
-  put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
+    put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
 
 %% @doc Put zone RRSet
--spec put_zone_rrset({dns:dname(), binary(), [dns:rr()]} | {dns:dname(), binary(), [dns:rr()], [any()]}, dns:dname(), dns:type(), integer()) -> ok | {error, Reason :: term()}.
+-spec put_zone_rrset({dns:dname(), binary(), [dns:rr()]} | {dns:dname(), binary(), [dns:rr()], [any()]}, dns:dname(), dns:type(), integer()) ->
+                        ok | {error, Reason :: term()}.
 put_zone_rrset({ZoneName, Digest, Records}, RRFqdn, Type, Counter) ->
-  put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
+    put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
 put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-     {ok, Zone} ->
-	  % TODO: remove debug
-	  lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
-	  KeySets = Zone#zone.keysets,
-	  DnsKeyRRs = get_zone_dnskey_records(ZoneName),
-	  SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
-	  RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            % TODO: remove debug
+            lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
+            KeySets = Zone#zone.keysets,
+            DnsKeyRRs = get_zone_dnskey_records(ZoneName),
+            SignedRRSet = sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets),
+            RRSigRecs = filter_rrsig_records_with_type_covered(RRFqdn, Type),
 
-	  % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
-	  TypedRecords = build_typed_index(Records ++ 
-					   SignedRRSet ++ 
-					   RRSigRecs),
-	  % put zone_records_typed records first then create the records in zone_records
-	  put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
+            % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
+            TypedRecords = build_typed_index(Records ++ SignedRRSet ++ RRSigRecs),
+            % put zone_records_typed records first then create the records in zone_records
+            put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
 
-	  update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
 
-	  write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
+            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
 
-	  lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
-	  ok;
-    _ -> % if zone is not in cache, return error
-      {error, zone_not_found}
-  end.
+            lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
+            ok;
+        _ -> % if zone is not in cache, return error
+            {error, zone_not_found}
+    end.
 
 put_zone_records_entry(_, none) ->
-  ok;
+    ok;
 put_zone_records_entry(Name, {K, V, I}) ->
-  put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
-  put_zone_records_entry(Name, maps:next(I)).
+    put_zone_records_typed_entry(Name, K, maps:next(maps:iterator(build_typed_index(V)))),
+    put_zone_records_entry(Name, maps:next(I)).
 
 put_zone_records_typed_entry(_, _, none) ->
-  ok;
+    ok;
 put_zone_records_typed_entry(ZoneName, Fqdn, {K, V, I}) ->
-  erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
-  put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
+    erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(Fqdn), K}, V}),
+    put_zone_records_typed_entry(ZoneName, Fqdn, maps:next(I)).
 
 %% @doc Remove a zone from the cache without waiting for a response.
 -spec delete_zone(binary()) -> any().
 delete_zone(Name) ->
-  gen_server:cast(?SERVER, {delete, Name}).
+    gen_server:cast(?SERVER, {delete, Name}).
 
 -spec delete_zone_records(binary()) -> any().
 delete_zone_records(Name) ->
-  erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'},[],[true]}]).
+    erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(Name), '_', '_'}, '_'}, [], [true]}]).
 
 %% @doc Remove zone RRSet
 -spec delete_zone_rrset(binary(), binary(), binary(), integer(), integer()) -> any().
 delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-    {ok, Zone} -> 
-      Zone,
-      CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
-      case Counter of
-        N when N =:= 0; CurrentCounter < N ->
-          lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            Zone,
+            CurrentCounter = get_rrset_sync_counter(ZoneName, RRFqdn, Type),
+            case Counter of
+                N when N =:= 0; CurrentCounter < N ->
+                    lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
 
-          erldns_storage:select_delete(zone_records_typed, [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'},[],[true]}]),
+                    erldns_storage:select_delete(zone_records_typed,
+                                                 [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'}, [], [true]}]),
 
-          % remove the RRSIG for the given record type
-          {_RRSigsCovering, RRSigsNotCovering} = lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)),
-          erldns_storage:insert(zone_records_typed, {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
+                    % remove the RRSIG for the given record type
+                    {_RRSigsCovering, RRSigsNotCovering} =
+                        lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)),
+                    erldns_storage:insert(zone_records_typed,
+                                          {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
 
-          % only write counter if called explicitly with Counter value i.e. different than 0.
-          % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
-          case Counter of
-            N when N > 0 ->
-              % DELETE RRSet command has been sent
-              % we need to update the zone digest as the zone content changes
-              update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
+                    % only write counter if called explicitly with Counter value i.e. different than 0.
+                    % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
+                    case Counter of
+                        N when N > 0 ->
+                            % DELETE RRSet command has been sent
+                            % we need to update the zone digest as the zone content changes
+                            update_zone_records_and_digest(ZoneName, get_zone_records(ZoneName), Digest),
 
-              write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
-            _ ->
-              ok
-          end;
-        N when CurrentCounter > N ->
-          lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
-      end;
-    _ -> {error, zone_not_found}
-  end.
+                            write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
+                        _ ->
+                            ok
+                    end;
+                N when CurrentCounter > N ->
+                    lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
+            end;
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Given a zone name, list of records, and a digest, update the zone metadata in cache.
 -spec update_zone_records_and_digest(dns:dname(), [dns:rr()], binary()) -> ok | {error, Reason :: term()}.
 update_zone_records_and_digest(ZoneName, Records, Digest) ->
-  case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
-    {ok, Zone} -> Zone,
-                  UpdatedZone = Zone#zone{version = Digest,
-                                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
-                                          record_count = length(Records),
-                                          records_by_name = build_named_index(Records)},
-                  put_zone(Zone#zone.name, UpdatedZone);
-    _ -> {error, zone_not_found}
-  end.
+    case find_zone_in_cache(erldns:normalize_name(ZoneName)) of
+        {ok, Zone} ->
+            Zone,
+            UpdatedZone =
+                Zone#zone{version = Digest,
+                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
+                          record_count = length(Records),
+                          records_by_name = build_named_index(Records)},
+            put_zone(Zone#zone.name, UpdatedZone);
+        _ ->
+            {error, zone_not_found}
+    end.
 
 %% @doc Filter RRSig records for FQDN, removing type covered.
 -spec filter_rrsig_records_with_type_covered(dns:dname(), dns:type()) -> [{{dns:dname(), dns:dname(), dns:type()}, [dns:rr()]} | []].
 filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
-  % guards below do not allow fun calls to prevent side effects
-  case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
-    {ok, _Zone} ->
-      lists:flatten(
-        lists:foldl(
-          fun(R, Records) ->
-              case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
-                true -> [R | Records];  
-                false -> [Records]
-              end
-          end, [], get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER))
-       );
-    _ ->
-      []
-  end.
+    % guards below do not allow fun calls to prevent side effects
+    case find_zone_in_cache(erldns:normalize_name(Fqdn)) of
+        {ok, _Zone} ->
+            lists:flatten(lists:foldl(fun(R, Records) ->
+                                         case R#dns_rr.data#dns_rrdata_rrsig.type_covered =/= TypeCovered of
+                                             true -> [R | Records];
+                                             false -> [Records]
+                                         end
+                                      end,
+                                      [],
+                                      get_records_by_name_and_type(Fqdn, ?DNS_TYPE_RRSIG_NUMBER)));
+        _ ->
+            []
+    end.
 
 % ----------------------------------------------------------------------------------------------------
 % Gen server init
@@ -400,170 +424,203 @@ filter_rrsig_records_with_type_covered(Fqdn, TypeCovered) ->
 %% @doc Initialize the zone cache.
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-  erldns_storage:create(schema),
-  erldns_storage:create(zones),
-  erldns_storage:create(zone_records_typed),
-  erldns_storage:create(authorities),
-  erldns_storage:create(sync_counters),
-  {ok, #state{parsers = []}}.
+    erldns_storage:create(schema),
+    erldns_storage:create(zones),
+    erldns_storage:create(zone_records_typed),
+    erldns_storage:create(authorities),
+    erldns_storage:create(sync_counters),
+    {ok, #state{parsers = []}}.
 
 % ----------------------------------------------------------------------------------------------------
 % gen_server callbacks
 
 handle_call(Message, _From, State) ->
-  lager:debug("Received unsupported call (message: ~p)", [Message]),
-  {reply, ok, State}.
+    lager:debug("Received unsupported call (message: ~p)", [Message]),
+    {reply, ok, State}.
 
 handle_cast({delete, Name}, State) ->
-  erldns_storage:delete(zones, erldns:normalize_name(Name)),
-  delete_zone_records(Name),
-  {noreply, State};
-
+    erldns_storage:delete(zones, erldns:normalize_name(Name)),
+    delete_zone_records(Name),
+    {noreply, State};
 handle_cast(Message, State) ->
-  lager:debug("Received unsupported cast (message: ~p)", [Message]),
-  {noreply, State}.
+    lager:debug("Received unsupported cast (message: ~p)", [Message]),
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
-
+    {ok, State}.
 
 % Internal API
 is_name_in_zone(Name, Zone) ->
-  ZoneName = erldns:normalize_name(Zone#zone.name),
-  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'},[],['$$']}], infinite)) of
-    [] -> 
-      case dns:dname_to_labels(Name) of
-        [] -> false;
-        [_] -> false;
-        [_|Labels] -> is_name_in_zone(dns:labels_to_dname(Labels), Zone)
-      end;
-    _ -> true
-  end.
+    ZoneName = erldns:normalize_name(Zone#zone.name),
+    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+        [] ->
+            case dns:dname_to_labels(Name) of
+                [] ->
+                    false;
+                [_] ->
+                    false;
+                [_ | Labels] ->
+                    is_name_in_zone(dns:labels_to_dname(Labels), Zone)
+            end;
+        _ ->
+            true
+    end.
 
 is_name_in_zone_with_wildcard(Name, Zone) ->
-  ZoneName = erldns:normalize_name(Zone#zone.name),
-  WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
-  case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'},[],['$$']}], infinite)) of
-    [] ->
-      case dns:dname_to_labels(Name) of
-        [] -> false;
-        [_] -> false;
-        [_|Labels] -> is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
-      end;
-    _ -> true
-  end.
+    ZoneName = erldns:normalize_name(Zone#zone.name),
+    WildcardName = erldns:normalize_name(erldns_records:wildcard_qname(Name)),
+    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, WildcardName, '_'}, '$1'}, [], ['$$']}], infinite)) of
+        [] ->
+            case dns:dname_to_labels(Name) of
+                [] ->
+                    false;
+                [_] ->
+                    false;
+                [_ | Labels] ->
+                    is_name_in_zone_with_wildcard(dns:labels_to_dname(Labels), Zone)
+            end;
+        _ ->
+            true
+    end.
 
 find_zone_in_cache(Qname) ->
-  Name = erldns:normalize_name(Qname),
-  find_zone_in_cache(Name, dns:dname_to_labels(Name)).
+    Name = erldns:normalize_name(Qname),
+    find_zone_in_cache(Name, dns:dname_to_labels(Name)).
 
 find_zone_in_cache(_Name, []) ->
-  {error, zone_not_found};
-find_zone_in_cache(Name, [_|Labels]) ->
-  case erldns_storage:select(zones, Name) of
-    [{Name, Zone}] -> {ok, Zone};
-    _ ->
-      case Labels of
-        [] -> {error, zone_not_found};
-        _ -> find_zone_in_cache(dns:labels_to_dname(Labels))
-      end
-  end.
+    {error, zone_not_found};
+find_zone_in_cache(Name, [_ | Labels]) ->
+    case erldns_storage:select(zones, Name) of
+        [{Name, Zone}] ->
+            {ok, Zone};
+        _ ->
+            case Labels of
+                [] ->
+                    {error, zone_not_found};
+                _ ->
+                    find_zone_in_cache(dns:labels_to_dname(Labels))
+            end
+    end.
 
 build_zone(Qname, Version, Records, Keys) ->
-  Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
-  #zone{name = Qname, version = Version, record_count = length(Records), authority = Authorities, records = Records, records_by_name = trimmed, keysets = Keys}.
+    Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
+    #zone{name = Qname,
+          version = Version,
+          record_count = length(Records),
+          authority = Authorities,
+          records = Records,
+          records_by_name = trimmed,
+          keysets = Keys}.
 
--spec(build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}).
+-spec build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}.
 build_named_index(Records) ->
-  NamedIndex = lists:foldl(fun (R, Idx) ->
-                               Name = erldns:normalize_name(R#dns_rr.name),
-                               maps:update_with(Name, fun (RR) -> [R | RR] end, [R], Idx)
-                           end, #{}, Records),
-  maps:map(fun (_K, V) -> lists:reverse(V) end, NamedIndex).
+    NamedIndex =
+        lists:foldl(fun(R, Idx) ->
+                       Name = erldns:normalize_name(R#dns_rr.name),
+                       maps:update_with(Name, fun(RR) -> [R | RR] end, [R], Idx)
+                    end,
+                    #{},
+                    Records),
+    maps:map(fun(_K, V) -> lists:reverse(V) end, NamedIndex).
 
--spec(build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}).
+-spec build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}.
 build_typed_index(Records) ->
-  TypedIndex = lists:foldl(fun (R, Idx) ->
-                               maps:update_with(R#dns_rr.type, fun (RR) -> [R | RR] end, [R], Idx)
-                           end, #{}, Records),
-  maps:map(fun (_K, V) -> lists:reverse(V) end, TypedIndex).
+    TypedIndex = lists:foldl(fun(R, Idx) -> maps:update_with(R#dns_rr.type, fun(RR) -> [R | RR] end, [R], Idx) end, #{}, Records),
+    maps:map(fun(_K, V) -> lists:reverse(V) end, TypedIndex).
 
--spec(sign_zone(erldns:zone()) -> erldns:zone()).
+-spec sign_zone(erldns:zone()) -> erldns:zone().
 sign_zone(Zone = #zone{keysets = []}) ->
-  Zone;
+    Zone;
 sign_zone(Zone) ->
-  % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
-  DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
-  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
-  Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
-  lager:debug("Zone verified: ~p", [Verify]),
-  % TODO: remove wildcard signatures as they will not be used but are taking up space
-  ZoneRRSigRecords = lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Zone#zone.records)), Zone#zone.keysets)),
-  Records = Zone#zone.records ++ KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
-  #zone{name = Zone#zone.name, version = Zone#zone.version, record_count = length(Records), authority = Zone#zone.authority, records = Records, records_by_name = build_named_index(Records), keysets = Zone#zone.keysets}.
+    % lager:debug("Signing zone (name: ~p)", [Zone#zone.name]),
+    DnskeyRRs = lists:filter(erldns_records:match_type(?DNS_TYPE_DNSKEY), Zone#zone.records),
+    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Zone#zone.name, DnskeyRRs), Zone#zone.keysets)),
+    Verify = verify_zone(Zone, DnskeyRRs, KeyRRSigRecords),
+    lager:debug("Zone verified: ~p", [Verify]),
+    % TODO: remove wildcard signatures as they will not be used but are taking up space
+    ZoneRRSigRecords =
+        lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name,
+                                                                lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end, Zone#zone.records)),
+                                Zone#zone.keysets)),
+    Records =
+        Zone#zone.records ++
+            KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
+    #zone{name = Zone#zone.name,
+          version = Zone#zone.version,
+          record_count = length(Records),
+          authority = Zone#zone.authority,
+          records = Records,
+          records_by_name = build_named_index(Records),
+          keysets = Zone#zone.keysets}.
 
--spec(verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean()).
+-spec verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean().
 verify_zone(_Zone, DnskeyRRs, KeyRRSigRecords) ->
-  % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
-  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
-    [] -> false;
-    KSKs -> 
-      % lager:debug("KSKs: ~p", [KSKs]),
-      KSKDnskey = lists:last(KSKs),
-      RRSig = lists:last(KeyRRSigRecords),
-      % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
-      VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
-      % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
-      VerifyResult
-  end.
+    % lager:debug("Verify zone (name: ~p)", [Zone#zone.name]),
+    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnskeyRRs) of
+        [] ->
+            false;
+        KSKs ->
+            % lager:debug("KSKs: ~p", [KSKs]),
+            KSKDnskey = lists:last(KSKs),
+            RRSig = lists:last(KeyRRSigRecords),
+            % lager:debug("Attempting to verify RRSIG (key: ~p)", [KSKDnskey]),
+            VerifyResult = dnssec:verify_rrsig(RRSig, DnskeyRRs, [KSKDnskey], []),
+            % lager:debug("KSK verification (verified?: ~p)", [VerifyResult]),
+            VerifyResult
+    end.
 
 % Sign RRSet
--spec(sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()]).
+-spec sign_rrset(binary(), [dns:rr()], [dns:rr()], [erldns:keyset()]) -> [dns:rr()].
 sign_rrset(Name, Records, DnsKeyRRs, KeySets) ->
-  % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
-  KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
-  ZoneRecords = get_zone_records(Name),
-  RRSigRecords = rewrite_soa_rrsig_ttl(ZoneRecords, lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name, lists:filter(fun(RR) -> (RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY) end, Records)), KeySets))),
-  verify_rrset(DnsKeyRRs, KeyRRSigRecords),
-  RRSigRecords.
+    % lager:debug("Signing RRSet for zone (name: ~p)", [Name]),
+    KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
+    ZoneRecords = get_zone_records(Name),
+    RRSigRecords =
+        rewrite_soa_rrsig_ttl(ZoneRecords,
+                              lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name,
+                                                                                      lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end,
+                                                                                                   Records)),
+                                                      KeySets))),
+    verify_rrset(DnsKeyRRs, KeyRRSigRecords),
+    RRSigRecords.
 
 % Verify RRSet
--spec(verify_rrset([dns:rr()], [dns:rr()]) -> boolean()).
+-spec verify_rrset([dns:rr()], [dns:rr()]) -> boolean().
 verify_rrset(DnsKeyRRs, KeyRRSigRecords) ->
-  % lager:debug("Verify RRSet"),
-  case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
-    [] -> false;
-    KSKs -> 
-      case KeyRRSigRecords of
-        [] -> false;
-        _ ->
-          % lager:debug("KSKs: ~p", [KSKs]),
-          KSKDnskey = lists:last(KSKs),
-          RRSig = lists:last(KeyRRSigRecords),
-          VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
-          VerifyResult
-      end
-  end.
+    % lager:debug("Verify RRSet"),
+    case lists:filter(fun(RR) -> RR#dns_rr.data#dns_rrdata_dnskey.flags =:= ?DNSKEY_KSK_TYPE end, DnsKeyRRs) of
+        [] ->
+            false;
+        KSKs ->
+            case KeyRRSigRecords of
+                [] ->
+                    false;
+                _ ->
+                    % lager:debug("KSKs: ~p", [KSKs]),
+                    KSKDnskey = lists:last(KSKs),
+                    RRSig = lists:last(KeyRRSigRecords),
+                    VerifyResult = dnssec:verify_rrsig(RRSig, DnsKeyRRs, [KSKDnskey], []),
+                    VerifyResult
+            end
+    end.
 
 % Rewrite the RRSIG TTL so it follows the same rewrite rules as the SOA TTL.
 rewrite_soa_rrsig_ttl(ZoneRecords, RRSigRecords) ->
-  SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
-  lists:map(
-    fun(RR) ->
-        case RR#dns_rr.type of
-          ?DNS_TYPE_RRSIG ->
-            case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
-              ?DNS_TYPE_SOA ->
-                erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
-              _ ->
-                RR
-            end;
-          _ -> RR
-        end
-    end, RRSigRecords).
+    SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
+    lists:map(fun(RR) ->
+                 case RR#dns_rr.type of
+                     ?DNS_TYPE_RRSIG ->
+                         case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
+                             ?DNS_TYPE_SOA -> erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
+                             _ -> RR
+                         end;
+                     _ -> RR
+                 end
+              end,
+              RRSigRecords).

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -19,6 +19,7 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([start_link/0]).
@@ -28,15 +29,13 @@
          zone_records_to_json/3,
          register_encoders/1,
          register_encoder/1]).
-
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -47,228 +46,213 @@
 %% @doc Start the encoder process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Encode a Zone meta data into JSON.
 -spec zone_meta_to_json(#zone{}) -> binary().
 zone_meta_to_json(Zone) ->
-  jsx:encode([{<<"erldns">>,
-                 [
-                  {<<"zone">>, [
-                                {<<"name">>, Zone#zone.name},
-                                {<<"version">>, Zone#zone.version},
-                                % Note: Private key material is purposely omitted
-                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}
-                               ]}
-                 ]
-               }]).
+    jsx:encode([{<<"erldns">>,
+                 [{<<"zone">>,
+                   [{<<"name">>, Zone#zone.name},
+                    {<<"version">>, Zone#zone.version},
+                    % Note: Private key material is purposely omitted
+                    {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}]}]}]).
 
 %% @doc Encode a Zone meta data plus all of its records into JSON.
 -spec zone_to_json(#zone{}) -> binary().
 zone_to_json(Zone) ->
-  gen_server:call(?SERVER, {encode_zone, Zone}).
+    gen_server:call(?SERVER, {encode_zone, Zone}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName) ->
-  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
+    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname(), dns:rrtype()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName, RecordSetType) ->
-  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
+    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
 
 %% @doc Register a list of encoder modules.
 -spec register_encoders([module()]) -> ok.
 register_encoders(Modules) ->
-  lager:info("Registering custom encoders (modules: ~p)", [Modules]),
-  gen_server:call(?SERVER, {register_encoders, Modules}).
+    lager:info("Registering custom encoders (modules: ~p)", [Modules]),
+    gen_server:call(?SERVER, {register_encoders, Modules}).
 
 %% @doc Register a single encoder module.
 -spec register_encoder(module()) -> ok.
 register_encoder(Module) ->
-  lager:info("Registering custom encoder (module: ~p)", [Module]),
-  gen_server:call(?SERVER, {register_encoder, Module}).
-
+    lager:info("Registering custom encoder (module: ~p)", [Module]),
+    gen_server:call(?SERVER, {register_encoder, Module}).
 
 % Gen server hooks
 
 init([]) ->
-  {ok, #state{encoders = []}}.
+    {ok, #state{encoders = []}}.
 
 handle_call({encode_zone, Zone}, _From, State) ->
-  {reply, encode_zone_to_json(Zone, State#state.encoders), State};
-
+    {reply, encode_zone_to_json(Zone, State#state.encoders), State};
 handle_call({encode_zone_records, ZoneName, RecordName}, _From, State) ->
-  {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
-
+    {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
 handle_call({encode_zone_records, ZoneName, RecordName, RecordType}, _From, State) ->
-  {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
-
+    {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
 handle_call({register_encoders, Modules}, _From, State) ->
-  {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
-
+    {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
 handle_call({register_encoder, Module}, _From, State) ->
-  {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
+    {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
 
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_, _State) ->
-  ok.
+    ok.
 
 code_change(_, State, _) ->
-  {ok, State}.
-
+    {ok, State}.
 
 % Internal API
 
 encode_zone_to_json(Zone, Encoders) ->
-  Records = records_to_json(Zone, Encoders),
-  FilteredRecords = lists:filter(record_filter(), Records),
-  jsx:encode([{<<"erldns">>,
-               [
-                {<<"zone">>, [
-                              {<<"name">>, Zone#zone.name},
-                              {<<"version">>, Zone#zone.version},
-                              {<<"records">>, FilteredRecords}
-                              % Note: Private key material is purposely omitted
-                             ]}
-               ]
-              }]).
+    Records = records_to_json(Zone, Encoders),
+    FilteredRecords = lists:filter(record_filter(), Records),
+    jsx:encode([{<<"erldns">>,
+                 [{<<"zone">>,
+                   [{<<"name">>, Zone#zone.name},
+                    {<<"version">>, Zone#zone.version},
+                    {<<"records">>,
+                     FilteredRecords}]}]}]).                              % Note: Private key material is purposely omitted
 
 encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->
-  Records = erldns_zone_cache:get_records_by_name(RecordName),
-  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+    Records = erldns_zone_cache:get_records_by_name(RecordName),
+    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 encode_zone_records_to_json(_ZoneName, RecordName, RecordType, Encoders) ->
-  Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
-  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+    Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
+    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 record_filter() ->
-  fun(R) ->
-      case R of
-        [] -> false;
-        {} -> false;
-        _ -> true
-      end
-  end.
+    fun(R) ->
+       case R of
+           [] -> false;
+           {} -> false;
+           _ -> true
+       end
+    end.
 
 records_to_json(Zone, Encoders) ->
-  lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
+    lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
 
 encode(Encoders) ->
-  fun(Record) ->
-      encode_record(Record, Encoders)
-  end.
+    fun(Record) -> encode_record(Record, Encoders) end.
 
 encode_record(Record, Encoders) ->
-  % lager:debug("Encoding record (record: ~p)", [Record]),
-  case encode_record(Record) of
-    [] ->
-      % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
-      try_custom_encoders(Record, Encoders);
-    EncodedRecord -> EncodedRecord
-  end.
+    % lager:debug("Encoding record (record: ~p)", [Record]),
+    case encode_record(Record) of
+        [] ->
+            % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
+            try_custom_encoders(Record, Encoders);
+        EncodedRecord ->
+            EncodedRecord
+    end.
 
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SOA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_A, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_AAAA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CNAME, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_MX, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_HINFO, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_TXT, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SPF, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SSHFP, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SRV, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NAPTR, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CAA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DNSKEY, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDNSKEY, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_RRSIG, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record(Record) ->
-  lager:warning("Unable to encode record (record: ~p)", [Record]),
-  [].
+    lager:warning("Unable to encode record (record: ~p)", [Record]),
+    [].
 
 encode_record(Name, Type, Ttl, Data) ->
-  [
-   {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-   {<<"type">>, dns:type_name(Type)},
-   {<<"ttl">>, Ttl},
-   {<<"content">>, encode_data(Data)}
-  ].
-
+    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+     {<<"type">>, dns:type_name(Type)},
+     {<<"ttl">>, Ttl},
+     {<<"content">>, encode_data(Data)}].
 
 try_custom_encoders(_Record, []) ->
-  {};
-try_custom_encoders(Record, [Encoder|Rest]) ->
-  % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
-  case Encoder:encode_record(Record) of
-    [] -> try_custom_encoders(Record, Rest);
-    EncodedData -> EncodedData
-  end.
+    {};
+try_custom_encoders(Record, [Encoder | Rest]) ->
+    % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
+    case Encoder:encode_record(Record) of
+        [] ->
+            try_custom_encoders(Record, Rest);
+        EncodedData ->
+            EncodedData
+    end.
 
 encode_data({dns_rrdata_soa, Mname, Rname, Serial, Refresh, Retry, Expire, Minimum}) ->
-  erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
+    erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
 encode_data({dns_rrdata_ns, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_a, Address}) ->
-  list_to_binary(inet_parse:ntoa(Address));
+    list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_aaaa, Address}) ->
-  list_to_binary(inet_parse:ntoa(Address));
+    list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_caa, Flags, Tag, Value}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
+    erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
 encode_data({dns_rrdata_cname, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_mx, Preference, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
+    erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
 encode_data({dns_rrdata_hinfo, Cpu, Os}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
 % RP
 encode_data({dns_rrdata_txt, Text}) ->
-  erlang:iolist_to_binary(io_lib:format("~s", [Text]));
+    erlang:iolist_to_binary(io_lib:format("~s", [Text]));
 encode_data({dns_rrdata_spf, [Data]}) ->
-  erlang:iolist_to_binary(io_lib:format("~s", [Data]));
+    erlang:iolist_to_binary(io_lib:format("~s", [Data]));
 encode_data({dns_rrdata_sshfp, Alg, Fptype, Fp}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
 encode_data({dns_rrdata_srv, Priority, Weight, Port, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
 encode_data({dns_rrdata_naptr, Order, Preference, Flags, Services, Regexp, Replacements}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
 encode_data({dns_rrdata_ds, Keytag, Alg, DigestType, Digest}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_cds, Keytag, Alg, DigestType, Digest}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_dnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s", [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s",
+                                          [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
 encode_data(Data) ->
-  erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
-  {}.
+    erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
+    {}.

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -19,6 +19,7 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([start_link/0]).
@@ -28,15 +29,13 @@
          zone_records_to_json/3,
          register_encoders/1,
          register_encoder/1]).
-
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -47,228 +46,212 @@
 %% @doc Start the encoder process.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Encode a Zone meta data into JSON.
 -spec zone_meta_to_json(#zone{}) -> binary().
 zone_meta_to_json(Zone) ->
-  jsx:encode([{<<"erldns">>,
-                 [
-                  {<<"zone">>, [
-                                {<<"name">>, Zone#zone.name},
-                                {<<"version">>, Zone#zone.version},
-                                % Note: Private key material is purposely omitted
-                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}
-                               ]}
-                 ]
-               }]).
+    jsx:encode([{<<"erldns">>,
+                 [{<<"zone">>,
+                   [{<<"name">>, Zone#zone.name},
+                    {<<"version">>, Zone#zone.version},
+                    % Note: Private key material is purposely omitted
+                    {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}]}]}]).
 
 %% @doc Encode a Zone meta data plus all of its records into JSON.
 -spec zone_to_json(#zone{}) -> binary().
 zone_to_json(Zone) ->
-  gen_server:call(?SERVER, {encode_zone, Zone}).
+    gen_server:call(?SERVER, {encode_zone, Zone}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName) ->
-  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
+    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname(), dns:rrtype()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName, RecordSetType) ->
-  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
+    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
 
 %% @doc Register a list of encoder modules.
 -spec register_encoders([module()]) -> ok.
 register_encoders(Modules) ->
-  lager:info("Registering custom encoders (modules: ~p)", [Modules]),
-  gen_server:call(?SERVER, {register_encoders, Modules}).
+    lager:info("Registering custom encoders (modules: ~p)", [Modules]),
+    gen_server:call(?SERVER, {register_encoders, Modules}).
 
 %% @doc Register a single encoder module.
 -spec register_encoder(module()) -> ok.
 register_encoder(Module) ->
-  lager:info("Registering custom encoder (module: ~p)", [Module]),
-  gen_server:call(?SERVER, {register_encoder, Module}).
-
+    lager:info("Registering custom encoder (module: ~p)", [Module]),
+    gen_server:call(?SERVER, {register_encoder, Module}).
 
 % Gen server hooks
 
 init([]) ->
-  {ok, #state{encoders = []}}.
+    {ok, #state{encoders = []}}.
 
 handle_call({encode_zone, Zone}, _From, State) ->
-  {reply, encode_zone_to_json(Zone, State#state.encoders), State};
-
+    {reply, encode_zone_to_json(Zone, State#state.encoders), State};
 handle_call({encode_zone_records, ZoneName, RecordName}, _From, State) ->
-  {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
-
+    {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
 handle_call({encode_zone_records, ZoneName, RecordName, RecordType}, _From, State) ->
-  {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
-
+    {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
 handle_call({register_encoders, Modules}, _From, State) ->
-  {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
-
+    {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
 handle_call({register_encoder, Module}, _From, State) ->
-  {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
+    {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
 
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_, _State) ->
-  ok.
+    ok.
 
 code_change(_, State, _) ->
-  {ok, State}.
-
+    {ok, State}.
 
 % Internal API
 
 encode_zone_to_json(Zone, Encoders) ->
-  Records = records_to_json(Zone, Encoders),
-  FilteredRecords = lists:filter(record_filter(), Records),
-  jsx:encode([{<<"erldns">>,
-               [
-                {<<"zone">>, [
-                              {<<"name">>, Zone#zone.name},
-                              {<<"version">>, Zone#zone.version},
-                              {<<"records">>, FilteredRecords}
-                              % Note: Private key material is purposely omitted
-                             ]}
-               ]
-              }]).
+    Records = records_to_json(Zone, Encoders),
+    FilteredRecords = lists:filter(record_filter(), Records),
+    jsx:encode([{<<"erldns">>,
+                 [{<<"zone">>,
+                   [{<<"name">>, Zone#zone.name},
+                    {<<"version">>, Zone#zone.version},
+                    {<<"records">>, FilteredRecords}]}]}]).                              % Note: Private key material is purposely omitted
 
 encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->
-  Records = erldns_zone_cache:get_records_by_name(RecordName),
-  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+    Records = erldns_zone_cache:get_records_by_name(RecordName),
+    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 encode_zone_records_to_json(_ZoneName, RecordName, RecordType, Encoders) ->
-  Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
-  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+    Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
+    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 record_filter() ->
-  fun(R) ->
-      case R of
-        [] -> false;
-        {} -> false;
-        _ -> true
-      end
-  end.
+    fun(R) ->
+       case R of
+           [] -> false;
+           {} -> false;
+           _ -> true
+       end
+    end.
 
 records_to_json(Zone, Encoders) ->
-  lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
+    lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
 
 encode(Encoders) ->
-  fun(Record) ->
-      encode_record(Record, Encoders)
-  end.
+    fun(Record) -> encode_record(Record, Encoders) end.
 
 encode_record(Record, Encoders) ->
-  % lager:debug("Encoding record (record: ~p)", [Record]),
-  case encode_record(Record) of
-    [] ->
-      % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
-      try_custom_encoders(Record, Encoders);
-    EncodedRecord -> EncodedRecord
-  end.
+    % lager:debug("Encoding record (record: ~p)", [Record]),
+    case encode_record(Record) of
+        [] ->
+            % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
+            try_custom_encoders(Record, Encoders);
+        EncodedRecord ->
+            EncodedRecord
+    end.
 
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SOA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_A, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_AAAA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CNAME, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_MX, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_HINFO, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_TXT, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SPF, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SSHFP, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SRV, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NAPTR, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CAA, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDS, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DNSKEY, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDNSKEY, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_RRSIG, Ttl, Data}) ->
-  encode_record(Name, Type, Ttl, Data);
+    encode_record(Name, Type, Ttl, Data);
 encode_record(Record) ->
-  lager:warning("Unable to encode record (record: ~p)", [Record]),
-  [].
+    lager:warning("Unable to encode record (record: ~p)", [Record]),
+    [].
 
 encode_record(Name, Type, Ttl, Data) ->
-  [
-   {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-   {<<"type">>, dns:type_name(Type)},
-   {<<"ttl">>, Ttl},
-   {<<"content">>, encode_data(Data)}
-  ].
-
+    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+     {<<"type">>, dns:type_name(Type)},
+     {<<"ttl">>, Ttl},
+     {<<"content">>, encode_data(Data)}].
 
 try_custom_encoders(_Record, []) ->
-  {};
-try_custom_encoders(Record, [Encoder|Rest]) ->
-  % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
-  case Encoder:encode_record(Record) of
-    [] -> try_custom_encoders(Record, Rest);
-    EncodedData -> EncodedData
-  end.
+    {};
+try_custom_encoders(Record, [Encoder | Rest]) ->
+    % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
+    case Encoder:encode_record(Record) of
+        [] ->
+            try_custom_encoders(Record, Rest);
+        EncodedData ->
+            EncodedData
+    end.
 
 encode_data({dns_rrdata_soa, Mname, Rname, Serial, Refresh, Retry, Expire, Minimum}) ->
-  erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
+    erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
 encode_data({dns_rrdata_ns, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_a, Address}) ->
-  list_to_binary(inet_parse:ntoa(Address));
+    list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_aaaa, Address}) ->
-  list_to_binary(inet_parse:ntoa(Address));
+    list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_caa, Flags, Tag, Value}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
+    erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
 encode_data({dns_rrdata_cname, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_mx, Preference, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
+    erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
 encode_data({dns_rrdata_hinfo, Cpu, Os}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
 % RP
 encode_data({dns_rrdata_txt, Text}) ->
-  erlang:iolist_to_binary(io_lib:format("~s", [Text]));
+    erlang:iolist_to_binary(io_lib:format("~s", [Text]));
 encode_data({dns_rrdata_spf, [Data]}) ->
-  erlang:iolist_to_binary(io_lib:format("~s", [Data]));
+    erlang:iolist_to_binary(io_lib:format("~s", [Data]));
 encode_data({dns_rrdata_sshfp, Alg, Fptype, Fp}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
 encode_data({dns_rrdata_srv, Priority, Weight, Port, Dname}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
 encode_data({dns_rrdata_naptr, Order, Preference, Flags, Services, Regexp, Replacements}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
 encode_data({dns_rrdata_ds, Keytag, Alg, DigestType, Digest}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_cds, Keytag, Alg, DigestType, Digest}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_dnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
-  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s", [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
+    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s",
+                                          [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
 encode_data(Data) ->
-  erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
-  {}.
+    erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
+    {}.

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -122,6 +122,7 @@ encode_zone_to_json(Zone, Encoders) ->
                  [{<<"zone">>,
                    [{<<"name">>, Zone#zone.name},
                     {<<"version">>, Zone#zone.version},
+                    {<<"records_count">>, length(FilteredRecords)},
                     {<<"records">>, FilteredRecords}]}]}]).                              % Note: Private key material is purposely omitted
 
 encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -19,7 +19,6 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([start_link/0]).
@@ -29,13 +28,15 @@
          zone_records_to_json/3,
          register_encoders/1,
          register_encoder/1]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -define(SERVER, ?MODULE).
 
@@ -46,213 +47,228 @@
 %% @doc Start the encoder process.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Encode a Zone meta data into JSON.
 -spec zone_meta_to_json(#zone{}) -> binary().
 zone_meta_to_json(Zone) ->
-    jsx:encode([{<<"erldns">>,
-                 [{<<"zone">>,
-                   [{<<"name">>, Zone#zone.name},
-                    {<<"version">>, Zone#zone.version},
-                    % Note: Private key material is purposely omitted
-                    {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}]}]}]).
+  jsx:encode([{<<"erldns">>,
+                 [
+                  {<<"zone">>, [
+                                {<<"name">>, Zone#zone.name},
+                                {<<"version">>, Zone#zone.version},
+                                % Note: Private key material is purposely omitted
+                                {<<"records_count">>, length(erldns_zone_cache:get_zone_records(Zone#zone.name))}
+                               ]}
+                 ]
+               }]).
 
 %% @doc Encode a Zone meta data plus all of its records into JSON.
 -spec zone_to_json(#zone{}) -> binary().
 zone_to_json(Zone) ->
-    gen_server:call(?SERVER, {encode_zone, Zone}).
+  gen_server:call(?SERVER, {encode_zone, Zone}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName) ->
-    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
+  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName}).
 
 %% @doc Encode the records in the zone with the given RRSet name and type into JSON
 -spec zone_records_to_json(dns:dname(), dns:dname(), dns:rrtype()) -> binary().
 zone_records_to_json(ZoneName, RecordSetName, RecordSetType) ->
-    gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
+  gen_server:call(?SERVER, {encode_zone_records, ZoneName, RecordSetName, RecordSetType}).
 
 %% @doc Register a list of encoder modules.
 -spec register_encoders([module()]) -> ok.
 register_encoders(Modules) ->
-    lager:info("Registering custom encoders (modules: ~p)", [Modules]),
-    gen_server:call(?SERVER, {register_encoders, Modules}).
+  lager:info("Registering custom encoders (modules: ~p)", [Modules]),
+  gen_server:call(?SERVER, {register_encoders, Modules}).
 
 %% @doc Register a single encoder module.
 -spec register_encoder(module()) -> ok.
 register_encoder(Module) ->
-    lager:info("Registering custom encoder (module: ~p)", [Module]),
-    gen_server:call(?SERVER, {register_encoder, Module}).
+  lager:info("Registering custom encoder (module: ~p)", [Module]),
+  gen_server:call(?SERVER, {register_encoder, Module}).
+
 
 % Gen server hooks
 
 init([]) ->
-    {ok, #state{encoders = []}}.
+  {ok, #state{encoders = []}}.
 
 handle_call({encode_zone, Zone}, _From, State) ->
-    {reply, encode_zone_to_json(Zone, State#state.encoders), State};
+  {reply, encode_zone_to_json(Zone, State#state.encoders), State};
+
 handle_call({encode_zone_records, ZoneName, RecordName}, _From, State) ->
-    {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
+  {reply, encode_zone_records_to_json(ZoneName, RecordName, State#state.encoders), State};
+
 handle_call({encode_zone_records, ZoneName, RecordName, RecordType}, _From, State) ->
-    {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
+  {reply, encode_zone_records_to_json(ZoneName, RecordName, RecordType, State#state.encoders), State};
+
 handle_call({register_encoders, Modules}, _From, State) ->
-    {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
+  {reply, ok, State#state{encoders = State#state.encoders ++ Modules}};
+
 handle_call({register_encoder, Module}, _From, State) ->
-    {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
+  {reply, ok, State#state{encoders = State#state.encoders ++ [Module]}}.
 
 handle_cast(_, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 handle_info(_, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_, _State) ->
-    ok.
+  ok.
 
 code_change(_, State, _) ->
-    {ok, State}.
+  {ok, State}.
+
 
 % Internal API
 
 encode_zone_to_json(Zone, Encoders) ->
-    Records = records_to_json(Zone, Encoders),
-    FilteredRecords = lists:filter(record_filter(), Records),
-    jsx:encode([{<<"erldns">>,
-                 [{<<"zone">>,
-                   [{<<"name">>, Zone#zone.name},
-                    {<<"version">>, Zone#zone.version},
-                    {<<"records">>,
-                     FilteredRecords}]}]}]).                              % Note: Private key material is purposely omitted
+  Records = records_to_json(Zone, Encoders),
+  FilteredRecords = lists:filter(record_filter(), Records),
+  jsx:encode([{<<"erldns">>,
+               [
+                {<<"zone">>, [
+                              {<<"name">>, Zone#zone.name},
+                              {<<"version">>, Zone#zone.version},
+                              {<<"records">>, FilteredRecords}
+                              % Note: Private key material is purposely omitted
+                             ]}
+               ]
+              }]).
 
 encode_zone_records_to_json(_ZoneName, RecordName, Encoders) ->
-    Records = erldns_zone_cache:get_records_by_name(RecordName),
-    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+  Records = erldns_zone_cache:get_records_by_name(RecordName),
+  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 encode_zone_records_to_json(_ZoneName, RecordName, RecordType, Encoders) ->
-    Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
-    jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
+  Records = erldns_zone_cache:get_records_by_name_and_type(RecordName, erldns_records:name_type(RecordType)),
+  jsx:encode(lists:filter(record_filter(), lists:map(encode(Encoders), Records))).
 
 record_filter() ->
-    fun(R) ->
-       case R of
-           [] -> false;
-           {} -> false;
-           _ -> true
-       end
-    end.
+  fun(R) ->
+      case R of
+        [] -> false;
+        {} -> false;
+        _ -> true
+      end
+  end.
 
 records_to_json(Zone, Encoders) ->
-    lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
+  lists:map(encode(Encoders), erldns_zone_cache:get_zone_records(Zone#zone.name)).
 
 encode(Encoders) ->
-    fun(Record) -> encode_record(Record, Encoders) end.
+  fun(Record) ->
+      encode_record(Record, Encoders)
+  end.
 
 encode_record(Record, Encoders) ->
-    % lager:debug("Encoding record (record: ~p)", [Record]),
-    case encode_record(Record) of
-        [] ->
-            % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
-            try_custom_encoders(Record, Encoders);
-        EncodedRecord ->
-            EncodedRecord
-    end.
+  % lager:debug("Encoding record (record: ~p)", [Record]),
+  case encode_record(Record) of
+    [] ->
+      % lager:debug("Trying custom encoders (encoders: ~p)", [Encoders]),
+      try_custom_encoders(Record, Encoders);
+    EncodedRecord -> EncodedRecord
+  end.
 
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SOA, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NS, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_A, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_AAAA, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CNAME, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_MX, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_HINFO, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_TXT, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SPF, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SSHFP, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SRV, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NAPTR, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CAA, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DS, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDS, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DNSKEY, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDNSKEY, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_RRSIG, Ttl, Data}) ->
-    encode_record(Name, Type, Ttl, Data);
+  encode_record(Name, Type, Ttl, Data);
 encode_record(Record) ->
-    lager:warning("Unable to encode record (record: ~p)", [Record]),
-    [].
+  lager:warning("Unable to encode record (record: ~p)", [Record]),
+  [].
 
 encode_record(Name, Type, Ttl, Data) ->
-    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-     {<<"type">>, dns:type_name(Type)},
-     {<<"ttl">>, Ttl},
-     {<<"content">>, encode_data(Data)}].
+  [
+   {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+   {<<"type">>, dns:type_name(Type)},
+   {<<"ttl">>, Ttl},
+   {<<"content">>, encode_data(Data)}
+  ].
+
 
 try_custom_encoders(_Record, []) ->
-    {};
-try_custom_encoders(Record, [Encoder | Rest]) ->
-    % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
-    case Encoder:encode_record(Record) of
-        [] ->
-            try_custom_encoders(Record, Rest);
-        EncodedData ->
-            EncodedData
-    end.
+  {};
+try_custom_encoders(Record, [Encoder|Rest]) ->
+  % lager:debug("Trying custom encoder (encoder: ~p)", [Encoder]),
+  case Encoder:encode_record(Record) of
+    [] -> try_custom_encoders(Record, Rest);
+    EncodedData -> EncodedData
+  end.
 
 encode_data({dns_rrdata_soa, Mname, Rname, Serial, Refresh, Retry, Expire, Minimum}) ->
-    erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
+  erlang:iolist_to_binary(io_lib:format("~s. ~s. (~w ~w ~w ~w ~w)", [Mname, Rname, Serial, Refresh, Retry, Expire, Minimum]));
 encode_data({dns_rrdata_ns, Dname}) ->
-    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_a, Address}) ->
-    list_to_binary(inet_parse:ntoa(Address));
+  list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_aaaa, Address}) ->
-    list_to_binary(inet_parse:ntoa(Address));
+  list_to_binary(inet_parse:ntoa(Address));
 encode_data({dns_rrdata_caa, Flags, Tag, Value}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
+  erlang:iolist_to_binary(io_lib:format("~w ~s \"~s\"", [Flags, Tag, Value]));
 encode_data({dns_rrdata_cname, Dname}) ->
-    erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
+  erlang:iolist_to_binary(io_lib:format("~s.", [Dname]));
 encode_data({dns_rrdata_mx, Preference, Dname}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
+  erlang:iolist_to_binary(io_lib:format("~w ~s.", [Preference, Dname]));
 encode_data({dns_rrdata_hinfo, Cpu, Os}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w", [Cpu, Os]));
 % RP
 encode_data({dns_rrdata_txt, Text}) ->
-    erlang:iolist_to_binary(io_lib:format("~s", [Text]));
+  erlang:iolist_to_binary(io_lib:format("~s", [Text]));
 encode_data({dns_rrdata_spf, [Data]}) ->
-    erlang:iolist_to_binary(io_lib:format("~s", [Data]));
+  erlang:iolist_to_binary(io_lib:format("~s", [Data]));
 encode_data({dns_rrdata_sshfp, Alg, Fptype, Fp}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~s", [Alg, Fptype, Fp]));
 encode_data({dns_rrdata_srv, Priority, Weight, Port, Dname}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s.", [Priority, Weight, Port, Dname]));
 encode_data({dns_rrdata_naptr, Order, Preference, Flags, Services, Regexp, Replacements}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~s ~s ~s ~s", [Order, Preference, Flags, Services, Regexp, Replacements]));
 encode_data({dns_rrdata_ds, Keytag, Alg, DigestType, Digest}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_cds, Keytag, Alg, DigestType, Digest}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_dnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s",
-                                          [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
+  erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w ~w ~w ~w ~s", [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]));
 encode_data(Data) ->
-    erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
-    {}.
+  erldns_events:notify({?MODULE, unsupported_rrdata_type, Data}),
+  {}.

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_zone_loader.erl
+++ b/src/erldns_zone_loader.erl
@@ -22,33 +22,33 @@
 % Public API
 
 %% @doc Load zones from a file. The default file name is "zones.json".
--spec load_zones() -> {ok, integer()} | {err, atom()}.
+-spec load_zones() -> {ok, integer()} | {err,  atom()}.
 load_zones() ->
-    case file:read_file(filename()) of
-        {ok, Binary} ->
-            lager:info("Parsing zones JSON"),
-            JsonZones = jsx:decode(Binary),
-            lager:info("Putting zones into cache"),
-            lists:foreach(fun(JsonZone) ->
-                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-                             case erldns_zone_cache:put_zone(Zone) of
-                                 {error, Reason} -> erldns_events:notify({?MODULE, put_zone_error, {JsonZone, Reason}});
-                                 _ -> ok
-                             end
-                          end,
-                          JsonZones),
-            lager:info("Loaded zones (count: ~p)", [length(JsonZones)]),
-            {ok, length(JsonZones)};
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, read_file_error, Reason}),
-            {err, Reason}
-    end.
+  case file:read_file(filename()) of
+    {ok, Binary} ->
+      lager:info("Parsing zones JSON"),
+      JsonZones = jsx:decode(Binary),
+      lager:info("Putting zones into cache"),
+      lists:foreach(
+        fun(JsonZone) ->
+            Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+            case erldns_zone_cache:put_zone(Zone) of
+              {error, Reason} -> erldns_events:notify({?MODULE, put_zone_error, {JsonZone, Reason}});
+              _ -> ok
+            end
+        end, JsonZones),
+      lager:info("Loaded zones (count: ~p)", [length(JsonZones)]),
+      {ok, length(JsonZones)};
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, read_file_error, Reason}),
+      {err, Reason}
+  end.
 
 % Internal API
 filename() ->
-    case application:get_env(erldns, zones) of
-        {ok, Filename} ->
-            Filename;
-        _ ->
-            ?FILENAME
-    end.
+  case application:get_env(erldns, zones) of
+    {ok, Filename} -> Filename;
+    _ -> ?FILENAME
+  end.
+
+

--- a/src/erldns_zone_loader.erl
+++ b/src/erldns_zone_loader.erl
@@ -22,33 +22,33 @@
 % Public API
 
 %% @doc Load zones from a file. The default file name is "zones.json".
--spec load_zones() -> {ok, integer()} | {err,  atom()}.
+-spec load_zones() -> {ok, integer()} | {err, atom()}.
 load_zones() ->
-  case file:read_file(filename()) of
-    {ok, Binary} ->
-      lager:info("Parsing zones JSON"),
-      JsonZones = jsx:decode(Binary),
-      lager:info("Putting zones into cache"),
-      lists:foreach(
-        fun(JsonZone) ->
-            Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-            case erldns_zone_cache:put_zone(Zone) of
-              {error, Reason} -> erldns_events:notify({?MODULE, put_zone_error, {JsonZone, Reason}});
-              _ -> ok
-            end
-        end, JsonZones),
-      lager:info("Loaded zones (count: ~p)", [length(JsonZones)]),
-      {ok, length(JsonZones)};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, read_file_error, Reason}),
-      {err, Reason}
-  end.
+    case file:read_file(filename()) of
+        {ok, Binary} ->
+            lager:info("Parsing zones JSON"),
+            JsonZones = jsx:decode(Binary),
+            lager:info("Putting zones into cache"),
+            lists:foreach(fun(JsonZone) ->
+                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+                             case erldns_zone_cache:put_zone(Zone) of
+                                 {error, Reason} -> erldns_events:notify({?MODULE, put_zone_error, {JsonZone, Reason}});
+                                 _ -> ok
+                             end
+                          end,
+                          JsonZones),
+            lager:info("Loaded zones (count: ~p)", [length(JsonZones)]),
+            {ok, length(JsonZones)};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, read_file_error, Reason}),
+            {err, Reason}
+    end.
 
 % Internal API
 filename() ->
-  case application:get_env(erldns, zones) of
-    {ok, Filename} -> Filename;
-    _ -> ?FILENAME
-  end.
-
-
+    case application:get_env(erldns, zones) of
+        {ok, Filename} ->
+            Filename;
+        _ ->
+            ?FILENAME
+    end.

--- a/src/erldns_zone_loader.erl
+++ b/src/erldns_zone_loader.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -18,30 +18,29 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
--export([
-         start_link/0,
+-export([start_link/0,
          zone_to_erlang/1,
          register_parsers/1,
          register_parser/1,
-         list_parsers/0
-        ]).
-
+         list_parsers/0]).
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
-        ]).
+         code_change/3]).
 
 -define(SERVER, ?MODULE).
 -define(PARSE_TIMEOUT, 30 * 1000).
 
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
 -endif.
 
 -record(state, {parsers}).
@@ -51,136 +50,141 @@
 %% @doc Start the parser processor.
 -spec start_link() -> any().
 start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Takes a JSON zone and turns it into the tuple {Name, Sha, Records}.
 %%
 %% The default timeout for parsing is currently 30 seconds.
 -spec zone_to_erlang(binary()) -> {binary(), binary(), [dns:rr()], [erldns:keyset()]}.
 zone_to_erlang(Zone) ->
-  gen_server:call(?SERVER, {parse_zone, Zone}, ?PARSE_TIMEOUT).
+    gen_server:call(?SERVER, {parse_zone, Zone}, ?PARSE_TIMEOUT).
 
 %% @doc Register a list of custom parser modules.
 -spec register_parsers([module()]) -> ok.
 register_parsers(Modules) ->
-  lager:info("Registering custom parsers (modules: ~p)", [Modules]),
-  gen_server:call(?SERVER, {register_parsers, Modules}).
+    lager:info("Registering custom parsers (modules: ~p)", [Modules]),
+    gen_server:call(?SERVER, {register_parsers, Modules}).
 
 %% @doc Regiaer a custom parser module.
 -spec register_parser(module()) -> ok.
 register_parser(Module) ->
-  lager:info("Registering custom parser (module: ~p)", [Module]),
-  gen_server:call(?SERVER, {register_parser, Module}).
+    lager:info("Registering custom parser (module: ~p)", [Module]),
+    gen_server:call(?SERVER, {register_parser, Module}).
 
 -spec list_parsers() -> [module()].
 list_parsers() ->
-  gen_server:call(?SERVER, list_parsers).
-
+    gen_server:call(?SERVER, list_parsers).
 
 %% Gen server hooks
 init([]) ->
-  {ok, #state{parsers = []}}.
+    {ok, #state{parsers = []}}.
 
 handle_call({parse_zone, Zone}, _From, State) ->
-  {reply, json_to_erlang(Zone, State#state.parsers), State};
-
+    {reply, json_to_erlang(Zone, State#state.parsers), State};
 handle_call({register_parsers, Modules}, _From, State) ->
-  {reply, ok, State#state{parsers = State#state.parsers ++ Modules}};
-
+    {reply, ok, State#state{parsers = State#state.parsers ++ Modules}};
 handle_call({register_parser, Module}, _From, State) ->
-  {reply, ok, State#state{parsers = State#state.parsers ++ [Module]}};
-
+    {reply, ok, State#state{parsers = State#state.parsers ++ [Module]}};
 handle_call(list_parsers, _From, State) ->
-  {reply, ok, State#state.parsers}.
+    {reply, ok, State#state.parsers}.
 
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_, _State) ->
-  ok.
+    ok.
 
 code_change(_, State, _) ->
-  {ok, State}.
-
-
+    {ok, State}.
 
 % Internal API
 json_to_erlang([{<<"name">>, Name}, {<<"records">>, JsonRecords}], Parsers) ->
-  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
-
+    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
 json_to_erlang([{<<"name">>, Name}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers) ->
-  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers);
-
+    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers);
 json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}], Parsers) ->
-  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
-
+    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
 json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers) ->
-  Records = lists:map(
-              fun(JsonRecord) ->
-                  Data = json_record_to_list(JsonRecord),
-                  % Filter by context
-                  case apply_context_options(Data) of
-                    pass ->
-                      case json_record_to_erlang(Data) of
-                        {} ->
-                          case try_custom_parsers(Data, Parsers) of
-                            {} ->
-                              erldns_events:notify({?MODULE, unsupported_record, Data}),
-                              {};
-                            ParsedRecord -> ParsedRecord
-                          end;
-                        ParsedRecord -> ParsedRecord
-                      end;
-                    _ ->
-                      {}
-                  end
-              end, JsonRecords),
-  FilteredRecords = lists:filter(record_filter(), Records),
-  DistinctRecords = lists:usort(FilteredRecords),
-  {Name, Sha, DistinctRecords, parse_json_keys(JsonKeys)}.
+    Records =
+        lists:map(fun(JsonRecord) ->
+                     Data = json_record_to_list(JsonRecord),
+                     % Filter by context
+                     case apply_context_options(Data) of
+                         pass ->
+                             case json_record_to_erlang(Data) of
+                                 {} ->
+                                     case try_custom_parsers(Data, Parsers) of
+                                         {} ->
+                                             erldns_events:notify({?MODULE, unsupported_record, Data}),
+                                             {};
+                                         ParsedRecord -> ParsedRecord
+                                     end;
+                                 ParsedRecord -> ParsedRecord
+                             end;
+                         _ -> {}
+                     end
+                  end,
+                  JsonRecords),
+    FilteredRecords = lists:filter(record_filter(), Records),
+    DistinctRecords = lists:usort(FilteredRecords),
+    {Name, Sha, DistinctRecords, parse_json_keys(JsonKeys)}.
 
-parse_json_keys(JsonKeys) -> parse_json_keys(JsonKeys, []).
+parse_json_keys(JsonKeys) ->
+    parse_json_keys(JsonKeys, []).
 
-parse_json_keys([], Keys) -> Keys;
-parse_json_keys([[{<<"ksk">>, KskBin}, {<<"ksk_keytag">>, KskKeytag}, {<<"ksk_alg">>, KskAlg}, {<<"zsk">>, ZskBin}, {<<"zsk_keytag">>, ZskKeytag}, {<<"zsk_alg">>, ZskAlg}, {<<"inception">>, Inception}, {<<"until">>, ValidUntil}]|Rest], Keys) ->
-  KeySet = #keyset{
-              key_signing_key = to_crypto_key(KskBin),
-              key_signing_key_tag = KskKeytag,
-              key_signing_alg = KskAlg,
-              zone_signing_key = to_crypto_key(ZskBin),
-              zone_signing_key_tag = ZskKeytag,
-              zone_signing_alg = ZskAlg,
-              inception = iso8601:parse(Inception),
-              valid_until = iso8601:parse(ValidUntil)
-             },
-  parse_json_keys(Rest, [KeySet | Keys]).
+parse_json_keys([], Keys) ->
+    Keys;
+parse_json_keys([[{<<"ksk">>, KskBin},
+                  {<<"ksk_keytag">>, KskKeytag},
+                  {<<"ksk_alg">>, KskAlg},
+                  {<<"zsk">>, ZskBin},
+                  {<<"zsk_keytag">>, ZskKeytag},
+                  {<<"zsk_alg">>, ZskAlg},
+                  {<<"inception">>, Inception},
+                  {<<"until">>, ValidUntil}]
+                 | Rest],
+                Keys) ->
+    KeySet =
+        #keyset{key_signing_key = to_crypto_key(KskBin),
+                key_signing_key_tag = KskKeytag,
+                key_signing_alg = KskAlg,
+                zone_signing_key = to_crypto_key(ZskBin),
+                zone_signing_key_tag = ZskKeytag,
+                zone_signing_alg = ZskAlg,
+                inception = iso8601:parse(Inception),
+                valid_until = iso8601:parse(ValidUntil)},
+    parse_json_keys(Rest, [KeySet | Keys]).
 
 to_crypto_key(RsaKeyBin) ->
-  % Where E is the public exponent, N is public modulus and D is the private exponent
-  [_,_,M,E,N|_] = tuple_to_list(public_key:pem_entry_decode(lists:last(public_key:pem_decode(RsaKeyBin)))),
-  [E,M,N].
+    % Where E is the public exponent, N is public modulus and D is the private exponent
+    [_, _, M, E, N | _] = tuple_to_list(public_key:pem_entry_decode(lists:last(public_key:pem_decode(RsaKeyBin)))),
+    [E, M, N].
 
 record_filter() ->
-  fun(R) ->
-      case R of
-        {} -> false;
-        _ -> true
-      end
-  end.
+    fun(R) ->
+       case R of
+           {} -> false;
+           _ -> true
+       end
+    end.
 
 -spec apply_context_list_check(sets:set(), sets:set()) -> [fail] | [pass].
 apply_context_list_check(ContextAllowSet, ContextSet) ->
-  case sets:size(sets:intersection(ContextAllowSet, ContextSet)) of
-    0 -> [fail];
-    _ -> [pass]
-  end.
+    case sets:size(sets:intersection(ContextAllowSet, ContextSet)) of
+        0 ->
+            [fail];
+        _ ->
+            [pass]
+    end.
 
 -spec apply_context_match_empty_check(boolean(), [any()]) -> [fail] | [pass].
-apply_context_match_empty_check(true, []) -> [pass];
-apply_context_match_empty_check(_, _) -> [fail].
+apply_context_match_empty_check(true, []) ->
+    [pass];
+apply_context_match_empty_check(_, _) ->
+    [fail].
 
 %% Determine if a record should be used in this name server's context.
 %%
@@ -189,401 +193,339 @@ apply_context_match_empty_check(_, _) -> [fail].
 %% If the context is a list and has at least one condition that passes
 %% then it will be included in the zone
 -spec apply_context_options([any()]) -> pass | fail.
-apply_context_options([_, _, _, _, undefined]) -> pass;
+apply_context_options([_, _, _, _, undefined]) ->
+    pass;
 apply_context_options([_, _, _, _, Context]) ->
-  case application:get_env(erldns, context_options) of
-    {ok, ContextOptions} ->
-      ContextSet = sets:from_list(Context),
-      Result = lists:append([
-                             apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
-                             apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)
-                            ]),
-      case lists:any(fun(I) -> I =:= pass end, Result) of
-        true -> pass;
-        _ -> fail
-      end;
-    _ ->
-      pass
-  end.
+    case application:get_env(erldns, context_options) of
+        {ok, ContextOptions} ->
+            ContextSet = sets:from_list(Context),
+            Result =
+                lists:append([apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
+                              apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)]),
+            case lists:any(fun(I) -> I =:= pass end, Result) of
+                true ->
+                    pass;
+                _ ->
+                    fail
+            end;
+        _ ->
+            pass
+    end.
 
 json_record_to_list(JsonRecord) ->
-  [
-   erldns_config:keyget(<<"name">>, JsonRecord),
-   erldns_config:keyget(<<"type">>, JsonRecord),
-   erldns_config:keyget(<<"ttl">>, JsonRecord),
-   erldns_config:keyget(<<"data">>, JsonRecord),
-   erldns_config:keyget(<<"context">>, JsonRecord)
-  ].
+    [erldns_config:keyget(<<"name">>, JsonRecord),
+     erldns_config:keyget(<<"type">>, JsonRecord),
+     erldns_config:keyget(<<"ttl">>, JsonRecord),
+     erldns_config:keyget(<<"data">>, JsonRecord),
+     erldns_config:keyget(<<"context">>, JsonRecord)].
 
 try_custom_parsers([_Name, _Type, _Ttl, _Rdata, _Context], []) ->
-  {};
-try_custom_parsers(Data, [Parser|Rest]) ->
-  case Parser:json_record_to_erlang(Data) of
-    {} -> try_custom_parsers(Data, Rest);
-    Record -> Record
-  end.
+    {};
+try_custom_parsers(Data, [Parser | Rest]) ->
+    case Parser:json_record_to_erlang(Data) of
+        {} ->
+            try_custom_parsers(Data, Rest);
+        Record ->
+            Record
+    end.
 
 % Internal converters
 json_record_to_erlang([Name, Type, _Ttl, Data = null, _]) ->
-  erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
-  {};
-
+    erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
+    {};
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_SOA,
-     data = #dns_rrdata_soa{
-               mname = erldns_config:keyget(<<"mname">>, Data),
-               rname = erldns_config:keyget(<<"rname">>, Data),
-               serial = erldns_config:keyget(<<"serial">>, Data),
-               refresh = erldns_config:keyget(<<"refresh">>, Data),
-               retry = erldns_config:keyget(<<"retry">>, Data),
-               expire = erldns_config:keyget(<<"expire">>, Data),
-               minimum = erldns_config:keyget(<<"minimum">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_SOA,
+            data =
+                #dns_rrdata_soa{mname = erldns_config:keyget(<<"mname">>, Data),
+                                rname = erldns_config:keyget(<<"rname">>, Data),
+                                serial = erldns_config:keyget(<<"serial">>, Data),
+                                refresh = erldns_config:keyget(<<"refresh">>, Data),
+                                retry = erldns_config:keyget(<<"retry">>, Data),
+                                expire = erldns_config:keyget(<<"expire">>, Data),
+                                minimum = erldns_config:keyget(<<"minimum">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"NS">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_NS,
-     data = #dns_rrdata_ns{
-               dname = erldns_config:keyget(<<"dname">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_NS,
+            data = #dns_rrdata_ns{dname = erldns_config:keyget(<<"dname">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) ->
-  case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
-    {ok, Address} ->
-      #dns_rr{name = Name, type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}, ttl = Ttl};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
-      {}
-  end;
-
+    case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
+        {ok, Address} ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_A,
+                    data = #dns_rrdata_a{ip = Address},
+                    ttl = Ttl};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) ->
-  case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
-    {ok, Address} ->
-      #dns_rr{name = Name, type = ?DNS_TYPE_AAAA, data = #dns_rrdata_aaaa{ip = Address}, ttl = Ttl};
-    {error, Reason} ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
-      {}
-  end;
-
+    case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
+        {ok, Address} ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_AAAA,
+                    data = #dns_rrdata_aaaa{ip = Address},
+                    ttl = Ttl};
+        {error, Reason} ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, <<"CAA">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_CAA,
-     data = #dns_rrdata_caa{
-               flags = erldns_config:keyget(<<"flags">>, Data),
-               tag = erldns_config:keyget(<<"tag">>, Data),
-               value = erldns_config:keyget(<<"value">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_CAA,
+            data =
+                #dns_rrdata_caa{flags = erldns_config:keyget(<<"flags">>, Data),
+                                tag = erldns_config:keyget(<<"tag">>, Data),
+                                value = erldns_config:keyget(<<"value">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"CNAME">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_CNAME,
-     data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_CNAME,
+            data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"MX">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_MX,
-     data = #dns_rrdata_mx{
-               exchange = erldns_config:keyget(<<"exchange">>, Data),
-               preference = erldns_config:keyget(<<"preference">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_MX,
+            data = #dns_rrdata_mx{exchange = erldns_config:keyget(<<"exchange">>, Data), preference = erldns_config:keyget(<<"preference">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"HINFO">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_HINFO,
-     data = #dns_rrdata_hinfo{
-               cpu = erldns_config:keyget(<<"cpu">>, Data),
-               os = erldns_config:keyget(<<"os">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_HINFO,
+            data = #dns_rrdata_hinfo{cpu = erldns_config:keyget(<<"cpu">>, Data), os = erldns_config:keyget(<<"os">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"RP">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_RP,
-     data = #dns_rrdata_rp{
-               mbox = erldns_config:keyget(<<"mbox">>, Data),
-               txt = erldns_config:keyget(<<"txt">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_RP,
+            data = #dns_rrdata_rp{mbox = erldns_config:keyget(<<"mbox">>, Data), txt = erldns_config:keyget(<<"txt">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, Type = <<"TXT">>, Ttl, Data, _Context]) ->
-  %% This function call may crash. Handle it as a bad record.
-  try erldns_txt:parse(erldns_config:keyget(<<"txt">>, Data)) of
-    ParsedText ->
-      #dns_rr{
-         name = Name,
-         type = ?DNS_TYPE_TXT,
-         data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
-         ttl = Ttl}
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
-
+    %% This function call may crash. Handle it as a bad record.
+    try erldns_txt:parse(erldns_config:keyget(<<"txt">>, Data)) of
+        ParsedText ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_TXT,
+                    data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
+                    ttl = Ttl}
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, <<"SPF">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_SPF,
-     data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_SPF,
+            data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"PTR">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_PTR,
-     data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_PTR,
+            data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, Type = <<"SSHFP">>, Ttl, Data, _Context]) ->
-  %% This function call may crash. Handle it as a bad record.
-  try hex_to_bin(erldns_config:keyget(<<"fp">>, Data)) of
-    Fp ->
-      #dns_rr{
-         name = Name,
-         type = ?DNS_TYPE_SSHFP,
-         data = #dns_rrdata_sshfp{
-                   alg = erldns_config:keyget(<<"alg">>, Data),
-                   fp_type = erldns_config:keyget(<<"fptype">>, Data),
-                   fp = Fp
-                  },
-         ttl = Ttl}
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
+    %% This function call may crash. Handle it as a bad record.
+    try hex_to_bin(erldns_config:keyget(<<"fp">>, Data)) of
+        Fp ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_SSHFP,
+                    data =
+                        #dns_rrdata_sshfp{alg = erldns_config:keyget(<<"alg">>, Data),
+                                          fp_type = erldns_config:keyget(<<"fptype">>, Data),
+                                          fp = Fp},
+                    ttl = Ttl}
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, <<"SRV">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_SRV,
-     data = #dns_rrdata_srv{
-               priority = erldns_config:keyget(<<"priority">>, Data),
-               weight = erldns_config:keyget(<<"weight">>, Data),
-               port = erldns_config:keyget(<<"port">>, Data),
-               target = erldns_config:keyget(<<"target">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_SRV,
+            data =
+                #dns_rrdata_srv{priority = erldns_config:keyget(<<"priority">>, Data),
+                                weight = erldns_config:keyget(<<"weight">>, Data),
+                                port = erldns_config:keyget(<<"port">>, Data),
+                                target = erldns_config:keyget(<<"target">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, <<"NAPTR">>, Ttl, Data, _Context]) ->
-  #dns_rr{
-     name = Name,
-     type = ?DNS_TYPE_NAPTR,
-     data = #dns_rrdata_naptr{
-               order = erldns_config:keyget(<<"order">>, Data),
-               preference = erldns_config:keyget(<<"preference">>, Data),
-               flags = erldns_config:keyget(<<"flags">>, Data),
-               services = erldns_config:keyget(<<"services">>, Data),
-               regexp = erldns_config:keyget(<<"regexp">>, Data),
-               replacement = erldns_config:keyget(<<"replacement">>, Data)
-              },
-     ttl = Ttl};
-
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_NAPTR,
+            data =
+                #dns_rrdata_naptr{order = erldns_config:keyget(<<"order">>, Data),
+                                  preference = erldns_config:keyget(<<"preference">>, Data),
+                                  flags = erldns_config:keyget(<<"flags">>, Data),
+                                  services = erldns_config:keyget(<<"services">>, Data),
+                                  regexp = erldns_config:keyget(<<"regexp">>, Data),
+                                  replacement = erldns_config:keyget(<<"replacement">>, Data)},
+            ttl = Ttl};
 json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) ->
-  try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
-    Digest ->
-      #dns_rr{
-         name = Name,
-         type = ?DNS_TYPE_DS,
-         data = #dns_rrdata_ds{
-                   keytag = erldns_config:keyget(<<"keytag">>, Data),
-                   alg = erldns_config:keyget(<<"alg">>, Data),
-                   digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                   digest = Digest
-                  },
-         ttl = Ttl}
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
+    try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
+        Digest ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_DS,
+                    data =
+                        #dns_rrdata_ds{keytag = erldns_config:keyget(<<"keytag">>, Data),
+                                       alg = erldns_config:keyget(<<"alg">>, Data),
+                                       digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                                       digest = Digest},
+                    ttl = Ttl}
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) ->
-  try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
-    Digest ->
-      #dns_rr{
-         name = Name,
-         type = ?DNS_TYPE_CDS,
-         data = #dns_rrdata_cds{
-                   keytag = erldns_config:keyget(<<"keytag">>, Data),
-                   alg = erldns_config:keyget(<<"alg">>, Data),
-                   digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                   digest = Digest
-                  },
-         ttl = Ttl}
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
+    try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
+        Digest ->
+            #dns_rr{name = Name,
+                    type = ?DNS_TYPE_CDS,
+                    data =
+                        #dns_rrdata_cds{keytag = erldns_config:keyget(<<"keytag">>, Data),
+                                        alg = erldns_config:keyget(<<"alg">>, Data),
+                                        digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                                        digest = Digest},
+                    ttl = Ttl}
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) ->
-  try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
-    PublicKey ->
-      dnssec:add_keytag_to_dnskey(
-        #dns_rr{
-           name = Name,
-           type = ?DNS_TYPE_DNSKEY,
-           data = #dns_rrdata_dnskey{
-                     flags = erldns_config:keyget(<<"flags">>, Data),
-                     protocol = erldns_config:keyget(<<"protocol">>, Data),
-                     alg = erldns_config:keyget(<<"alg">>, Data),
-                     public_key = PublicKey
-                    },
-           ttl = Ttl})
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
+    try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
+        PublicKey ->
+            dnssec:add_keytag_to_dnskey(#dns_rr{name = Name,
+                                                type = ?DNS_TYPE_DNSKEY,
+                                                data =
+                                                    #dns_rrdata_dnskey{flags = erldns_config:keyget(<<"flags">>, Data),
+                                                                       protocol = erldns_config:keyget(<<"protocol">>, Data),
+                                                                       alg = erldns_config:keyget(<<"alg">>, Data),
+                                                                       public_key = PublicKey},
+                                                ttl = Ttl})
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) ->
-  try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
-    PublicKey ->
-      dnssec:add_keytag_to_cdnskey(
-        #dns_rr{
-           name = Name,
-           type = ?DNS_TYPE_CDNSKEY,
-           data = #dns_rrdata_cdnskey{
-                     flags = erldns_config:keyget(<<"flags">>, Data),
-                     protocol = erldns_config:keyget(<<"protocol">>, Data),
-                     alg = erldns_config:keyget(<<"alg">>, Data),
-                     public_key = PublicKey
-                    },
-           ttl = Ttl})
-  catch
-    Exception:Reason ->
-      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-      {}
-  end;
-
+    try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
+        PublicKey ->
+            dnssec:add_keytag_to_cdnskey(#dns_rr{name = Name,
+                                                 type = ?DNS_TYPE_CDNSKEY,
+                                                 data =
+                                                     #dns_rrdata_cdnskey{flags = erldns_config:keyget(<<"flags">>, Data),
+                                                                         protocol = erldns_config:keyget(<<"protocol">>, Data),
+                                                                         alg = erldns_config:keyget(<<"alg">>, Data),
+                                                                         public_key = PublicKey},
+                                                 ttl = Ttl})
+    catch
+        Exception:Reason ->
+            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+            {}
+    end;
 json_record_to_erlang(_Data) ->
-  {}.
+    {}.
 
 hex_to_bin(Bin) when is_binary(Bin) ->
-  Fun = fun(A, B) ->
-            case io_lib:fread("~16u", [A, B]) of
-              {ok, [V], []} -> V;
-              _ -> error(badarg)
-            end
-        end,
-  << <<(Fun(A,B))>> || <<A, B>> <= Bin >>.
+    Fun = fun(A, B) ->
+             case io_lib:fread("~16u", [A, B]) of
+                 {ok, [V], []} -> V;
+                 _ -> error(badarg)
+             end
+          end,
+    << <<(Fun(A, B))>> || <<A, B>> <= Bin >>.
 
 base64_to_bin(Bin) when is_binary(Bin) ->
-  base64:decode(Bin).
+    base64:decode(Bin).
 
 -ifdef(TEST).
+
 json_record_to_erlang_test() ->
-  erldns_events:start_link(),
-  ?assertEqual({}, json_record_to_erlang([])),
-  Name = <<"example.com">>,
-  ?assertEqual({}, json_record_to_erlang([Name, <<"SOA">>, 3600, null, null])).
+    erldns_events:start_link(),
+    ?assertEqual({}, json_record_to_erlang([])),
+    Name = <<"example.com">>,
+    ?assertEqual({}, json_record_to_erlang([Name, <<"SOA">>, 3600, null, null])).
 
 json_record_soa_to_erlang_test() ->
-  Name = <<"example.com">>,
-  ?assertEqual(#dns_rr{name = Name,
-                       type = ?DNS_TYPE_SOA,
-                       data = #dns_rrdata_soa{
-                                 mname = <<"ns1.example.com">>,
-                                 rname = <<"admin.example.com">>,
-                                 serial = 12345,
-                                 refresh = 555,
-                                 retry = 666,
-                                 expire = 777,
-                                 minimum = 888
-                                },
-                       ttl = 3600},
-               json_record_to_erlang([Name, <<"SOA">>, 3600, [
-                                                              {<<"mname">>, <<"ns1.example.com">>},
-                                                              {<<"rname">>, <<"admin.example.com">>},
-                                                              {<<"serial">>, 12345},
-                                                              {<<"refresh">>, 555},
-                                                              {<<"retry">>, 666},
-                                                              {<<"expire">>, 777},
-                                                              {<<"minimum">>, 888}
-                                                             ], undefined])).
+    Name = <<"example.com">>,
+    ?assertEqual(#dns_rr{name = Name,
+                         type = ?DNS_TYPE_SOA,
+                         data =
+                             #dns_rrdata_soa{mname = <<"ns1.example.com">>,
+                                             rname = <<"admin.example.com">>,
+                                             serial = 12345,
+                                             refresh = 555,
+                                             retry = 666,
+                                             expire = 777,
+                                             minimum = 888},
+                         ttl = 3600},
+                 json_record_to_erlang([Name,
+                                        <<"SOA">>,
+                                        3600,
+                                        [{<<"mname">>, <<"ns1.example.com">>},
+                                         {<<"rname">>, <<"admin.example.com">>},
+                                         {<<"serial">>, 12345},
+                                         {<<"refresh">>, 555},
+                                         {<<"retry">>, 666},
+                                         {<<"expire">>, 777},
+                                         {<<"minimum">>, 888}],
+                                        undefined])).
 
 json_record_ns_to_erlang_test() ->
-  Name = <<"example.com">>,
-  ?assertEqual(#dns_rr{name = Name,
-                       type = ?DNS_TYPE_NS,
-                       data = #dns_rrdata_ns{
-                                 dname = <<"ns1.example.com">>
-                                },
-                       ttl = 3600},
-               json_record_to_erlang([Name, <<"NS">>, 3600, [
-                                                             {<<"dname">>, <<"ns1.example.com">>}
-                                                            ], undefined])).
+    Name = <<"example.com">>,
+    ?assertEqual(#dns_rr{name = Name,
+                         type = ?DNS_TYPE_NS,
+                         data = #dns_rrdata_ns{dname = <<"ns1.example.com">>},
+                         ttl = 3600},
+                 json_record_to_erlang([Name, <<"NS">>, 3600, [{<<"dname">>, <<"ns1.example.com">>}], undefined])).
 
 json_record_a_to_erlang_test() ->
-  Name = <<"example.com">>,
-  ?assertEqual(#dns_rr{name = Name,
-                       type = ?DNS_TYPE_A,
-                       data = #dns_rrdata_a{
-                                 ip = {1,2,3,4}
-                                },
-                       ttl = 3600},
-               json_record_to_erlang([Name, <<"A">>, 3600, [
-                                                            {<<"ip">>, <<"1.2.3.4">>}
-                                                           ], undefined])).
+    Name = <<"example.com">>,
+    ?assertEqual(#dns_rr{name = Name,
+                         type = ?DNS_TYPE_A,
+                         data = #dns_rrdata_a{ip = {1, 2, 3, 4}},
+                         ttl = 3600},
+                 json_record_to_erlang([Name, <<"A">>, 3600, [{<<"ip">>, <<"1.2.3.4">>}], undefined])).
 
 json_record_aaaa_to_erlang_test() ->
-  Name = <<"example.com">>,
-  ?assertEqual(#dns_rr{name = Name,
-                       type = ?DNS_TYPE_AAAA,
-                       data = #dns_rrdata_aaaa{
-                                 ip = {0,0,0,0,0,0,0,1}
-                                },
-                       ttl = 3600},
-               json_record_to_erlang([Name, <<"AAAA">>, 3600, [
-                                                               {<<"ip">>, <<"::1">>}
-                                                              ], undefined])).
+    Name = <<"example.com">>,
+    ?assertEqual(#dns_rr{name = Name,
+                         type = ?DNS_TYPE_AAAA,
+                         data = #dns_rrdata_aaaa{ip = {0, 0, 0, 0, 0, 0, 0, 1}},
+                         ttl = 3600},
+                 json_record_to_erlang([Name, <<"AAAA">>, 3600, [{<<"ip">>, <<"::1">>}], undefined])).
 
 json_record_cds_to_erlang_test() ->
-  Name = <<"example-dnssec.com">>,
-  ?assertEqual(#dns_rr{name = Name,
-                       type = ?DNS_TYPE_CDS,
-                       data = #dns_rrdata_cds{
-                                  keytag = 0,
-                                  digest_type = 2,
-                                  alg = 8,
-                                  digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)
-                                },
-                       ttl = 3600},
-               json_record_to_erlang([Name, <<"CDS">>, 3600, [
-                                                              {<<"keytag">>, 0},
-                                                              {<<"digest_type">>, 2},
-                                                              {<<"alg">>, 8},
-                                                              {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}
-                                                             ], undefined])).
+    Name = <<"example-dnssec.com">>,
+    ?assertEqual(#dns_rr{name = Name,
+                         type = ?DNS_TYPE_CDS,
+                         data =
+                             #dns_rrdata_cds{keytag = 0,
+                                             digest_type = 2,
+                                             alg = 8,
+                                             digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)},
+                         ttl = 3600},
+                 json_record_to_erlang([Name,
+                                        <<"CDS">>,
+                                        3600,
+                                        [{<<"keytag">>, 0},
+                                         {<<"digest_type">>, 2},
+                                         {<<"alg">>, 8},
+                                         {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}],
+                                        undefined])).
 
 hex_to_bin_test() ->
-  ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
-  ?assertEqual(<<255, 0, 255>>, hex_to_bin(<<"FF00FF">>)).
+    ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
+    ?assertEqual(<<255, 0, 255>>, hex_to_bin(<<"FF00FF">>)).
 
 base64_to_bin_test() ->
-  ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
-  ?assertEqual(<<3,1,0,1,191,165,76,56,217,9,250,187,15,147,125,112,215,
-                 117,186,13,244,192,186,219,9,112,125,153,82,73,64,105,
-                 80,64,122,98,28,121,76,104,177,134,177,93,191,143,159,
-                 158,162,49,233,249,100,20,204,218,78,206,181,11,23,169,
-                 172,108,75,212,185,93,160,72,73,233,110,231,145,87,139,
-                 112,59,201,174,24,79,177,121,75,172,121,42,7,135,246,
-                 147,164,15,25,245,35,238,109,189,53,153,219,170,169,165,
-                 4,55,146,110,207,100,56,132,93,29,73,68,137,98,82,79,42,
-                 26,122,54,179,160,161,236,163>>, base64_to_bin(<<"AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8muGE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj">>)).
+    ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
+    ?assertEqual(<<3, 1, 0, 1, 191, 165, 76, 56, 217, 9, 250, 187, 15, 147, 125, 112, 215, 117, 186, 13, 244, 192, 186, 219, 9, 112, 125, 153, 82, 73, 64,
+                   105, 80, 64, 122, 98, 28, 121, 76, 104, 177, 134, 177, 93, 191, 143, 159, 158, 162, 49, 233, 249, 100, 20, 204, 218, 78, 206, 181, 11, 23,
+                   169, 172, 108, 75, 212, 185, 93, 160, 72, 73, 233, 110, 231, 145, 87, 139, 112, 59, 201, 174, 24, 79, 177, 121, 75, 172, 121, 42, 7, 135,
+                   246, 147, 164, 15, 25, 245, 35, 238, 109, 189, 53, 153, 219, 170, 169, 165, 4, 55, 146, 110, 207, 100, 56, 132, 93, 29, 73, 68, 137, 98, 82,
+                   79, 42, 26, 122, 54, 179, 160, 161, 236, 163>>,
+                 base64_to_bin(<<"AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8mu"
+                                 "GE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj">>)).
+
 -endif.

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -18,29 +18,30 @@
 -behavior(gen_server).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
--export([start_link/0,
+-export([
+         start_link/0,
          zone_to_erlang/1,
          register_parsers/1,
          register_parser/1,
-         list_parsers/0]).
+         list_parsers/0
+        ]).
+
 % Gen server hooks
 -export([init/1,
          handle_call/3,
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3
+        ]).
 
 -define(SERVER, ?MODULE).
 -define(PARSE_TIMEOUT, 30 * 1000).
 
 -ifdef(TEST).
-
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
 -record(state, {parsers}).
@@ -50,141 +51,136 @@
 %% @doc Start the parser processor.
 -spec start_link() -> any().
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %% @doc Takes a JSON zone and turns it into the tuple {Name, Sha, Records}.
 %%
 %% The default timeout for parsing is currently 30 seconds.
 -spec zone_to_erlang(binary()) -> {binary(), binary(), [dns:rr()], [erldns:keyset()]}.
 zone_to_erlang(Zone) ->
-    gen_server:call(?SERVER, {parse_zone, Zone}, ?PARSE_TIMEOUT).
+  gen_server:call(?SERVER, {parse_zone, Zone}, ?PARSE_TIMEOUT).
 
 %% @doc Register a list of custom parser modules.
 -spec register_parsers([module()]) -> ok.
 register_parsers(Modules) ->
-    lager:info("Registering custom parsers (modules: ~p)", [Modules]),
-    gen_server:call(?SERVER, {register_parsers, Modules}).
+  lager:info("Registering custom parsers (modules: ~p)", [Modules]),
+  gen_server:call(?SERVER, {register_parsers, Modules}).
 
 %% @doc Regiaer a custom parser module.
 -spec register_parser(module()) -> ok.
 register_parser(Module) ->
-    lager:info("Registering custom parser (module: ~p)", [Module]),
-    gen_server:call(?SERVER, {register_parser, Module}).
+  lager:info("Registering custom parser (module: ~p)", [Module]),
+  gen_server:call(?SERVER, {register_parser, Module}).
 
 -spec list_parsers() -> [module()].
 list_parsers() ->
-    gen_server:call(?SERVER, list_parsers).
+  gen_server:call(?SERVER, list_parsers).
+
 
 %% Gen server hooks
 init([]) ->
-    {ok, #state{parsers = []}}.
+  {ok, #state{parsers = []}}.
 
 handle_call({parse_zone, Zone}, _From, State) ->
-    {reply, json_to_erlang(Zone, State#state.parsers), State};
+  {reply, json_to_erlang(Zone, State#state.parsers), State};
+
 handle_call({register_parsers, Modules}, _From, State) ->
-    {reply, ok, State#state{parsers = State#state.parsers ++ Modules}};
+  {reply, ok, State#state{parsers = State#state.parsers ++ Modules}};
+
 handle_call({register_parser, Module}, _From, State) ->
-    {reply, ok, State#state{parsers = State#state.parsers ++ [Module]}};
+  {reply, ok, State#state{parsers = State#state.parsers ++ [Module]}};
+
 handle_call(list_parsers, _From, State) ->
-    {reply, ok, State#state.parsers}.
+  {reply, ok, State#state.parsers}.
 
 handle_cast(_, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 handle_info(_, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_, _State) ->
-    ok.
+  ok.
 
 code_change(_, State, _) ->
-    {ok, State}.
+  {ok, State}.
+
+
 
 % Internal API
 json_to_erlang([{<<"name">>, Name}, {<<"records">>, JsonRecords}], Parsers) ->
-    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
+  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
+
 json_to_erlang([{<<"name">>, Name}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers) ->
-    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers);
+  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, ""}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers);
+
 json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}], Parsers) ->
-    json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
+  json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, []}], Parsers);
+
 json_to_erlang([{<<"name">>, Name}, {<<"sha">>, Sha}, {<<"records">>, JsonRecords}, {<<"keys">>, JsonKeys}], Parsers) ->
-    Records =
-        lists:map(fun(JsonRecord) ->
-                     Data = json_record_to_list(JsonRecord),
-                     % Filter by context
-                     case apply_context_options(Data) of
-                         pass ->
-                             case json_record_to_erlang(Data) of
-                                 {} ->
-                                     case try_custom_parsers(Data, Parsers) of
-                                         {} ->
-                                             erldns_events:notify({?MODULE, unsupported_record, Data}),
-                                             {};
-                                         ParsedRecord -> ParsedRecord
-                                     end;
-                                 ParsedRecord -> ParsedRecord
-                             end;
-                         _ -> {}
-                     end
-                  end,
-                  JsonRecords),
-    FilteredRecords = lists:filter(record_filter(), Records),
-    DistinctRecords = lists:usort(FilteredRecords),
-    {Name, Sha, DistinctRecords, parse_json_keys(JsonKeys)}.
+  Records = lists:map(
+              fun(JsonRecord) ->
+                  Data = json_record_to_list(JsonRecord),
+                  % Filter by context
+                  case apply_context_options(Data) of
+                    pass ->
+                      case json_record_to_erlang(Data) of
+                        {} ->
+                          case try_custom_parsers(Data, Parsers) of
+                            {} ->
+                              erldns_events:notify({?MODULE, unsupported_record, Data}),
+                              {};
+                            ParsedRecord -> ParsedRecord
+                          end;
+                        ParsedRecord -> ParsedRecord
+                      end;
+                    _ ->
+                      {}
+                  end
+              end, JsonRecords),
+  FilteredRecords = lists:filter(record_filter(), Records),
+  DistinctRecords = lists:usort(FilteredRecords),
+  {Name, Sha, DistinctRecords, parse_json_keys(JsonKeys)}.
 
-parse_json_keys(JsonKeys) ->
-    parse_json_keys(JsonKeys, []).
+parse_json_keys(JsonKeys) -> parse_json_keys(JsonKeys, []).
 
-parse_json_keys([], Keys) ->
-    Keys;
-parse_json_keys([[{<<"ksk">>, KskBin},
-                  {<<"ksk_keytag">>, KskKeytag},
-                  {<<"ksk_alg">>, KskAlg},
-                  {<<"zsk">>, ZskBin},
-                  {<<"zsk_keytag">>, ZskKeytag},
-                  {<<"zsk_alg">>, ZskAlg},
-                  {<<"inception">>, Inception},
-                  {<<"until">>, ValidUntil}]
-                 | Rest],
-                Keys) ->
-    KeySet =
-        #keyset{key_signing_key = to_crypto_key(KskBin),
-                key_signing_key_tag = KskKeytag,
-                key_signing_alg = KskAlg,
-                zone_signing_key = to_crypto_key(ZskBin),
-                zone_signing_key_tag = ZskKeytag,
-                zone_signing_alg = ZskAlg,
-                inception = iso8601:parse(Inception),
-                valid_until = iso8601:parse(ValidUntil)},
-    parse_json_keys(Rest, [KeySet | Keys]).
+parse_json_keys([], Keys) -> Keys;
+parse_json_keys([[{<<"ksk">>, KskBin}, {<<"ksk_keytag">>, KskKeytag}, {<<"ksk_alg">>, KskAlg}, {<<"zsk">>, ZskBin}, {<<"zsk_keytag">>, ZskKeytag}, {<<"zsk_alg">>, ZskAlg}, {<<"inception">>, Inception}, {<<"until">>, ValidUntil}]|Rest], Keys) ->
+  KeySet = #keyset{
+              key_signing_key = to_crypto_key(KskBin),
+              key_signing_key_tag = KskKeytag,
+              key_signing_alg = KskAlg,
+              zone_signing_key = to_crypto_key(ZskBin),
+              zone_signing_key_tag = ZskKeytag,
+              zone_signing_alg = ZskAlg,
+              inception = iso8601:parse(Inception),
+              valid_until = iso8601:parse(ValidUntil)
+             },
+  parse_json_keys(Rest, [KeySet | Keys]).
 
 to_crypto_key(RsaKeyBin) ->
-    % Where E is the public exponent, N is public modulus and D is the private exponent
-    [_, _, M, E, N | _] = tuple_to_list(public_key:pem_entry_decode(lists:last(public_key:pem_decode(RsaKeyBin)))),
-    [E, M, N].
+  % Where E is the public exponent, N is public modulus and D is the private exponent
+  [_,_,M,E,N|_] = tuple_to_list(public_key:pem_entry_decode(lists:last(public_key:pem_decode(RsaKeyBin)))),
+  [E,M,N].
 
 record_filter() ->
-    fun(R) ->
-       case R of
-           {} -> false;
-           _ -> true
-       end
-    end.
+  fun(R) ->
+      case R of
+        {} -> false;
+        _ -> true
+      end
+  end.
 
 -spec apply_context_list_check(sets:set(), sets:set()) -> [fail] | [pass].
 apply_context_list_check(ContextAllowSet, ContextSet) ->
-    case sets:size(sets:intersection(ContextAllowSet, ContextSet)) of
-        0 ->
-            [fail];
-        _ ->
-            [pass]
-    end.
+  case sets:size(sets:intersection(ContextAllowSet, ContextSet)) of
+    0 -> [fail];
+    _ -> [pass]
+  end.
 
 -spec apply_context_match_empty_check(boolean(), [any()]) -> [fail] | [pass].
-apply_context_match_empty_check(true, []) ->
-    [pass];
-apply_context_match_empty_check(_, _) ->
-    [fail].
+apply_context_match_empty_check(true, []) -> [pass];
+apply_context_match_empty_check(_, _) -> [fail].
 
 %% Determine if a record should be used in this name server's context.
 %%
@@ -193,339 +189,401 @@ apply_context_match_empty_check(_, _) ->
 %% If the context is a list and has at least one condition that passes
 %% then it will be included in the zone
 -spec apply_context_options([any()]) -> pass | fail.
-apply_context_options([_, _, _, _, undefined]) ->
-    pass;
+apply_context_options([_, _, _, _, undefined]) -> pass;
 apply_context_options([_, _, _, _, Context]) ->
-    case application:get_env(erldns, context_options) of
-        {ok, ContextOptions} ->
-            ContextSet = sets:from_list(Context),
-            Result =
-                lists:append([apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
-                              apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)]),
-            case lists:any(fun(I) -> I =:= pass end, Result) of
-                true ->
-                    pass;
-                _ ->
-                    fail
-            end;
-        _ ->
-            pass
-    end.
+  case application:get_env(erldns, context_options) of
+    {ok, ContextOptions} ->
+      ContextSet = sets:from_list(Context),
+      Result = lists:append([
+                             apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
+                             apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)
+                            ]),
+      case lists:any(fun(I) -> I =:= pass end, Result) of
+        true -> pass;
+        _ -> fail
+      end;
+    _ ->
+      pass
+  end.
 
 json_record_to_list(JsonRecord) ->
-    [erldns_config:keyget(<<"name">>, JsonRecord),
-     erldns_config:keyget(<<"type">>, JsonRecord),
-     erldns_config:keyget(<<"ttl">>, JsonRecord),
-     erldns_config:keyget(<<"data">>, JsonRecord),
-     erldns_config:keyget(<<"context">>, JsonRecord)].
+  [
+   erldns_config:keyget(<<"name">>, JsonRecord),
+   erldns_config:keyget(<<"type">>, JsonRecord),
+   erldns_config:keyget(<<"ttl">>, JsonRecord),
+   erldns_config:keyget(<<"data">>, JsonRecord),
+   erldns_config:keyget(<<"context">>, JsonRecord)
+  ].
 
 try_custom_parsers([_Name, _Type, _Ttl, _Rdata, _Context], []) ->
-    {};
-try_custom_parsers(Data, [Parser | Rest]) ->
-    case Parser:json_record_to_erlang(Data) of
-        {} ->
-            try_custom_parsers(Data, Rest);
-        Record ->
-            Record
-    end.
+  {};
+try_custom_parsers(Data, [Parser|Rest]) ->
+  case Parser:json_record_to_erlang(Data) of
+    {} -> try_custom_parsers(Data, Rest);
+    Record -> Record
+  end.
 
 % Internal converters
 json_record_to_erlang([Name, Type, _Ttl, Data = null, _]) ->
-    erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
-    {};
+  erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
+  {};
+
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SOA,
-            data =
-                #dns_rrdata_soa{mname = erldns_config:keyget(<<"mname">>, Data),
-                                rname = erldns_config:keyget(<<"rname">>, Data),
-                                serial = erldns_config:keyget(<<"serial">>, Data),
-                                refresh = erldns_config:keyget(<<"refresh">>, Data),
-                                retry = erldns_config:keyget(<<"retry">>, Data),
-                                expire = erldns_config:keyget(<<"expire">>, Data),
-                                minimum = erldns_config:keyget(<<"minimum">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_SOA,
+     data = #dns_rrdata_soa{
+               mname = erldns_config:keyget(<<"mname">>, Data),
+               rname = erldns_config:keyget(<<"rname">>, Data),
+               serial = erldns_config:keyget(<<"serial">>, Data),
+               refresh = erldns_config:keyget(<<"refresh">>, Data),
+               retry = erldns_config:keyget(<<"retry">>, Data),
+               expire = erldns_config:keyget(<<"expire">>, Data),
+               minimum = erldns_config:keyget(<<"minimum">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"NS">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NS,
-            data = #dns_rrdata_ns{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_NS,
+     data = #dns_rrdata_ns{
+               dname = erldns_config:keyget(<<"dname">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) ->
-    case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
-        {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_A,
-                    data = #dns_rrdata_a{ip = Address},
-                    ttl = Ttl};
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
-            {}
-    end;
+  case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
+    {ok, Address} ->
+      #dns_rr{name = Name, type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}, ttl = Ttl};
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) ->
-    case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
-        {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_AAAA,
-                    data = #dns_rrdata_aaaa{ip = Address},
-                    ttl = Ttl};
-        {error, Reason} ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
-            {}
-    end;
+  case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
+    {ok, Address} ->
+      #dns_rr{name = Name, type = ?DNS_TYPE_AAAA, data = #dns_rrdata_aaaa{ip = Address}, ttl = Ttl};
+    {error, Reason} ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, <<"CAA">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CAA,
-            data =
-                #dns_rrdata_caa{flags = erldns_config:keyget(<<"flags">>, Data),
-                                tag = erldns_config:keyget(<<"tag">>, Data),
-                                value = erldns_config:keyget(<<"value">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_CAA,
+     data = #dns_rrdata_caa{
+               flags = erldns_config:keyget(<<"flags">>, Data),
+               tag = erldns_config:keyget(<<"tag">>, Data),
+               value = erldns_config:keyget(<<"value">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"CNAME">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CNAME,
-            data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_CNAME,
+     data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"MX">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_MX,
-            data = #dns_rrdata_mx{exchange = erldns_config:keyget(<<"exchange">>, Data), preference = erldns_config:keyget(<<"preference">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_MX,
+     data = #dns_rrdata_mx{
+               exchange = erldns_config:keyget(<<"exchange">>, Data),
+               preference = erldns_config:keyget(<<"preference">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"HINFO">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_HINFO,
-            data = #dns_rrdata_hinfo{cpu = erldns_config:keyget(<<"cpu">>, Data), os = erldns_config:keyget(<<"os">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_HINFO,
+     data = #dns_rrdata_hinfo{
+               cpu = erldns_config:keyget(<<"cpu">>, Data),
+               os = erldns_config:keyget(<<"os">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"RP">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_RP,
-            data = #dns_rrdata_rp{mbox = erldns_config:keyget(<<"mbox">>, Data), txt = erldns_config:keyget(<<"txt">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_RP,
+     data = #dns_rrdata_rp{
+               mbox = erldns_config:keyget(<<"mbox">>, Data),
+               txt = erldns_config:keyget(<<"txt">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, Type = <<"TXT">>, Ttl, Data, _Context]) ->
-    %% This function call may crash. Handle it as a bad record.
-    try erldns_txt:parse(erldns_config:keyget(<<"txt">>, Data)) of
-        ParsedText ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_TXT,
-                    data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
-                    ttl = Ttl}
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  %% This function call may crash. Handle it as a bad record.
+  try erldns_txt:parse(erldns_config:keyget(<<"txt">>, Data)) of
+    ParsedText ->
+      #dns_rr{
+         name = Name,
+         type = ?DNS_TYPE_TXT,
+         data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
+         ttl = Ttl}
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
+
 json_record_to_erlang([Name, <<"SPF">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SPF,
-            data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_SPF,
+     data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"PTR">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_PTR,
-            data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_PTR,
+     data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
+     ttl = Ttl};
+
 json_record_to_erlang([Name, Type = <<"SSHFP">>, Ttl, Data, _Context]) ->
-    %% This function call may crash. Handle it as a bad record.
-    try hex_to_bin(erldns_config:keyget(<<"fp">>, Data)) of
-        Fp ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_SSHFP,
-                    data =
-                        #dns_rrdata_sshfp{alg = erldns_config:keyget(<<"alg">>, Data),
-                                          fp_type = erldns_config:keyget(<<"fptype">>, Data),
-                                          fp = Fp},
-                    ttl = Ttl}
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  %% This function call may crash. Handle it as a bad record.
+  try hex_to_bin(erldns_config:keyget(<<"fp">>, Data)) of
+    Fp ->
+      #dns_rr{
+         name = Name,
+         type = ?DNS_TYPE_SSHFP,
+         data = #dns_rrdata_sshfp{
+                   alg = erldns_config:keyget(<<"alg">>, Data),
+                   fp_type = erldns_config:keyget(<<"fptype">>, Data),
+                   fp = Fp
+                  },
+         ttl = Ttl}
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, <<"SRV">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SRV,
-            data =
-                #dns_rrdata_srv{priority = erldns_config:keyget(<<"priority">>, Data),
-                                weight = erldns_config:keyget(<<"weight">>, Data),
-                                port = erldns_config:keyget(<<"port">>, Data),
-                                target = erldns_config:keyget(<<"target">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_SRV,
+     data = #dns_rrdata_srv{
+               priority = erldns_config:keyget(<<"priority">>, Data),
+               weight = erldns_config:keyget(<<"weight">>, Data),
+               port = erldns_config:keyget(<<"port">>, Data),
+               target = erldns_config:keyget(<<"target">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, <<"NAPTR">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NAPTR,
-            data =
-                #dns_rrdata_naptr{order = erldns_config:keyget(<<"order">>, Data),
-                                  preference = erldns_config:keyget(<<"preference">>, Data),
-                                  flags = erldns_config:keyget(<<"flags">>, Data),
-                                  services = erldns_config:keyget(<<"services">>, Data),
-                                  regexp = erldns_config:keyget(<<"regexp">>, Data),
-                                  replacement = erldns_config:keyget(<<"replacement">>, Data)},
-            ttl = Ttl};
+  #dns_rr{
+     name = Name,
+     type = ?DNS_TYPE_NAPTR,
+     data = #dns_rrdata_naptr{
+               order = erldns_config:keyget(<<"order">>, Data),
+               preference = erldns_config:keyget(<<"preference">>, Data),
+               flags = erldns_config:keyget(<<"flags">>, Data),
+               services = erldns_config:keyget(<<"services">>, Data),
+               regexp = erldns_config:keyget(<<"regexp">>, Data),
+               replacement = erldns_config:keyget(<<"replacement">>, Data)
+              },
+     ttl = Ttl};
+
 json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) ->
-    try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
-        Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_DS,
-                    data =
-                        #dns_rrdata_ds{keytag = erldns_config:keyget(<<"keytag">>, Data),
-                                       alg = erldns_config:keyget(<<"alg">>, Data),
-                                       digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                                       digest = Digest},
-                    ttl = Ttl}
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
+    Digest ->
+      #dns_rr{
+         name = Name,
+         type = ?DNS_TYPE_DS,
+         data = #dns_rrdata_ds{
+                   keytag = erldns_config:keyget(<<"keytag">>, Data),
+                   alg = erldns_config:keyget(<<"alg">>, Data),
+                   digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                   digest = Digest
+                  },
+         ttl = Ttl}
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) ->
-    try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
-        Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_CDS,
-                    data =
-                        #dns_rrdata_cds{keytag = erldns_config:keyget(<<"keytag">>, Data),
-                                        alg = erldns_config:keyget(<<"alg">>, Data),
-                                        digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                                        digest = Digest},
-                    ttl = Ttl}
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
+    Digest ->
+      #dns_rr{
+         name = Name,
+         type = ?DNS_TYPE_CDS,
+         data = #dns_rrdata_cds{
+                   keytag = erldns_config:keyget(<<"keytag">>, Data),
+                   alg = erldns_config:keyget(<<"alg">>, Data),
+                   digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                   digest = Digest
+                  },
+         ttl = Ttl}
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) ->
-    try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
-        PublicKey ->
-            dnssec:add_keytag_to_dnskey(#dns_rr{name = Name,
-                                                type = ?DNS_TYPE_DNSKEY,
-                                                data =
-                                                    #dns_rrdata_dnskey{flags = erldns_config:keyget(<<"flags">>, Data),
-                                                                       protocol = erldns_config:keyget(<<"protocol">>, Data),
-                                                                       alg = erldns_config:keyget(<<"alg">>, Data),
-                                                                       public_key = PublicKey},
-                                                ttl = Ttl})
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
+    PublicKey ->
+      dnssec:add_keytag_to_dnskey(
+        #dns_rr{
+           name = Name,
+           type = ?DNS_TYPE_DNSKEY,
+           data = #dns_rrdata_dnskey{
+                     flags = erldns_config:keyget(<<"flags">>, Data),
+                     protocol = erldns_config:keyget(<<"protocol">>, Data),
+                     alg = erldns_config:keyget(<<"alg">>, Data),
+                     public_key = PublicKey
+                    },
+           ttl = Ttl})
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) ->
-    try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
-        PublicKey ->
-            dnssec:add_keytag_to_cdnskey(#dns_rr{name = Name,
-                                                 type = ?DNS_TYPE_CDNSKEY,
-                                                 data =
-                                                     #dns_rrdata_cdnskey{flags = erldns_config:keyget(<<"flags">>, Data),
-                                                                         protocol = erldns_config:keyget(<<"protocol">>, Data),
-                                                                         alg = erldns_config:keyget(<<"alg">>, Data),
-                                                                         public_key = PublicKey},
-                                                 ttl = Ttl})
-    catch
-        Exception:Reason ->
-            erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
-            {}
-    end;
+  try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
+    PublicKey ->
+      dnssec:add_keytag_to_cdnskey(
+        #dns_rr{
+           name = Name,
+           type = ?DNS_TYPE_CDNSKEY,
+           data = #dns_rrdata_cdnskey{
+                     flags = erldns_config:keyget(<<"flags">>, Data),
+                     protocol = erldns_config:keyget(<<"protocol">>, Data),
+                     alg = erldns_config:keyget(<<"alg">>, Data),
+                     public_key = PublicKey
+                    },
+           ttl = Ttl})
+  catch
+    Exception:Reason ->
+      erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
+      {}
+  end;
+
 json_record_to_erlang(_Data) ->
-    {}.
+  {}.
 
 hex_to_bin(Bin) when is_binary(Bin) ->
-    Fun = fun(A, B) ->
-             case io_lib:fread("~16u", [A, B]) of
-                 {ok, [V], []} -> V;
-                 _ -> error(badarg)
-             end
-          end,
-    << <<(Fun(A, B))>> || <<A, B>> <= Bin >>.
+  Fun = fun(A, B) ->
+            case io_lib:fread("~16u", [A, B]) of
+              {ok, [V], []} -> V;
+              _ -> error(badarg)
+            end
+        end,
+  << <<(Fun(A,B))>> || <<A, B>> <= Bin >>.
 
 base64_to_bin(Bin) when is_binary(Bin) ->
-    base64:decode(Bin).
+  base64:decode(Bin).
 
 -ifdef(TEST).
-
 json_record_to_erlang_test() ->
-    erldns_events:start_link(),
-    ?assertEqual({}, json_record_to_erlang([])),
-    Name = <<"example.com">>,
-    ?assertEqual({}, json_record_to_erlang([Name, <<"SOA">>, 3600, null, null])).
+  erldns_events:start_link(),
+  ?assertEqual({}, json_record_to_erlang([])),
+  Name = <<"example.com">>,
+  ?assertEqual({}, json_record_to_erlang([Name, <<"SOA">>, 3600, null, null])).
 
 json_record_soa_to_erlang_test() ->
-    Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_SOA,
-                         data =
-                             #dns_rrdata_soa{mname = <<"ns1.example.com">>,
-                                             rname = <<"admin.example.com">>,
-                                             serial = 12345,
-                                             refresh = 555,
-                                             retry = 666,
-                                             expire = 777,
-                                             minimum = 888},
-                         ttl = 3600},
-                 json_record_to_erlang([Name,
-                                        <<"SOA">>,
-                                        3600,
-                                        [{<<"mname">>, <<"ns1.example.com">>},
-                                         {<<"rname">>, <<"admin.example.com">>},
-                                         {<<"serial">>, 12345},
-                                         {<<"refresh">>, 555},
-                                         {<<"retry">>, 666},
-                                         {<<"expire">>, 777},
-                                         {<<"minimum">>, 888}],
-                                        undefined])).
+  Name = <<"example.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_SOA,
+                       data = #dns_rrdata_soa{
+                                 mname = <<"ns1.example.com">>,
+                                 rname = <<"admin.example.com">>,
+                                 serial = 12345,
+                                 refresh = 555,
+                                 retry = 666,
+                                 expire = 777,
+                                 minimum = 888
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"SOA">>, 3600, [
+                                                              {<<"mname">>, <<"ns1.example.com">>},
+                                                              {<<"rname">>, <<"admin.example.com">>},
+                                                              {<<"serial">>, 12345},
+                                                              {<<"refresh">>, 555},
+                                                              {<<"retry">>, 666},
+                                                              {<<"expire">>, 777},
+                                                              {<<"minimum">>, 888}
+                                                             ], undefined])).
 
 json_record_ns_to_erlang_test() ->
-    Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_NS,
-                         data = #dns_rrdata_ns{dname = <<"ns1.example.com">>},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"NS">>, 3600, [{<<"dname">>, <<"ns1.example.com">>}], undefined])).
+  Name = <<"example.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_NS,
+                       data = #dns_rrdata_ns{
+                                 dname = <<"ns1.example.com">>
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"NS">>, 3600, [
+                                                             {<<"dname">>, <<"ns1.example.com">>}
+                                                            ], undefined])).
 
 json_record_a_to_erlang_test() ->
-    Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_A,
-                         data = #dns_rrdata_a{ip = {1, 2, 3, 4}},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"A">>, 3600, [{<<"ip">>, <<"1.2.3.4">>}], undefined])).
+  Name = <<"example.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_A,
+                       data = #dns_rrdata_a{
+                                 ip = {1,2,3,4}
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"A">>, 3600, [
+                                                            {<<"ip">>, <<"1.2.3.4">>}
+                                                           ], undefined])).
 
 json_record_aaaa_to_erlang_test() ->
-    Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_AAAA,
-                         data = #dns_rrdata_aaaa{ip = {0, 0, 0, 0, 0, 0, 0, 1}},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"AAAA">>, 3600, [{<<"ip">>, <<"::1">>}], undefined])).
+  Name = <<"example.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_AAAA,
+                       data = #dns_rrdata_aaaa{
+                                 ip = {0,0,0,0,0,0,0,1}
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"AAAA">>, 3600, [
+                                                               {<<"ip">>, <<"::1">>}
+                                                              ], undefined])).
 
 json_record_cds_to_erlang_test() ->
-    Name = <<"example-dnssec.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_CDS,
-                         data =
-                             #dns_rrdata_cds{keytag = 0,
-                                             digest_type = 2,
-                                             alg = 8,
-                                             digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)},
-                         ttl = 3600},
-                 json_record_to_erlang([Name,
-                                        <<"CDS">>,
-                                        3600,
-                                        [{<<"keytag">>, 0},
-                                         {<<"digest_type">>, 2},
-                                         {<<"alg">>, 8},
-                                         {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}],
-                                        undefined])).
+  Name = <<"example-dnssec.com">>,
+  ?assertEqual(#dns_rr{name = Name,
+                       type = ?DNS_TYPE_CDS,
+                       data = #dns_rrdata_cds{
+                                  keytag = 0,
+                                  digest_type = 2,
+                                  alg = 8,
+                                  digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)
+                                },
+                       ttl = 3600},
+               json_record_to_erlang([Name, <<"CDS">>, 3600, [
+                                                              {<<"keytag">>, 0},
+                                                              {<<"digest_type">>, 2},
+                                                              {<<"alg">>, 8},
+                                                              {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}
+                                                             ], undefined])).
 
 hex_to_bin_test() ->
-    ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
-    ?assertEqual(<<255, 0, 255>>, hex_to_bin(<<"FF00FF">>)).
+  ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
+  ?assertEqual(<<255, 0, 255>>, hex_to_bin(<<"FF00FF">>)).
 
 base64_to_bin_test() ->
-    ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
-    ?assertEqual(<<3, 1, 0, 1, 191, 165, 76, 56, 217, 9, 250, 187, 15, 147, 125, 112, 215, 117, 186, 13, 244, 192, 186, 219, 9, 112, 125, 153, 82, 73, 64,
-                   105, 80, 64, 122, 98, 28, 121, 76, 104, 177, 134, 177, 93, 191, 143, 159, 158, 162, 49, 233, 249, 100, 20, 204, 218, 78, 206, 181, 11, 23,
-                   169, 172, 108, 75, 212, 185, 93, 160, 72, 73, 233, 110, 231, 145, 87, 139, 112, 59, 201, 174, 24, 79, 177, 121, 75, 172, 121, 42, 7, 135,
-                   246, 147, 164, 15, 25, 245, 35, 238, 109, 189, 53, 153, 219, 170, 169, 165, 4, 55, 146, 110, 207, 100, 56, 132, 93, 29, 73, 68, 137, 98, 82,
-                   79, 42, 26, 122, 54, 179, 160, 161, 236, 163>>,
-                 base64_to_bin(<<"AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8mu"
-                                 "GE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj">>)).
-
+  ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
+  ?assertEqual(<<3,1,0,1,191,165,76,56,217,9,250,187,15,147,125,112,215,
+                 117,186,13,244,192,186,219,9,112,125,153,82,73,64,105,
+                 80,64,122,98,28,121,76,104,177,134,177,93,191,143,159,
+                 158,162,49,233,249,100,20,204,218,78,206,181,11,23,169,
+                 172,108,75,212,185,93,160,72,73,233,110,231,145,87,139,
+                 112,59,201,174,24,79,177,121,75,172,121,42,7,135,246,
+                 147,164,15,25,245,35,238,109,189,53,153,219,170,169,165,
+                 4,55,146,110,207,100,56,132,93,29,73,68,137,98,82,79,42,
+                 26,122,54,179,160,161,236,163>>, base64_to_bin(<<"AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8muGE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj">>)).
 -endif.

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/gen_nb_server.erl
+++ b/src/gen_nb_server.erl
@@ -26,36 +26,40 @@
 
 %% API
 -export([start_link/4]).
+
+
 %% gen_server callbacks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
 
--record(state, {cb, sock, server_state}).
+-record(state, {cb,
+                sock,
+                server_state}).
 
 -type state() :: term().
 
 -callback init(term()) -> {ok, State :: state()}.
 -callback handle_call(Request :: term(), From :: {pid(), Tag :: term()}, State :: state()) ->
-                         {reply, Reply :: term(), NewState :: state()} |
-                         {reply, Reply :: term(), NewState :: state(), timeout() | hibernate} |
-                         {noreply, NewState :: state()} |
-                         {noreply, NewState :: state(), timeout() | hibernate} |
-                         {stop, Reason :: term(), Reply :: term(), NewState :: state()} |
-                         {stop, Reason :: term(), NewState :: state()}.
+  {reply, Reply :: term(), NewState :: state()} |
+  {reply, Reply :: term(), NewState :: state(), timeout() | hibernate} |
+  {noreply, NewState :: state()} |
+  {noreply, NewState :: state(), timeout() | hibernate} |
+  {stop, Reason :: term(), Reply :: term(), NewState :: state()} |
+  {stop, Reason :: term(), NewState :: state()}.
 -callback handle_cast(Request :: term(), State :: state()) ->
-                         {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: term()}.
+  {noreply, NewState :: state()} |
+  {noreply, NewState :: state(), timeout() | hibernate} |
+  {stop, Reason :: term(), NewState :: term()}.
 -callback handle_info(Info :: timeout | term(), State :: state()) ->
-                         {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: state()}.
--callback terminate(Reason :: normal | shutdown | {shutdown, term()} | term(), State :: state()) -> term().
+  {noreply, NewState :: state()} |
+  {noreply, NewState :: state(), timeout() | hibernate} |
+  {stop, Reason :: term(), NewState :: state()}.
+-callback terminate(Reason :: (normal | shutdown | {shutdown, term()} | term()), State :: state()) -> term().
 -callback sock_opts() -> [gen_tcp:listen_option()].
 -callback new_connection(Socket :: gen_tcp:socket(), State :: state()) ->
-                            {ok, NewServerState :: state()} | {stop, Reason :: term(), NewServerState :: state()}.
+  {ok, NewServerState :: state()} | {stop, Reason :: term(), NewServerState :: state()}.
 
 -export_type([state/0]).
 
@@ -67,87 +71,82 @@
 %% Result = {ok, pid()} | {error, any()}
 %% @doc Start server listening on IpAddr:Port
 start_link(CallbackModule, IpAddr, Port, InitParams) ->
-    gen_server:start_link(?MODULE, [CallbackModule, IpAddr, Port, InitParams], []).
+  gen_server:start_link(?MODULE, [CallbackModule, IpAddr, Port, InitParams], []).
 
 %% @hidden
 init([CallbackModule, IpAddr, Port, InitParams]) ->
-    case CallbackModule:init(InitParams) of
-        {ok, ServerState} ->
-            case listen_on(CallbackModule, IpAddr, Port) of
-                {ok, Sock} ->
-                    process_flag(trap_exit, true),
-                    {ok,
-                     #state{cb = CallbackModule,
-                            sock = Sock,
-                            server_state = ServerState}};
-                Error ->
-                    CallbackModule:terminate(Error, ServerState),
-                    Error
-            end;
-        Err ->
-            Err
-    end.
+  case CallbackModule:init(InitParams) of
+    {ok, ServerState} ->
+      case listen_on(CallbackModule, IpAddr, Port) of
+        {ok, Sock} ->
+          process_flag(trap_exit, true),
+          {ok, #state{cb=CallbackModule, sock=Sock, server_state=ServerState}};
+        Error ->
+          CallbackModule:terminate(Error, ServerState),
+          Error
+      end;
+    Err ->
+      Err
+  end.
 
 %% @hidden
-handle_call(Request, From, #state{cb = Callback, server_state = ServerState} = State) ->
-    case Callback:handle_call(Request, From, ServerState) of
-        {reply, Reply, NewServerState} ->
-            {reply, Reply, State#state{server_state = NewServerState}};
-        {reply, Reply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
-            {reply, Reply, State#state{server_state = NewServerState}, Arg};
-        {noreply, NewServerState} ->
-            {noreply, State#state{server_state = NewServerState}};
-        {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
-            {noreply, State#state{server_state = NewServerState}, Arg};
-        {stop, Reason, NewServerState} ->
-            {stop, Reason, State#state{server_state = NewServerState}};
-        {stop, Reason, Reply, NewServerState} ->
-            {stop, Reason, Reply, State#state{server_state = NewServerState}}
-    end.
+handle_call(Request, From, #state{cb=Callback, server_state=ServerState}=State) ->
+  case Callback:handle_call(Request, From, ServerState) of
+    {reply, Reply, NewServerState} ->
+      {reply, Reply, State#state{server_state=NewServerState}};
+    {reply, Reply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
+      {reply, Reply, State#state{server_state=NewServerState}, Arg};
+    {noreply, NewServerState} ->
+      {noreply, State#state{server_state=NewServerState}};
+    {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
+      {noreply, State#state{server_state=NewServerState}, Arg};
+    {stop, Reason, NewServerState} ->
+      {stop, Reason, State#state{server_state=NewServerState}};
+    {stop, Reason, Reply, NewServerState} ->
+      {stop, Reason, Reply, State#state{server_state=NewServerState}}
+  end.
 
 %% @hidden
-handle_cast(Msg, #state{cb = Callback, server_state = ServerState} = State) ->
-    case Callback:handle_cast(Msg, ServerState) of
-        {noreply, NewServerState} ->
-            {noreply, State#state{server_state = NewServerState}};
-        {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
-            {noreply, State#state{server_state = NewServerState}, Arg};
-        {stop, Reason, NewServerState} ->
-            {stop, Reason, State#state{server_state = NewServerState}}
-    end.
+handle_cast(Msg, #state{cb=Callback, server_state=ServerState}=State) ->
+  case Callback:handle_cast(Msg, ServerState) of
+    {noreply, NewServerState} ->
+      {noreply, State#state{server_state=NewServerState}};
+    {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
+      {noreply, State#state{server_state=NewServerState}, Arg};
+    {stop, Reason, NewServerState} ->
+      {stop, Reason, State#state{server_state=NewServerState}}
+  end.
 
 %% @hidden
-handle_info({inet_async, ListSock, _Ref, {ok, CliSocket}}, #state{cb = Callback, server_state = ServerState} = State) ->
-    inet_db:register_socket(CliSocket, inet_tcp),
-    case Callback:new_connection(CliSocket, ServerState) of
-        {ok, NewServerState} ->
-            prim_inet:async_accept(ListSock, -1),
-            {noreply, State#state{server_state = NewServerState}};
-        {stop, Reason, NewServerState} ->
-            {stop, Reason, State#state{server_state = NewServerState}}
-    end;
-handle_info(Info, #state{cb = Callback, server_state = ServerState} = State) ->
-    case Callback:handle_info(Info, ServerState) of
-        {noreply, NewServerState} ->
-            {noreply, State#state{server_state = NewServerState}};
-        {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
-            {noreply, State#state{server_state = NewServerState}, Arg};
-        {stop, Reason, NewServerState} ->
-            {stop, Reason, State#state{server_state = NewServerState}}
-    end.
+handle_info({inet_async, ListSock, _Ref, {ok, CliSocket}}, #state{cb=Callback, server_state=ServerState}=State) ->
+  inet_db:register_socket(CliSocket, inet_tcp),
+  case Callback:new_connection(CliSocket, ServerState) of
+    {ok, NewServerState} ->
+      prim_inet:async_accept(ListSock, -1),
+      {noreply, State#state{server_state=NewServerState}};
+    {stop, Reason, NewServerState} ->
+      {stop, Reason, State#state{server_state=NewServerState}}
+  end;
+
+handle_info(Info, #state{cb=Callback, server_state=ServerState}=State) ->
+  case Callback:handle_info(Info, ServerState) of
+    {noreply, NewServerState} ->
+      {noreply, State#state{server_state=NewServerState}};
+    {noreply, NewServerState, Arg} when Arg =:= hibernate orelse is_number(Arg) ->
+      {noreply, State#state{server_state=NewServerState}, Arg};
+    {stop, Reason, NewServerState} ->
+      {stop, Reason, State#state{server_state=NewServerState}}
+  end.
 
 %% @hidden
-terminate(Reason,
-          #state{cb = Callback,
-                 sock = Sock,
-                 server_state = ServerState}) ->
-    gen_tcp:close(Sock),
-    Callback:terminate(Reason, ServerState),
-    ok.
+terminate(Reason, #state{cb=Callback, sock=Sock, server_state=ServerState}) ->
+  gen_tcp:close(Sock),
+  Callback:terminate(Reason, ServerState),
+  ok.
 
 %% @hidden
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% Internal functions
 
@@ -158,11 +157,11 @@ code_change(_OldVsn, State, _Extra) ->
 %% Port = integer()
 %% Result = {ok, port()} | {error, any()}
 listen_on(CallbackModule, IpAddr, Port) ->
-    SockOpts = [{ip, IpAddr} | CallbackModule:sock_opts()],
-    case gen_tcp:listen(Port, SockOpts) of
-        {ok, LSock} ->
-            {ok, _Ref} = prim_inet:async_accept(LSock, -1),
-            {ok, LSock};
-        Err ->
-            Err
-    end.
+  SockOpts = [{ip, IpAddr}|CallbackModule:sock_opts()],
+  case gen_tcp:listen(Port, SockOpts) of
+    {ok, LSock} ->
+      {ok, _Ref} = prim_inet:async_accept(LSock, -1),
+      {ok, LSock};
+    Err ->
+      Err
+  end.

--- a/src/print_delegate.erl
+++ b/src/print_delegate.erl
@@ -1,6 +1,0 @@
--module(print_delegate).
--behaviour(erldns_resolver).
--export([get_records_by_name/1]).
-get_records_by_name(Qname) ->
-  io:format("get_records_by_name(~p).~n", [Qname]),
-  [].

--- a/src/sample_custom_handler.erl
+++ b/src/sample_custom_handler.erl
@@ -16,14 +16,21 @@
 -module(sample_custom_handler).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -behavior(gen_server).
 
--export([start_link/0, handle/4, filter/1]).
-
+-export([start_link/0,
+         handle/4,
+         filter/1]).
 % Gen server hooks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
 
 -define(DNS_SAMPLE_TYPE, 20001).
 
@@ -32,54 +39,55 @@
 %% API
 
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 handle(Qname, Qtype, Records, _Message) ->
-  gen_server:call(?MODULE, {handle, Qname, Qtype, Records}).
+    gen_server:call(?MODULE, {handle, Qname, Qtype, Records}).
 
 filter(Records) ->
-  gen_server:call(?MODULE, {filter, Records}).
+    gen_server:call(?MODULE, {filter, Records}).
 
 %% Gen server hooks
 init([]) ->
-  erldns_handler:register_handler([?DNS_TYPE_A], ?MODULE, 2),
-  {ok, #state{}}.
+    erldns_handler:register_handler([?DNS_TYPE_A], ?MODULE, 2),
+    {ok, #state{}}.
 
 handle_call({handle, _Qname, _Qtype, Records}, _From, State) ->
-  SampleRecords = lists:filter(type_match(), Records),
-  NewRecords = lists:flatten(lists:map(convert(), SampleRecords)),
-  {reply, NewRecords, State};
-
+    SampleRecords = lists:filter(type_match(), Records),
+    NewRecords = lists:flatten(lists:map(convert(), SampleRecords)),
+    {reply, NewRecords, State};
 handle_call({filter, Records}, _From, State) ->
-  TypeMatchFunction = type_match(),
-  ConvertFunction = convert(),
-  NewRecords = lists:flatten(lists:map(
-                               fun(R) ->
+    TypeMatchFunction = type_match(),
+    ConvertFunction = convert(),
+    NewRecords =
+        lists:flatten(lists:map(fun(R) ->
                                    case TypeMatchFunction(R) of
-                                     true -> ConvertFunction(R);
-                                     false -> R
+                                       true -> ConvertFunction(R);
+                                       false -> R
                                    end
-                               end, Records)),
-  {reply, NewRecords, State}.
+                                end,
+                                Records)),
+    {reply, NewRecords, State}.
 
 handle_cast(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 handle_info(_Message, State) ->
-  {noreply, State}.
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 %% Internal functions
 
-type_match() -> fun(Record) -> Record#dns_rr.type =:= ?DNS_SAMPLE_TYPE end.
+type_match() ->
+    fun(Record) -> Record#dns_rr.type =:= ?DNS_SAMPLE_TYPE end.
 
-convert() -> 
-  fun(Record) ->
-      {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
-      Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip=Address}}
-  end.
+convert() ->
+    fun(Record) ->
+       {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
+       Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}}
+    end.

--- a/src/sample_custom_handler.erl
+++ b/src/sample_custom_handler.erl
@@ -16,21 +16,14 @@
 -module(sample_custom_handler).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -behavior(gen_server).
 
--export([start_link/0,
-         handle/4,
-         filter/1]).
+-export([start_link/0, handle/4, filter/1]).
+
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -define(DNS_SAMPLE_TYPE, 20001).
 
@@ -39,55 +32,54 @@
 %% API
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 handle(Qname, Qtype, Records, _Message) ->
-    gen_server:call(?MODULE, {handle, Qname, Qtype, Records}).
+  gen_server:call(?MODULE, {handle, Qname, Qtype, Records}).
 
 filter(Records) ->
-    gen_server:call(?MODULE, {filter, Records}).
+  gen_server:call(?MODULE, {filter, Records}).
 
 %% Gen server hooks
 init([]) ->
-    erldns_handler:register_handler([?DNS_TYPE_A], ?MODULE, 2),
-    {ok, #state{}}.
+  erldns_handler:register_handler([?DNS_TYPE_A], ?MODULE, 2),
+  {ok, #state{}}.
 
 handle_call({handle, _Qname, _Qtype, Records}, _From, State) ->
-    SampleRecords = lists:filter(type_match(), Records),
-    NewRecords = lists:flatten(lists:map(convert(), SampleRecords)),
-    {reply, NewRecords, State};
+  SampleRecords = lists:filter(type_match(), Records),
+  NewRecords = lists:flatten(lists:map(convert(), SampleRecords)),
+  {reply, NewRecords, State};
+
 handle_call({filter, Records}, _From, State) ->
-    TypeMatchFunction = type_match(),
-    ConvertFunction = convert(),
-    NewRecords =
-        lists:flatten(lists:map(fun(R) ->
+  TypeMatchFunction = type_match(),
+  ConvertFunction = convert(),
+  NewRecords = lists:flatten(lists:map(
+                               fun(R) ->
                                    case TypeMatchFunction(R) of
-                                       true -> ConvertFunction(R);
-                                       false -> R
+                                     true -> ConvertFunction(R);
+                                     false -> R
                                    end
-                                end,
-                                Records)),
-    {reply, NewRecords, State}.
+                               end, Records)),
+  {reply, NewRecords, State}.
 
 handle_cast(_Message, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 handle_info(_Message, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok.
+  ok.
 
 code_change(_PreviousVersion, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %% Internal functions
 
-type_match() ->
-    fun(Record) -> Record#dns_rr.type =:= ?DNS_SAMPLE_TYPE end.
+type_match() -> fun(Record) -> Record#dns_rr.type =:= ?DNS_SAMPLE_TYPE end.
 
-convert() ->
-    fun(Record) ->
-       {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
-       Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}}
-    end.
+convert() -> 
+  fun(Record) ->
+      {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
+      Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip=Address}}
+  end.

--- a/src/sample_custom_handler.erl
+++ b/src/sample_custom_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/sample_custom_zone_encoder.erl
+++ b/src/sample_custom_zone_encoder.erl
@@ -16,6 +16,7 @@
 -module(sample_custom_zone_encoder).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([encode_record/1]).
@@ -23,13 +24,11 @@
 -define(DNS_TYPE_SAMPLE, 40000).
 
 encode_record({dns_rr, Name, _, ?DNS_TYPE_SAMPLE, Ttl, Data}) ->
-  lager:debug("Encoding SAMPLE record"),
-  [
-   {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-   {<<"type">>, <<"SAMPLE">>},
-   {<<"ttl">>, Ttl},
-   {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}
-  ];
+    lager:debug("Encoding SAMPLE record"),
+    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+     {<<"type">>, <<"SAMPLE">>},
+     {<<"ttl">>, Ttl},
+     {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}];
 encode_record(_) ->
-  lager:debug("Could not encode record"),
-  [].
+    lager:debug("Could not encode record"),
+    [].

--- a/src/sample_custom_zone_encoder.erl
+++ b/src/sample_custom_zone_encoder.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/sample_custom_zone_encoder.erl
+++ b/src/sample_custom_zone_encoder.erl
@@ -16,7 +16,6 @@
 -module(sample_custom_zone_encoder).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([encode_record/1]).
@@ -24,11 +23,13 @@
 -define(DNS_TYPE_SAMPLE, 40000).
 
 encode_record({dns_rr, Name, _, ?DNS_TYPE_SAMPLE, Ttl, Data}) ->
-    lager:debug("Encoding SAMPLE record"),
-    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-     {<<"type">>, <<"SAMPLE">>},
-     {<<"ttl">>, Ttl},
-     {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}];
+  lager:debug("Encoding SAMPLE record"),
+  [
+   {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+   {<<"type">>, <<"SAMPLE">>},
+   {<<"ttl">>, Ttl},
+   {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}
+  ];
 encode_record(_) ->
-    lager:debug("Could not encode record"),
-    [].
+  lager:debug("Could not encode record"),
+  [].

--- a/src/sample_custom_zone_parser.erl
+++ b/src/sample_custom_zone_parser.erl
@@ -16,6 +16,7 @@
 -module(sample_custom_zone_parser).
 
 -include_lib("dns_erlang/include/dns.hrl").
+
 -include("erldns.hrl").
 
 -export([json_record_to_erlang/1]).
@@ -23,6 +24,9 @@
 -define(DNS_TYPE_SAMPLE, 40000).
 
 json_record_to_erlang([Name, <<"SAMPLE">>, Ttl, Data, _Context]) ->
-  #dns_rr{name = Name, type = ?DNS_TYPE_SAMPLE, data = erldns_config:keyget(<<"dname">>, Data), ttl = Ttl};
-
-json_record_to_erlang(_) -> {}.
+    #dns_rr{name = Name,
+            type = ?DNS_TYPE_SAMPLE,
+            data = erldns_config:keyget(<<"dname">>, Data),
+            ttl = Ttl};
+json_record_to_erlang(_) ->
+    {}.

--- a/src/sample_custom_zone_parser.erl
+++ b/src/sample_custom_zone_parser.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2018, DNSimple Corporation
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/sample_custom_zone_parser.erl
+++ b/src/sample_custom_zone_parser.erl
@@ -16,7 +16,6 @@
 -module(sample_custom_zone_parser).
 
 -include_lib("dns_erlang/include/dns.hrl").
-
 -include("erldns.hrl").
 
 -export([json_record_to_erlang/1]).
@@ -24,9 +23,6 @@
 -define(DNS_TYPE_SAMPLE, 40000).
 
 json_record_to_erlang([Name, <<"SAMPLE">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SAMPLE,
-            data = erldns_config:keyget(<<"dname">>, Data),
-            ttl = Ttl};
-json_record_to_erlang(_) ->
-    {}.
+  #dns_rr{name = Name, type = ?DNS_TYPE_SAMPLE, data = erldns_config:keyget(<<"dname">>, Data), ttl = Ttl};
+
+json_record_to_erlang(_) -> {}.

--- a/src/t.erl
+++ b/src/t.erl
@@ -1,8 +1,8 @@
 -module(t).
 
--export([t/2] ).
+-export([t/2]).
 
 t(N, F) ->
-  {T, V} = timer:tc(F),
-  lager:info("~s: ~p", [N, T / 1000]),
-  V.
+    {T, V} = timer:tc(F),
+    lager:info("~s: ~p", [N, T / 1000]),
+    V.

--- a/src/t.erl
+++ b/src/t.erl
@@ -1,8 +1,8 @@
 -module(t).
 
--export([t/2]).
+-export([t/2] ).
 
 t(N, F) ->
-    {T, V} = timer:tc(F),
-    lager:info("~s: ~p", [N, T / 1000]),
-    V.
+  {T, V} = timer:tc(F),
+  lager:info("~s: ~p", [N, T / 1000]),
+  V.


### PR DESCRIPTION
This is a clean up of the erldns codebase, especially the zone cache and the resolving logic.

## Backwards incompatible changes:

- Removes zone delegates

## Enhancements

- Add additional typespecs
- Reduce number of functions in resolver for better clarity in behavior
- Start erldns_server_sup under the erldns_sup supervisor, fixes #35 

## Bug Fixes

- Fix RRSIG management when processing RRSet DELETE messages.