### PR TITLE
Optimise delegation lookup ETS queries and drop named index on zone update

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,7 @@
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 
-{relx, [{release, {erldns, "2.1.1"},
+{relx, [{release, {erldns, "2.2.0"},
          [erldns]},
 
         {dev_mode, true},

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,7 @@
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 
-{relx, [{release, {erldns, "1.0.1"},
+{relx, [{release, {erldns, "2.1.1"},
          [erldns]},
 
         {dev_mode, true},

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,7 @@
 {shell, [{apps, [erldns]},
          {config, "erldns.config"}]}.
 
-{relx, [{release, {erldns, "1.0.0"},
+{relx, [{release, {erldns, "1.0.1"},
          [erldns]},
 
         {dev_mode, true},

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -393,8 +393,7 @@ update_zone_records_and_digest(ZoneName, Records, Digest) ->
             UpdatedZone =
                 Zone#zone{version = Digest,
                           authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
-                          record_count = length(Records),
-                          records_by_name = build_named_index(Records)},
+                          record_count = length(Records)},
             put_zone(Zone#zone.name, UpdatedZone);
         _ ->
             {error, zone_not_found}

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -157,7 +157,7 @@ get_delegations(Name) ->
         {ok, Zone} ->
             Records =
                 lists:flatten(erldns_storage:select(zone_records_typed,
-                                                    [{{{erldns:normalize_name(Zone#zone.name), '_', ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
+                                                    [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
                                                     infinite)),
             lists:filter(erldns_records:match_delegation(Name), Records);
         _ ->


### PR DESCRIPTION
The PR introduces optimizations for large zones:

1. Optimise delegation lookup ETS queries by dropping wildcard in the matchspec for `get_delegated/1` function.
2. Drop named index on zone update via RRSet.