### PR TITLE
rebar: Use https:// instead of git:// for github deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         recon,
         folsom,
         {jsx, "3.0.0"},
-        {dns_erlang, ".*", {git, "git://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
+        {dns_erlang, ".*", {git, "https://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
         iso8601,
         {nodefinder, "2.0.0"},
         {opentelemetry_api, "0.6.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
  {<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},1},
  {<<"dns_erlang">>,
-  {git,"git://github.com/dnsimple/dns_erlang.git",
+  {git,"https://github.com/dnsimple/dns_erlang.git",
        {ref,"52f7279afb4cc97b4d76babde223257ec08f3676"}},
   0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.8">>},0},


### PR DESCRIPTION
Github has discontinuted the git:// protocol in favor of only providing https for anonymous clones.

```
$ DEBUG=1 rebar3 get-deps
...
===> Fetching dns_erlang (from {git,"git://github.com/dnsimple/dns_erlang.git",
                      {ref,"52f7279afb4cc97b4d76babde223257ec08f3676"}})
===> sh(git clone  -n git://github.com/dnsimple/dns_erlang.git .tmp_dir967982599246)
failed with return code 128 and the following output:
Cloning into '.tmp_dir967982599246'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

===> Failed to fetch and copy dep: {git,
                                  "git://github.com/dnsimple/dns_erlang.git",
                                  {ref,
                                      "52f7279afb4cc97b4d76babde223257ec08f3676"}}
```

Reference: https://github.blog/2021-09-01-improving-git-protocol-security-github/