### PR TITLE
erldns_udp_server: Fix flow control

### DIFF
--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -93,11 +93,12 @@ handle_cast(_Message, State) ->
 
 handle_info(timeout, State) ->
     {noreply, State};
+handle_info({udp_passive, _Socket}, State) ->
+    inet:setopts(State#state.socket, [{active, 100}]),
+    {noreply, State};
 handle_info({udp, Socket, Host, Port, Bin}, State) ->
     % lager:debug("Received request: ~p", [Bin]),
-    Response = folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]),
-    inet:setopts(State#state.socket, [{active, 100}]),
-    Response;
+    folsom_metrics:histogram_timed_update(udp_handoff_histogram, ?MODULE, handle_request, [Socket, Host, Port, Bin, State]);
 handle_info(_Message, State) ->
     {noreply, State}.
 


### PR DESCRIPTION
Reset the `{active, N}` socket option only when receiving an `udp_passive` message, rather than on every received packet, which provides no flow control and therefore no advantage over `{active, true}` mode.  (BTW, resetting `{active, N}` actually _adds_ `N` to the current count, so adding `100` on every packet could in theory overflow the counter at some point.)