### PR TITLE
Update deps to new accepted uri

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         recon,
         folsom,
         {jsx, "3.0.0"},
-        {dns_erlang, ".*", {git, "git@github.com:dnsimple/dns_erlang.git", {branch, "main"}}},
+        {dns_erlang, ".*", {git, "https://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
         iso8601,
         {nodefinder, "2.0.0"},
         {opentelemetry_api, "0.6.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         recon,
         folsom,
         {jsx, "3.0.0"},
-        {dns_erlang, ".*", {git, "git://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
+        {dns_erlang, ".*", {git, "git@github.com:dnsimple/dns_erlang.git", {branch, "main"}}},
         iso8601,
         {nodefinder, "2.0.0"},
         {opentelemetry_api, "0.6.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
  {<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},1},
  {<<"dns_erlang">>,
-  {git,"git://github.com/dnsimple/dns_erlang.git",
+  {git,"git@github.com:dnsimple/dns_erlang.git",
        {ref,"52f7279afb4cc97b4d76babde223257ec08f3676"}},
   0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.8">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
  {<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},1},
  {<<"dns_erlang">>,
-  {git,"git@github.com:dnsimple/dns_erlang.git",
+  {git,"https://github.com/dnsimple/dns_erlang.git",
        {ref,"52f7279afb4cc97b4d76babde223257ec08f3676"}},
   0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.8">>},0},


### PR DESCRIPTION
GitHub has strengthened its security requirements by deprecating unencrypted `git://` protocol and certain keys that are also no longer supported for more information you can read their [announcement](https://github.blog/2021-09-01-improving-git-protocol-security-github/).