### PR TITLE
Adopt Erlfmt

### DIFF
--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -1,26 +1,28 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--record(keyset,
-        {key_signing_key :: crypto:rsa_private(),
-         key_signing_key_tag :: non_neg_integer(),
-         key_signing_alg :: non_neg_integer(),
-         zone_signing_key :: crypto:rsa_private(),
-         zone_signing_key_tag :: non_neg_integer(),
-         zone_signing_alg :: non_neg_integer(),
-         inception :: erlang:timestamp() | calendar:datetime1970(),
-         valid_until :: erlang:timestamp() | calendar:datetime1970()}).
--record(zone,
-        {name :: dns:dname(),
-         version :: binary(),
-         authority = [] :: [dns:rr()],
-         record_count = 0 :: non_neg_integer(),
-         records = [] :: [dns:rr()] | trimmed,
-         %% records_by_name is deprecated
-         records_by_name :: #{binary() => [dns:rr()]} | trimmed,
-         %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
-         %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
-         records_by_type :: term(),
-         keysets :: [erldns:keyset()]}).
+-record(keyset, {
+    key_signing_key :: crypto:rsa_private(),
+    key_signing_key_tag :: non_neg_integer(),
+    key_signing_alg :: non_neg_integer(),
+    zone_signing_key :: crypto:rsa_private(),
+    zone_signing_key_tag :: non_neg_integer(),
+    zone_signing_alg :: non_neg_integer(),
+    inception :: erlang:timestamp() | calendar:datetime1970(),
+    valid_until :: erlang:timestamp() | calendar:datetime1970()
+}).
+-record(zone, {
+    name :: dns:dname(),
+    version :: binary(),
+    authority = [] :: [dns:rr()],
+    record_count = 0 :: non_neg_integer(),
+    records = [] :: [dns:rr()] | trimmed,
+    %% records_by_name is deprecated
+    records_by_name :: #{binary() => [dns:rr()]} | trimmed,
+    %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
+    %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
+    records_by_type :: term(),
+    keysets :: [erldns:keyset()]
+}).
 -record(authorities, {owner_name, ttl, class, name_server, email_addr, serial_num, refresh, retry, expiry, nxdomain}).
 -record(zone_records, {zone_name, fqdn, records}).
 -record(zone_records_typed, {zone_name, fqdn, type, records}).

--- a/rebar.config
+++ b/rebar.config
@@ -1,22 +1,26 @@
 %%-*- mode: erlang -*-
 {cover_enabled, true}.
-{erl_opts, [debug_info, fail_on_warning,
-            {platform_define, "^[0-9]+", namespaced_types},
-            {parse_transform, lager_transform}]}.
+{erl_opts, [
+    debug_info,
+    fail_on_warning,
+    {platform_define, "^[0-9]+", namespaced_types},
+    {parse_transform, lager_transform}
+]}.
 
 {project_plugins, [
     erlfmt
 ]}.
 
-{deps, [{lager, "3.9.2"},
-        recon,
-        folsom,
-        {jsx, "3.0.0"},
-        {dns_erlang, ".*", {git, "https://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
-        iso8601,
-        {nodefinder, "2.0.0"},
-        {opentelemetry_api, "0.6.0"},
-        {meck, "0.9.2"}
+{deps, [
+    {lager, "3.9.2"},
+    recon,
+    folsom,
+    {jsx, "3.0.0"},
+    {dns_erlang, ".*", {git, "https://github.com/dnsimple/dns_erlang.git", {branch, "main"}}},
+    iso8601,
+    {nodefinder, "2.0.0"},
+    {opentelemetry_api, "0.6.0"},
+    {meck, "0.9.2"}
 ]}.
 
 {profiles, [{test, [{deps, [proper]}]}]}.
@@ -24,49 +28,52 @@
 {project_plugins, [rebar3_format]}.
 
 {format, [
-          {formatter, default_formatter},
-          {files, [
-                   "src/**/*.?rl", "include/**/*.?rl"
-                  ]},
-          {options, #{
-             paper => 160,
-             ribbon => 150,
-             inline_attributes => none,
-             inline_qualified_function_composition => true}
-          }]
-}.
+    {formatter, default_formatter},
+    {files, [
+        "src/**/*.?rl", "include/**/*.?rl"
+    ]},
+    {options, #{
+        paper => 160,
+        ribbon => 150,
+        inline_attributes => none,
+        inline_qualified_function_composition => true
+    }}
+]}.
 
-{shell, [{apps, [erldns]},
-         {config, "erldns.config"}]}.
+{shell, [
+    {apps, [erldns]},
+    {config, "erldns.config"}
+]}.
 
-{relx, [{release, {erldns, "3.0.0"},
-         [erldns]},
+{relx, [
+    {release, {erldns, "3.0.0"}, [erldns]},
 
-        {dev_mode, true},
-        {include_erts, false},
-        {sys_config, "erldns.config"},
-        {overlay, [{copy, "priv/zones-example.json", "priv/zones-example.json"},
-                   {copy, "priv/zones-test.json", "priv/zones-test.json"}]},
+    {dev_mode, true},
+    {include_erts, false},
+    {sys_config, "erldns.config"},
+    {overlay, [
+        {copy, "priv/zones-example.json", "priv/zones-example.json"},
+        {copy, "priv/zones-test.json", "priv/zones-test.json"}
+    ]},
 
-        {extended_start_script, true}]}.
+    {extended_start_script, true}
+]}.
 
 %% This is a rebar3-ism
 {overrides, [
-    {override, dns_erlang,
-        [
-            {plugins,[
-                {provider_asn1, "0.2.3"}
+    {override, dns_erlang, [
+        {plugins, [
+            {provider_asn1, "0.2.3"}
+        ]},
+        {provider_hooks, [
+            {pre, [
+                {compile, {asn, compile}}
             ]},
-            {provider_hooks, [
-                {pre, [
-                    {compile, {asn, compile}}
-                ]},
-                {post, [
-                    {clean, {asn, clean}}
-                ]}
+            {post, [
+                {clean, {asn, clean}}
             ]}
-        ]
-    }
+        ]}
+    ]}
 ]}.
 
 {dialyzer, [{warnings, [no_unknown]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,12 @@
 %%-*- mode: erlang -*-
 {cover_enabled, true}.
-
 {erl_opts, [debug_info, fail_on_warning,
             {platform_define, "^[0-9]+", namespaced_types},
             {parse_transform, lager_transform}]}.
+
+{project_plugins, [
+    erlfmt
+]}.
 
 {deps, [{lager, "3.9.2"},
         recon,
@@ -67,3 +70,8 @@
 ]}.
 
 {dialyzer, [{warnings, [no_unknown]}]}.
+
+{erlfmt, [
+    write,
+    {print_width, 140}
+]}.

--- a/src/erldns.app.src
+++ b/src/erldns.app.src
@@ -1,25 +1,27 @@
 % -*- mode: Erlang; -*-
-{application, erldns,
- [{description, "Erlang Authoritative DNS Server"},
-  {vsn, "3.0.0"},
-  {licenses, ["MIT"]},
-  {mod, { erldns_app, []}},
-  {applications, [kernel,
-                  stdlib,
-                  inets,
-                  crypto,
-                  lager,
-                  dns_erlang,
-                  jsx,
-                  ssl,
-                  mnesia,
-                  bear,
-                  folsom,
-                  iso8601,
-                  opentelemetry_api,
-                  nodefinder]},
-  {start_phases, [{post_start, []}]},
+{application, erldns, [
+    {description, "Erlang Authoritative DNS Server"},
+    {vsn, "3.0.0"},
+    {licenses, ["MIT"]},
+    {mod, {erldns_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        inets,
+        crypto,
+        lager,
+        dns_erlang,
+        jsx,
+        ssl,
+        mnesia,
+        bear,
+        folsom,
+        iso8601,
+        opentelemetry_api,
+        nodefinder
+    ]},
+    {start_phases, [{post_start, []}]},
 
-  {licenses, ["Apache-2.0"]},
-  {links, [{"GitHub", "https://github.com/dnsimple/erldns"}]}
-  ]}.
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/dnsimple/erldns"}]}
+]}.

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -20,8 +20,10 @@
 -export([start/0]).
 -export([normalize_name/1]).
 
--export_type([keyset/0,
-              zone/0]).
+-export_type([
+    keyset/0,
+    zone/0
+]).
 
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -18,9 +18,11 @@
 -behavior(application).
 
 % Application hooks
--export([start/2,
-         start_phase/3,
-         stop/1]).
+-export([
+    start/2,
+    start_phase/3,
+    stop/1
+]).
 
 start(_Type, _Args) ->
     lager:info("Starting erldns application"),

--- a/src/erldns_axfr.erl
+++ b/src/erldns_axfr.erl
@@ -17,18 +17,22 @@
 
 -include_lib("dns_erlang/include/dns.hrl").
 
--export([is_enabled/2,
-         optionally_append_soa/1]).
+-export([
+    is_enabled/2,
+    optionally_append_soa/1
+]).
 
 %% Determine if AXFR is enabled for the given request host.
 is_enabled(Host, Metadata) ->
     MatchingMetadata =
-        lists:filter(fun(MetadataRow) ->
-                        [_Id, _DomainId, Kind, Content] = MetadataRow,
-                        {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
-                        AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
-                     end,
-                     Metadata),
+        lists:filter(
+            fun(MetadataRow) ->
+                [_Id, _DomainId, Kind, Content] = MetadataRow,
+                {ok, AllowedAddress} = inet_parse:address(binary_to_list(Content)),
+                AllowedAddress =:= Host andalso Kind =:= <<"axfr">>
+            end,
+            Metadata
+        ),
     length(MatchingMetadata) > 0.
 
 %% If the message is an AXFR request then append the SOA record.

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -15,37 +15,51 @@
 %% @doc Provide application-wide configuration access.
 -module(erldns_config).
 
--export([get_servers/0,
-         get_address/1,
-         get_port/0,
-         get_num_workers/0]).
+-export([
+    get_servers/0,
+    get_address/1,
+    get_port/0,
+    get_num_workers/0
+]).
 -export([use_root_hints/0]).
--export([packet_cache_enabled/0,
-         packet_cache_default_ttl/0,
-         packet_cache_sweep_interval/0,
-         packet_cache_ttl_overrides/0]).
--export([zone_server_env/0,
-         zone_server_max_processes/0,
-         zone_server_protocol/0,
-         zone_server_host/0,
-         zone_server_port/0]).
--export([websocket_env/0,
-         websocket_protocol/0,
-         websocket_host/0,
-         websocket_port/0,
-         websocket_path/0,
-         websocket_url/0]).
--export([storage_env/0,
-         storage_type/0,
-         storage_user/0,
-         storage_pass/0,
-         storage_host/0,
-         storage_port/0,
-         storage_dir/0]).
--export([keyget/2,
-         keyget/3]).
--export([ingress_udp_request_timeout/0,
-         ingress_tcp_request_timeout/0]).
+-export([
+    packet_cache_enabled/0,
+    packet_cache_default_ttl/0,
+    packet_cache_sweep_interval/0,
+    packet_cache_ttl_overrides/0
+]).
+-export([
+    zone_server_env/0,
+    zone_server_max_processes/0,
+    zone_server_protocol/0,
+    zone_server_host/0,
+    zone_server_port/0
+]).
+-export([
+    websocket_env/0,
+    websocket_protocol/0,
+    websocket_host/0,
+    websocket_port/0,
+    websocket_path/0,
+    websocket_url/0
+]).
+-export([
+    storage_env/0,
+    storage_type/0,
+    storage_user/0,
+    storage_pass/0,
+    storage_host/0,
+    storage_port/0,
+    storage_dir/0
+]).
+-export([
+    keyget/2,
+    keyget/3
+]).
+-export([
+    ingress_udp_request_timeout/0,
+    ingress_tcp_request_timeout/0
+]).
 
 -ifdef(TEST).
 
@@ -58,7 +72,8 @@
 -define(DEFAULT_PORT, 53).
 -define(DEFAULT_NUM_WORKERS, 10).
 -define(DEFAULT_CACHE_TTL, 20).
--define(DEFAULT_SWEEP_INTERVAL, 1000 * 60 * 3). % Every 3 minutes
+% Every 3 minutes
+-define(DEFAULT_SWEEP_INTERVAL, 1000 * 60 * 3).
 -define(DEFAULT_ZONE_SERVER_PORT, 443).
 -define(DEFAULT_WEBSOCKET_PATH, "/ws").
 -define(DEFAULT_UDP_PROCESS_TIMEOUT, 500).
@@ -67,24 +82,34 @@
 get_servers() ->
     case application:get_env(erldns, servers) of
         {ok, Servers} ->
-            lists:map(fun(Server) ->
-                         [{name, keyget(name, Server)},
-                          {address, parse_address(keyget(address, Server))},
-                          {port, keyget(port, Server)},
-                          {family, keyget(family, Server)},
-                          {processes, keyget(processes, Server, 1)}]
-                      end,
-                      Servers);
+            lists:map(
+                fun(Server) ->
+                    [
+                        {name, keyget(name, Server)},
+                        {address, parse_address(keyget(address, Server))},
+                        {port, keyget(port, Server)},
+                        {family, keyget(family, Server)},
+                        {processes, keyget(processes, Server, 1)}
+                    ]
+                end,
+                Servers
+            );
         undefined ->
-            lists:map(fun(Family) -> [{name, Family}, {address, get_address(Family)}, {port, get_port()}, {family, Family}] end, [inet, inet6])
+            lists:map(fun(Family) -> [{name, Family}, {address, get_address(Family)}, {port, get_port()}, {family, Family}] end, [
+                inet, inet6
+            ])
     end.
 
 -ifdef(TEST).
 
 get_servers_undefined_test() ->
-    ?assertEqual([[{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
-                  [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]],
-                 get_servers()).
+    ?assertEqual(
+        [
+            [{name, inet}, {address, ?DEFAULT_IPV4_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet}],
+            [{name, inet6}, {address, ?DEFAULT_IPV6_ADDRESS}, {port, ?DEFAULT_PORT}, {family, inet6}]
+        ],
+        get_servers()
+    ).
 
 get_servers_empty_list_test() ->
     application:set_env(erldns, servers, []),
@@ -95,13 +120,21 @@ get_servers_single_server_test() ->
     ?assertEqual([[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}]], get_servers()).
 
 get_servers_multiple_servers_test() ->
-    application:set_env(erldns,
-                        servers,
-                        [[{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
-                         [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]]),
-    ?assertEqual([[{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
-                  [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]],
-                 get_servers()).
+    application:set_env(
+        erldns,
+        servers,
+        [
+            [{name, example_inet}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}],
+            [{name, example_inet6}, {address, "::1"}, {port, 8053}, {family, inet6}]
+        ]
+    ),
+    ?assertEqual(
+        [
+            [{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
+            [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]
+        ],
+        get_servers()
+    ).
 
 -endif.
 

--- a/src/erldns_encoder.erl
+++ b/src/erldns_encoder.erl
@@ -18,8 +18,10 @@
 
 -include_lib("dns_erlang/include/dns_records.hrl").
 
--export([encode_message/1,
-         encode_message/2]).
+-export([
+    encode_message/1,
+    encode_message/2
+]).
 
 %% @doc Encode the DNS message into its binary representation.
 %%
@@ -49,10 +51,10 @@ encode_message(Response) ->
 %% configuration, then this function should never throw an
 %% exception.
 -spec encode_message(dns:message(), [dns:encode_message_opt()]) ->
-                        {false, dns:message_bin()} |
-                        {true, dns:message_bin(), dns:message()} |
-                        {false, dns:message_bin(), dns:tsig_mac()} |
-                        {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
+    {false, dns:message_bin()}
+    | {true, dns:message_bin(), dns:message()}
+    | {false, dns:message_bin(), dns:tsig_mac()}
+    | {true, dns:message_bin(), dns:tsig_mac(), dns:message()}.
 encode_message(Response, Opts) ->
     case application:get_env(erldns, catch_exceptions) of
         {ok, false} ->
@@ -77,12 +79,14 @@ build_error_response({_, Response}) ->
     build_error_response(Response, ?DNS_RCODE_SERVFAIL).
 
 build_error_response(Response, Rcode) ->
-    Response#dns_message{anc = 0,
-                         auc = 0,
-                         adc = 0,
-                         qr = true,
-                         aa = true,
-                         rc = Rcode,
-                         answers = [],
-                         authority = [],
-                         additional = []}.
+    Response#dns_message{
+        anc = 0,
+        auc = 0,
+        adc = 0,
+        qr = true,
+        aa = true,
+        rc = Rcode,
+        answers = [],
+        authority = [],
+        additional = []
+    }.

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -17,12 +17,14 @@
 
 -behavior(gen_event).
 
--export([init/1,
-         handle_event/2,
-         handle_call/2,
-         handle_info/2,
-         code_change/3,
-         terminate/2]).
+-export([
+    init/1,
+    handle_event/2,
+    handle_call/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+]).
 
 -record(state, {servers_running = false}).
 
@@ -34,12 +36,16 @@ handle_event({_M, start_servers}, State) ->
         false ->
             % Start up the UDP and TCP servers
             lager:info("Starting the UDP and TCP supervisor"),
-            supervisor:start_child(erldns_sup,
-                                   #{id => erldns_sup,
-                                     start => {erldns_server_sup, start_link, []},
-                                     restart => permanent,
-                                     shutdown => 5000,
-                                     type => supervisor}),
+            supervisor:start_child(
+                erldns_sup,
+                #{
+                    id => erldns_sup,
+                    start => {erldns_server_sup, start_link, []},
+                    restart => permanent,
+                    shutdown => 5000,
+                    type => supervisor
+                }
+            ),
             erldns_events:notify({?MODULE, servers_started}),
             {ok, State#state{servers_running = true}};
         _ ->
@@ -91,8 +97,10 @@ handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Reason}}, St
     lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, reason: ~p)", [M, E, Name, Type, Data, Reason]),
     {ok, State};
 handle_event({M = erldns_zone_parser, E = error, {Name, Type, Data, Exception, Reason}}, State) ->
-    lager:error("Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)",
-                [M, E, Name, Type, Data, Exception, Reason]),
+    lager:error(
+        "Error parsing record (module: ~p, event: ~p, name: ~p, type: ~p, data: ~p, exception: ~p, reason: ~p)",
+        [M, E, Name, Type, Data, Exception, Reason]
+    ),
     {ok, State};
 handle_event({M = erldns_zone_parser, E = unsupported_record, Data}, State) ->
     lager:warning("Unsupported record (module: ~p, event: ~p, data: ~p)", [M, E, Data]),
@@ -101,11 +109,15 @@ handle_event({M = erldns_decoder, E = decode_message_error, {Exception, Reason, 
     lager:error("Error decoding message (module: ~p, event: ~p, data: ~p, exception: ~p, reason: ~p)", [M, E, Bin, Exception, Reason]),
     {ok, State};
 handle_event({M = eldns_encoder, E = encode_message_error, {Exception, Reason, Response}}, State) ->
-    lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [M, E, Response, Exception, Reason]),
+    lager:error("Error encoding message (module: ~p, event: ~p, response: ~p, exception: ~p, reason: ~p)", [
+        M, E, Response, Exception, Reason
+    ]),
     {ok, State};
 handle_event({M = erldns_encoder, E = encode_message_error, {Exception, Reason, Response, Opts}}, State) ->
-    lager:error("Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)",
-                [M, E, Response, Opts, Exception, Reason]),
+    lager:error(
+        "Error encoding with opts (module: ~p, event: ~p, response: ~p, opts: ~p, exception: ~p, reason: ~p)",
+        [M, E, Response, Opts, Exception, Reason]
+    ),
     {ok, State};
 handle_event({M = erldns_storage, E = failed_zones_load, Reason}, State) ->
     lager:error("Failed to load zones (module: ~p, event: ~p, reason: ~p)", [M, E, Reason]),

--- a/src/erldns_events.erl
+++ b/src/erldns_events.erl
@@ -15,10 +15,12 @@
 %% @doc Public API for erldns event handler registration and notification.
 -module(erldns_events).
 
--export([start_link/0,
-         notify/1,
-         add_handler/1,
-         add_handler/2]).
+-export([
+    start_link/0,
+    notify/1,
+    add_handler/1,
+    add_handler/2
+]).
 
 %% @doc Start the event process.
 -spec start_link() -> any().

--- a/src/erldns_packet_cache.erl
+++ b/src/erldns_packet_cache.erl
@@ -21,20 +21,24 @@
 -behavior(gen_server).
 
 % API
--export([start_link/0,
-         get/1,
-         get/2,
-         put/2,
-         sweep/0,
-         clear/0,
-         stop/0]).
+-export([
+    start_link/0,
+    get/1,
+    get/2,
+    put/2,
+    sweep/0,
+    clear/0,
+    stop/0
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -define(SERVER, ?MODULE).
 
@@ -103,10 +107,11 @@ init([]) ->
 init([TTL]) ->
     erldns_storage:create(packet_cache),
     {ok, Tref} = timer:apply_interval(erldns_config:packet_cache_sweep_interval(), ?MODULE, sweep, []),
-    {ok,
-     #state{ttl = TTL,
-            ttl_overrides = erldns_config:packet_cache_ttl_overrides(),
-            tref = Tref}}.
+    {ok, #state{
+        ttl = TTL,
+        ttl_overrides = erldns_config:packet_cache_ttl_overrides(),
+        tref = Tref
+    }}.
 
 handle_call({set_packet, [Key, Response]}, _From, State) ->
     erldns_storage:insert(packet_cache, {Key, {Response, timestamp() + State#state.ttl}}),

--- a/src/erldns_query_throttle.erl
+++ b/src/erldns_query_throttle.erl
@@ -22,21 +22,27 @@
 -include_lib("dns_erlang/include/dns_records.hrl").
 
 %% API
--export([start_link/0,
-         throttle/2,
-         sweep/0,
-         stop/0]).
+-export([
+    start_link/0,
+    throttle/2,
+    sweep/0,
+    stop/0
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 %% Types
--export_type([throttle_result/0,
-              throttle_hit_count/0]).
+-export_type([
+    throttle_result/0,
+    throttle_hit_count/0
+]).
 
 -type throttle_hit_count() :: non_neg_integer().
 -type throttle_result() :: {throttled | ok, inet:ip_address() | inet:hostname(), throttle_hit_count()}.

--- a/src/erldns_records.erl
+++ b/src/erldns_records.erl
@@ -26,24 +26,32 @@
 -endif.
 
 % Wildcard functions
--export([optionally_convert_wildcard/2,
-         wildcard_qname/1]).
+-export([
+    optionally_convert_wildcard/2,
+    wildcard_qname/1
+]).
 % SOA TTL functions
--export([minimum_soa_ttl/2,
-         rewrite_soa_ttl/1]).
+-export([
+    minimum_soa_ttl/2,
+    rewrite_soa_ttl/1
+]).
 % Matcher functions
--export([match_name/1,
-         match_type/1,
-         match_name_and_type/2,
-         match_types/1,
-         match_wildcard/0,
-         match_delegation/1,
-         match_type_covered/1]).
--export([default_ttl/1,
-         default_priority/1,
-         name_type/1,
-         root_hints/0,
-         replace_name/1]).
+-export([
+    match_name/1,
+    match_type/1,
+    match_name_and_type/2,
+    match_types/1,
+    match_wildcard/0,
+    match_delegation/1,
+    match_type_covered/1
+]).
+-export([
+    default_ttl/1,
+    default_priority/1,
+    name_type/1,
+    root_hints/0,
+    replace_name/1
+]).
 
 %% @doc If given Name is a wildcard name then the original qname needs to be returned in its place.
 -spec optionally_convert_wildcard(dns:dname(), dns:dname()) -> dns:dname().
@@ -290,110 +298,168 @@ name_type(Type) when is_binary(Type) ->
 
 -spec root_hints() -> {[dns:rr()], [dns:rr()]}.
 root_hints() ->
-    {[#dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}},
-      #dns_rr{name = <<"">>,
-              type = ?DNS_TYPE_NS,
-              ttl = 518400,
-              data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}}],
-     [#dns_rr{name = <<"a.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {198, 41, 0, 4}}},
-      #dns_rr{name = <<"b.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 228, 79, 201}}},
-      #dns_rr{name = <<"c.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 33, 4, 12}}},
-      #dns_rr{name = <<"d.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {128, 8, 10, 90}}},
-      #dns_rr{name = <<"e.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 203, 230, 10}}},
-      #dns_rr{name = <<"f.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 5, 5, 241}}},
-      #dns_rr{name = <<"g.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 112, 36, 4}}},
-      #dns_rr{name = <<"h.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {128, 63, 2, 53}}},
-      #dns_rr{name = <<"i.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 36, 148, 17}}},
-      #dns_rr{name = <<"j.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {192, 58, 128, 30}}},
-      #dns_rr{name = <<"k.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {193, 0, 14, 129}}},
-      #dns_rr{name = <<"l.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {198, 32, 64, 12}}},
-      #dns_rr{name = <<"m.root-servers.net">>,
-              type = ?DNS_TYPE_A,
-              ttl = 3600000,
-              data = #dns_rrdata_a{ip = {202, 12, 27, 33}}}]}.
+    {
+        [
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"a.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"b.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"c.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"d.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"e.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"f.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"g.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"h.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"i.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"j.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"k.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"l.root-servers.net">>}
+            },
+            #dns_rr{
+                name = <<"">>,
+                type = ?DNS_TYPE_NS,
+                ttl = 518400,
+                data = #dns_rrdata_ns{dname = <<"m.root-servers.net">>}
+            }
+        ],
+        [
+            #dns_rr{
+                name = <<"a.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {198, 41, 0, 4}}
+            },
+            #dns_rr{
+                name = <<"b.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 228, 79, 201}}
+            },
+            #dns_rr{
+                name = <<"c.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 33, 4, 12}}
+            },
+            #dns_rr{
+                name = <<"d.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {128, 8, 10, 90}}
+            },
+            #dns_rr{
+                name = <<"e.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 203, 230, 10}}
+            },
+            #dns_rr{
+                name = <<"f.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 5, 5, 241}}
+            },
+            #dns_rr{
+                name = <<"g.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 112, 36, 4}}
+            },
+            #dns_rr{
+                name = <<"h.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {128, 63, 2, 53}}
+            },
+            #dns_rr{
+                name = <<"i.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 36, 148, 17}}
+            },
+            #dns_rr{
+                name = <<"j.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {192, 58, 128, 30}}
+            },
+            #dns_rr{
+                name = <<"k.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {193, 0, 14, 129}}
+            },
+            #dns_rr{
+                name = <<"l.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {198, 32, 64, 12}}
+            },
+            #dns_rr{
+                name = <<"m.root-servers.net">>,
+                type = ?DNS_TYPE_A,
+                ttl = 3600000,
+                data = #dns_rrdata_a{ip = {202, 12, 27, 33}}
+            }
+        ]
+    }.
 
 -ifdef(TEST).
 
@@ -401,37 +467,53 @@ wildcard_qname_test_() ->
     ?_assertEqual(<<"*.b.example.com">>, wildcard_qname(<<"a.b.example.com">>)).
 
 minimum_soa_ttl_test_() ->
-    [?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
-     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
-     ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))].
+    [
+        ?_assertMatch(#dns_rr{ttl = 3600}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_a{})),
+        ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 3600}, #dns_rrdata_soa{minimum = 30})),
+        ?_assertMatch(#dns_rr{ttl = 30}, minimum_soa_ttl(#dns_rr{ttl = 30}, #dns_rrdata_soa{minimum = 3600}))
+    ].
 
 replace_name_test_() ->
-    [?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
-     ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))].
+    [
+        ?_assertEqual([], lists:map(replace_name(<<"example">>), [])),
+        ?_assertMatch([#dns_rr{name = <<"example">>}], lists:map(replace_name(<<"example">>), [#dns_rr{name = <<"test.com">>}]))
+    ].
 
 match_name_test_() ->
-    [?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
-     ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))].
+    [
+        ?_assert(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.com">>}])),
+        ?_assertNot(lists:any(match_name(<<"example.com">>), [#dns_rr{name = <<"example.net">>}]))
+    ].
 
 match_type_test_() ->
-    [?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))].
+    [
+        ?_assert(lists:any(match_type(?DNS_TYPE_A), [#dns_rr{type = ?DNS_TYPE_A}])),
+        ?_assertNot(lists:any(match_type(?DNS_TYPE_CNAME), [#dns_rr{type = ?DNS_TYPE_A}]))
+    ].
 
 match_types_test_() ->
-    [?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
-     ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))].
+    [
+        ?_assert(lists:any(match_types([?DNS_TYPE_A]), [#dns_rr{type = ?DNS_TYPE_A}])),
+        ?_assert(lists:any(match_types([?DNS_TYPE_A, ?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}])),
+        ?_assertNot(lists:any(match_types([?DNS_TYPE_CNAME]), [#dns_rr{type = ?DNS_TYPE_A}]))
+    ].
 
 match_wildcard_test_() ->
-    [?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
-     ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))].
+    [
+        ?_assert(lists:any(match_wildcard(), [#dns_rr{name = <<"*.example.com">>}])),
+        ?_assertNot(lists:any(match_wildcard(), [#dns_rr{name = <<"www.example.com">>}]))
+    ].
 
 match_delegation_test_() ->
-    [?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
-     ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))].
+    [
+        ?_assert(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns1.example.com">>}}])),
+        ?_assertNot(lists:any(match_delegation(<<"ns1.example.com">>), [#dns_rr{data = #dns_rrdata_ns{dname = <<"ns2.example.com">>}}]))
+    ].
 
 match_wildcard_label_test_() ->
-    [?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
-     ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))].
+    [
+        ?_assert(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"*.example.com">>))),
+        ?_assertNot(lists:any(match_wildcard_label(), dns:dname_to_labels(<<"www.example.com">>)))
+    ].
 
 -endif.

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -36,16 +36,20 @@ init(_Args) ->
     {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
 define_servers(Servers) ->
-    lists:flatten(lists:map(fun(Server) ->
-                               Name = erldns_config:keyget(name, Server),
-                               Address = erldns_config:keyget(address, Server),
-                               Port = erldns_config:keyget(port, Server),
-                               Family = erldns_config:keyget(family, Server),
+    lists:flatten(
+        lists:map(
+            fun(Server) ->
+                Name = erldns_config:keyget(name, Server),
+                Address = erldns_config:keyget(address, Server),
+                Port = erldns_config:keyget(port, Server),
+                Family = erldns_config:keyget(family, Server),
 
-                               Processes = erldns_config:keyget(processes, Server, 1),
-                               define_server(Name, Address, Port, Family, Processes)
-                            end,
-                            Servers)).
+                Processes = erldns_config:keyget(processes, Server, 1),
+                define_server(Name, Address, Port, Family, Processes)
+            end,
+            Servers
+        )
+    ).
 
 define_server(Name, Address, Port, Family, N) ->
     define_server(Name, Address, Port, Family, N, []).
@@ -55,18 +59,24 @@ define_server(_, _, _, _, 0, Definitions) ->
 define_server(Name, Address, Port, Family, 1, []) ->
     UDPName = list_to_atom(lists:concat([udp, '_', Name])),
     TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
-    [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
-     {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}];
+    [
+        {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port]}, permanent, 5000, worker, [UDPName]},
+        {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
+    ];
 define_server(Name, Address, Port, Family, N = 1, Definitions) ->
     UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
     TCPName = list_to_atom(lists:concat([tcp, '_', Name])),
     Definition =
-        [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
-         {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}],
+        [
+            {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]},
+            {TCPName, {erldns_tcp_server, start_link, [TCPName, Family, Address, Port]}, permanent, 5000, worker, [TCPName]}
+        ],
     define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition);
 define_server(Name, Address, Port, Family, N, Definitions) ->
     UDPName = list_to_atom(lists:concat([udp, '_', Name, '_', N])),
-    Definition = [{UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}],
+    Definition = [
+        {UDPName, {erldns_udp_server, start_link, [UDPName, Family, Address, Port, socket_opts()]}, permanent, 5000, worker, [UDPName]}
+    ],
     define_server(Name, Address, Port, Family, N - 1, Definitions ++ Definition).
 
 socket_opts() ->

--- a/src/erldns_storage.erl
+++ b/src/erldns_storage.erl
@@ -20,27 +20,31 @@
 %% inter-module API
 -export([start_link/0]).
 %% API
--export([create/1,
-         insert/2,
-         delete_table/1,
-         delete/2,
-         select_delete/2,
-         backup_table/1,
-         backup_tables/0,
-         select/2,
-         select/3,
-         foldl/3,
-         empty_table/1,
-         list_table/1,
-         load_zones/0,
-         load_zones/1]).
+-export([
+    create/1,
+    insert/2,
+    delete_table/1,
+    delete/2,
+    select_delete/2,
+    backup_table/1,
+    backup_tables/0,
+    select/2,
+    select/3,
+    foldl/3,
+    empty_table/1,
+    list_table/1,
+    load_zones/0,
+    load_zones/1
+]).
 %% gen_server callbacks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -record(state, {}).
 
@@ -168,11 +172,13 @@ load_zones(Filename) when is_list(Filename) ->
             lager:debug("Parsing zones JSON"),
             JsonZones = jsx:decode(Binary, [{return_maps, false}]),
             lager:debug("Putting zones into cache"),
-            lists:foreach(fun(JsonZone) ->
-                             Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
-                             ok = erldns_zone_cache:put_zone(Zone)
-                          end,
-                          JsonZones),
+            lists:foreach(
+                fun(JsonZone) ->
+                    Zone = erldns_zone_parser:zone_to_erlang(JsonZone),
+                    ok = erldns_zone_cache:put_zone(Zone)
+                end,
+                JsonZones
+            ),
             lager:debug("Loaded zones (count: ~p)", [length(JsonZones)]),
             {ok, length(JsonZones)};
         {error, Reason} ->

--- a/src/erldns_storage_json.erl
+++ b/src/erldns_storage_json.erl
@@ -16,18 +16,20 @@
 -module(erldns_storage_json).
 
 %% API
--export([create/1,
-         insert/2,
-         delete_table/1,
-         delete/2,
-         select_delete/2,
-         backup_table/1,
-         backup_tables/0,
-         select/2,
-         select/3,
-         foldl/3,
-         empty_table/1,
-         list_table/1]).
+-export([
+    create/1,
+    insert/2,
+    delete_table/1,
+    delete/2,
+    select_delete/2,
+    backup_table/1,
+    backup_tables/0,
+    select/2,
+    select/3,
+    foldl/3,
+    empty_table/1,
+    list_table/1
+]).
 
 %% Public API
 %% @doc Create ets table wrapper. Use match cases for adding different options to the table.

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -20,9 +20,11 @@
 
 % API
 -export([start_link/0]).
--export([gc/0,
-         gc_registered/0,
-         gc_registered/1]).
+-export([
+    gc/0,
+    gc_registered/0,
+    gc_registered/1
+]).
 % Supervisor hooks
 -export([init/1]).
 
@@ -55,13 +57,15 @@ gc_registered(ProcessName) ->
 %% Callbacks
 init(_Args) ->
     SysProcs =
-        [?CHILD(erldns_events, worker, []),
-         ?CHILD(erldns_zone_cache, worker, []),
-         ?CHILD(erldns_zone_parser, worker, []),
-         ?CHILD(erldns_zone_encoder, worker, []),
-         ?CHILD(erldns_packet_cache, worker, []),
-         ?CHILD(erldns_query_throttle, worker, []),
-         ?CHILD(erldns_handler, worker, []),
-         ?CHILD(sample_custom_handler, worker, [])],
+        [
+            ?CHILD(erldns_events, worker, []),
+            ?CHILD(erldns_zone_cache, worker, []),
+            ?CHILD(erldns_zone_parser, worker, []),
+            ?CHILD(erldns_zone_encoder, worker, []),
+            ?CHILD(erldns_packet_cache, worker, []),
+            ?CHILD(erldns_query_throttle, worker, []),
+            ?CHILD(erldns_handler, worker, []),
+            ?CHILD(sample_custom_handler, worker, [])
+        ],
 
     {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_tcp_server.erl
+++ b/src/erldns_tcp_server.erl
@@ -18,17 +18,21 @@
 -behavior(gen_nb_server).
 
 % API
--export([start_link/2,
-         start_link/4]).
+-export([
+    start_link/2,
+    start_link/4
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         sock_opts/0,
-         new_connection/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    sock_opts/0,
+    new_connection/2,
+    code_change/3
+]).
 % Internal API
 -export([handle_request/3]).
 

--- a/src/erldns_txt.erl
+++ b/src/erldns_txt.erl
@@ -49,7 +49,8 @@ parse(String, [C | Rest], Tokens, Escaped) ->
     parse_char(String, C, Rest, Tokens, Escaped).
 
 parse(_, [], Tokens, CurrentToken, true) ->
-    Tokens ++ [CurrentToken]; % Last character is escaped
+    % Last character is escaped
+    Tokens ++ [CurrentToken];
 parse(String, [C | Rest], Tokens, CurrentToken, Escaped) ->
     parse_char(String, C, Rest, Tokens, CurrentToken, Escaped).
 
@@ -129,33 +130,37 @@ quoteless_ascii_string1() ->
     list(oneof([integer(0, 33), integer(35, 255)])).
 
 quoteless_ascii_string() ->
-    ?SUCHTHAT(String,
-              quoteless_ascii_string1(),
-              begin
-                  case lists:reverse(String) of
-                      [92 | _] ->
-                          false;
-                      _ ->
-                          true
-                  end
-              end).
+    ?SUCHTHAT(
+        String,
+        quoteless_ascii_string1(),
+        begin
+            case lists:reverse(String) of
+                [92 | _] ->
+                    false;
+                _ ->
+                    true
+            end
+        end
+    ).
 
 quoted_ascii_string1() ->
     %% " has character code 34.
     ?LET(String, quoteless_ascii_string(), [34] ++ String ++ [34]).
 
 quoted_ascii_string() ->
-    ?SUCHTHAT(String,
-              quoted_ascii_string1(),
-              begin
-                  case lists:reverse(String) of
-                      % "\
-                      [34, 92 | _] ->
-                          false;
-                      _ ->
-                          true
-                  end
-              end).
+    ?SUCHTHAT(
+        String,
+        quoted_ascii_string1(),
+        begin
+            case lists:reverse(String) of
+                % "\
+                [34, 92 | _] ->
+                    false;
+                _ ->
+                    true
+            end
+        end
+    ).
 
 quoted_and_unquoted_ascii_string_unflattened() ->
     list(oneof([quoted_ascii_string(), quoteless_ascii_string()])).
@@ -164,11 +169,13 @@ quoted_and_unquoted_ascii_string() ->
     ?LET(StringList, quoted_and_unquoted_ascii_string_unflattened(), lists:flatten(StringList)).
 
 prop_parse_holds_type() ->
-    ?FORALL(ASCIIString,
-            quoted_and_unquoted_ascii_string(),
-            begin
-                BinaryOfBinaryList = parse(ASCIIString),
-                check_bblist(BinaryOfBinaryList)
-            end).
+    ?FORALL(
+        ASCIIString,
+        quoted_and_unquoted_ascii_string(),
+        begin
+            BinaryOfBinaryList = parse(ASCIIString),
+            check_bblist(BinaryOfBinaryList)
+        end
+    ).
 
 -endif.

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -18,22 +18,27 @@
 -behavior(gen_server).
 
 % API
--export([start_link/2,
-         start_link/4,
-         start_link/5,
-         is_running/0]).
+-export([
+    start_link/2,
+    start_link/4,
+    start_link/5,
+    is_running/0
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 % Internal API
 -export([handle_request/5]).
 
 -define(SERVER, ?MODULE).
--define(DEFAULT_UDP_RECBUF, 1024 * 1024). % 1 MB
+% 1 MB
+-define(DEFAULT_UDP_RECBUF, 1024 * 1024).
 
 -record(state, {address, port, socket, workers}).
 
@@ -66,24 +71,27 @@ is_running() ->
 init([InetFamily]) ->
     Port = erldns_config:get_port(),
     {ok, Socket} = start(Port, InetFamily),
-    {ok,
-     #state{port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}};
+    {ok, #state{
+        port = Port,
+        socket = Socket,
+        workers = make_workers(queue:new())
+    }};
 init([InetFamily, Address, Port]) ->
     {ok, Socket} = start(Address, Port, InetFamily),
-    {ok,
-     #state{address = Address,
-            port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}};
+    {ok, #state{
+        address = Address,
+        port = Port,
+        socket = Socket,
+        workers = make_workers(queue:new())
+    }};
 init([InetFamily, Address, Port, SocketOpts]) ->
     {ok, Socket} = start(Address, Port, InetFamily, SocketOpts),
-    {ok,
-     #state{address = Address,
-            port = Port,
-            socket = Socket,
-            workers = make_workers(queue:new())}}.
+    {ok, #state{
+        address = Address,
+        port = Port,
+        socket = Socket,
+        workers = make_workers(queue:new())
+    }}.
 
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
@@ -114,7 +122,11 @@ start(Port, InetFamily) ->
 
 start(Address, Port, InetFamily) ->
     lager:info("Starting UDP server (family: ~p, address: ~p, port: ~p)", [InetFamily, Address, Port]),
-    case gen_udp:open(Port, [binary, {active, 100}, {reuseaddr, true}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily]) of
+    case
+        gen_udp:open(Port, [
+            binary, {active, 100}, {reuseaddr, true}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily
+        ])
+    of
         {ok, Socket} ->
             lager:info("UDP server (family: ~p, address: ~p, socket: ~p)", [InetFamily, Address, Socket]),
             {ok, Socket};
@@ -125,8 +137,20 @@ start(Address, Port, InetFamily) ->
 
 start(Address, Port, InetFamily, SocketOpts) ->
     lager:info("Starting UDP server (family: ~p, address: ~p, port ~p, sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
-    case gen_udp:open(Port,
-                      [{reuseaddr, true}, binary, {active, 100}, {read_packets, 1000}, {ip, Address}, {recbuf, ?DEFAULT_UDP_RECBUF}, InetFamily | SocketOpts])
+    case
+        gen_udp:open(
+            Port,
+            [
+                {reuseaddr, true},
+                binary,
+                {active, 100},
+                {read_packets, 1000},
+                {ip, Address},
+                {recbuf, ?DEFAULT_UDP_RECBUF},
+                InetFamily
+                | SocketOpts
+            ]
+        )
     of
         {ok, Socket} ->
             lager:info("UDP server (family: ~p, address: ~p, socket: ~p, sockopts: ~p)", [InetFamily, Address, Socket, SocketOpts]),

--- a/src/erldns_worker_process_sup.erl
+++ b/src/erldns_worker_process_sup.erl
@@ -29,5 +29,8 @@ start_link([WorkerId]) ->
 
 init(WorkerId) ->
     {ok,
-     {{one_for_one, 20, 10},
-      [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}.
+        {{one_for_one, 20, 10}, [
+            {{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [
+                erldns_worker_process
+            ]}
+        ]}}.

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -29,34 +29,40 @@
 
 -export([start_link/0]).
 % Read APIs
--export([find_zone/1,
-         find_zone/2,
-         get_zone/1,
-         get_authority/1,
-         get_delegations/1,
-         get_zone_records/1,
-         get_records_by_name/1,
-         get_records_by_name_and_type/2,
-         in_zone/1,
-         record_name_in_zone/2,
-         zone_names_and_versions/0,
-         get_rrset_sync_counter/3]).
+-export([
+    find_zone/1,
+    find_zone/2,
+    get_zone/1,
+    get_authority/1,
+    get_delegations/1,
+    get_zone_records/1,
+    get_records_by_name/1,
+    get_records_by_name_and_type/2,
+    in_zone/1,
+    record_name_in_zone/2,
+    zone_names_and_versions/0,
+    get_rrset_sync_counter/3
+]).
 % Deprecated APIs
 -export([get_zone_with_records/1]).
 % Write APIs
--export([put_zone/1,
-         put_zone/2,
-         delete_zone/1,
-         update_zone_records_and_digest/3,
-         put_zone_rrset/4,
-         delete_zone_rrset/5]).
+-export([
+    put_zone/1,
+    put_zone/2,
+    delete_zone/1,
+    update_zone_records_and_digest/3,
+    put_zone_rrset/4,
+    delete_zone_rrset/5
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -define(SERVER, ?MODULE).
 
@@ -77,7 +83,7 @@ find_zone(Qname) ->
 
 %% @doc Find a zone for a given qname.
 -spec find_zone(dns:dname(), {error, any()} | {ok, dns:rr()} | [dns:rr()] | dns:rr()) ->
-                   #zone{} | {error, zone_not_found} | {error, not_authoritative}.
+    #zone{} | {error, zone_not_found} | {error, not_authoritative}.
 find_zone(Qname, {error, _}) ->
     find_zone(Qname, []);
 find_zone(Qname, {ok, Authority}) ->
@@ -112,10 +118,11 @@ get_zone(Name) ->
     NormalizedName = erldns:normalize_name(Name),
     case erldns_storage:select(zones, NormalizedName) of
         [{NormalizedName, Zone}] ->
-            {ok,
-             Zone#zone{name = NormalizedName,
-                       records = [],
-                       records_by_name = trimmed}};
+            {ok, Zone#zone{
+                name = NormalizedName,
+                records = [],
+                records_by_name = trimmed
+            }};
         _ ->
             {error, zone_not_found}
     end.
@@ -158,9 +165,13 @@ get_delegations(Name) ->
     case find_zone_in_cache(Name) of
         {ok, Zone} ->
             Records =
-                lists:flatten(erldns_storage:select(zone_records_typed,
-                                                    [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
-                                                    infinite)),
+                lists:flatten(
+                    erldns_storage:select(
+                        zone_records_typed,
+                        [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), ?DNS_TYPE_NS}, '$1'}, [], ['$$']}],
+                        infinite
+                    )
+                ),
             lists:filter(erldns_records:match_delegation(Name), Records);
         _ ->
             []
@@ -171,7 +182,11 @@ get_delegations(Name) ->
 get_zone_records(Name) ->
     case find_zone_in_cache(Name) of
         {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'}, [], ['$$']}], infinite));
+            lists:flatten(
+                erldns_storage:select(
+                    zone_records_typed, [{{{erldns:normalize_name(Zone#zone.name), '_', '_'}, '$1'}, [], ['$$']}], infinite
+                )
+            );
         _ ->
             []
     end.
@@ -181,9 +196,13 @@ get_zone_records(Name) ->
 get_records_by_name_and_type(Name, Type) ->
     case find_zone_in_cache(Name) of
         {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed,
-                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'}, [], ['$$']}],
-                                                infinite));
+            lists:flatten(
+                erldns_storage:select(
+                    zone_records_typed,
+                    [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), Type}, '$1'}, [], ['$$']}],
+                    infinite
+                )
+            );
         _ ->
             []
     end.
@@ -203,9 +222,13 @@ get_zone_dnskey_records(Name) ->
 get_records_by_name(Name) ->
     case find_zone_in_cache(Name) of
         {ok, Zone} ->
-            lists:flatten(erldns_storage:select(zone_records_typed,
-                                                [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}],
-                                                infinite));
+            lists:flatten(
+                erldns_storage:select(
+                    zone_records_typed,
+                    [{{{erldns:normalize_name(Zone#zone.name), erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}],
+                    infinite
+                )
+            );
         _ ->
             []
     end.
@@ -225,7 +248,13 @@ in_zone(Name) ->
 record_name_in_zone(ZoneName, Name) ->
     case find_zone_in_cache(Name) of
         {ok, Zone} ->
-            case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+            case
+                lists:flatten(
+                    erldns_storage:select(
+                        zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite
+                    )
+                )
+            of
                 [] ->
                     is_name_in_zone_with_wildcard(Name, Zone);
                 _ ->
@@ -250,11 +279,16 @@ zone_names_and_versions() ->
 %% @doc Return current sync counter
 -spec get_rrset_sync_counter(dns:dname(), dns:dname(), dns:type()) -> integer().
 get_rrset_sync_counter(ZoneName, RRFqdn, Type) ->
-    case erldns_storage:select(sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite) of
+    case
+        erldns_storage:select(
+            sync_counters, [{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type, '$1'}, [], ['$_']}], infinite
+        )
+    of
         [{ZoneName, RRFqdn, Type, Counter}] ->
             Counter;
         [] ->
-            0 % return default value of 0
+            % return default value of 0
+            0
     end.
 
 %% @doc Update the RRSet sync counter for the given RR set name and type in the given zone.
@@ -269,11 +303,11 @@ write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}) ->
 %% used to determine if the zone requires updating.
 %%
 %% This function will build the necessary Zone record before inserting.
--spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()}
-    when Name :: binary(),
-         Sha :: binary(),
-         Records :: [dns:rr()],
-         Keys :: [erldns:keyset()].
+-spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()} when
+    Name :: binary(),
+    Sha :: binary(),
+    Records :: [dns:rr()],
+    Keys :: [erldns:keyset()].
 put_zone({Name, Sha, Records}) ->
     put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
@@ -297,8 +331,10 @@ put_zone_records(Name, RecordsByName) ->
     put_zone_records_entry(Name, maps:next(maps:iterator(RecordsByName))).
 
 %% @doc Put zone RRSet
--spec put_zone_rrset({dns:dname(), binary(), [dns:rr()]} | {dns:dname(), binary(), [dns:rr()], [any()]}, dns:dname(), dns:type(), integer()) ->
-                        ok | {error, Reason :: term()}.
+-spec put_zone_rrset(
+    {dns:dname(), binary(), [dns:rr()]} | {dns:dname(), binary(), [dns:rr()], [any()]}, dns:dname(), dns:type(), integer()
+) ->
+    ok | {error, Reason :: term()}.
 put_zone_rrset({ZoneName, Digest, Records}, RRFqdn, Type, Counter) ->
     put_zone_rrset({ZoneName, Digest, Records, []}, RRFqdn, Type, Counter);
 put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
@@ -308,11 +344,14 @@ put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
             lager:debug("Putting RRSet (~p) with Type: ~p for Zone (~p): ~p", [RRFqdn, Type, ZoneName, Records]),
             KeySets = Zone#zone.keysets,
             DnsKeyRRs = get_zone_dnskey_records(ZoneName),
-            SignedRRSet = ?with_span(<<"sign_rrset">>, #{},
+            SignedRRSet = ?with_span(
+                <<"sign_rrset">>,
+                #{},
                 fun(_SpanCtx) ->
                     ?set_attributes([{zone, ZoneName}, {type, Type}]),
                     sign_rrset(ZoneName, Records, DnsKeyRRs, KeySets)
-                end),
+                end
+            ),
             {RRSigRecsCovering, RRSigRecsNotCovering} = filter_rrsig_records_with_type_covered(RRFqdn, Type),
             % RRSet records + RRSIG records for the type + the rest of RRSIG records for FQDN
             TypedRecords = build_typed_index(Records ++ SignedRRSet ++ RRSigRecsNotCovering),
@@ -321,19 +360,24 @@ put_zone_rrset({ZoneName, Digest, Records, _Keys}, RRFqdn, Type, Counter) ->
             % put zone_records_typed records first then create the records in zone_records
             put_zone_records_typed_entry(ZoneName, RRFqdn, maps:next(maps:iterator(TypedRecords))),
 
-            ?with_span(<<"update_zone_recs">>, #{},
+            ?with_span(
+                <<"update_zone_recs">>,
+                #{},
                 fun(_SpanCtx) ->
                     ?set_attributes([{zone, ZoneName}]),
-                    UpdatedZoneRecordsCount = ZoneRecordsCount +
-                                                ((length(Records) - length(CurrentRRSetRecords))) +
-                                                (length(SignedRRSet) - length(RRSigRecsCovering)),
+                    UpdatedZoneRecordsCount =
+                        ZoneRecordsCount +
+                            (length(Records) - length(CurrentRRSetRecords)) +
+                            (length(SignedRRSet) - length(RRSigRecsCovering)),
                     update_zone_records_and_digest(ZoneName, UpdatedZoneRecordsCount, Digest)
-                end),
+                end
+            ),
             write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter}),
 
             lager:debug("RRSet update completed for FQDN: ~p, Type: ~p", [RRFqdn, Type]),
             ok;
-        _ -> % if zone is not in cache, return error
+        % if zone is not in cache, return error
+        _ ->
             {error, zone_not_found}
     end.
 
@@ -370,14 +414,20 @@ delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
                     lager:debug("Removing RRSet (~p) with type ~p", [RRFqdn, Type]),
                     ZoneRecordsCount = Zone#zone.record_count,
                     CurrentRRSetRecords = get_records_by_name_and_type(RRFqdn, Type),
-                    erldns_storage:select_delete(zone_records_typed,
-                                                 [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'}, [], [true]}]),
+                    erldns_storage:select_delete(
+                        zone_records_typed,
+                        [{{{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), Type}, '_'}, [], [true]}]
+                    ),
 
                     % remove the RRSIG for the given record type
                     {RRSigsCovering, RRSigsNotCovering} =
-                        lists:partition(erldns_records:match_type_covered(Type), get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)),
-                    erldns_storage:insert(zone_records_typed,
-                                          {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}),
+                        lists:partition(
+                            erldns_records:match_type_covered(Type), get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)
+                        ),
+                    erldns_storage:insert(
+                        zone_records_typed,
+                        {{erldns:normalize_name(ZoneName), erldns:normalize_name(RRFqdn), ?DNS_TYPE_RRSIG_NUMBER}, RRSigsNotCovering}
+                    ),
 
                     % only write counter if called explicitly with Counter value i.e. different than 0.
                     % this will not write the counter if called by put_zone_rrset/3 as it will prevent subsequent delete ops
@@ -385,16 +435,19 @@ delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
                         N when N > 0 ->
                             % DELETE RRSet command has been sent
                             % we need to update the zone digest as the zone content changes
-                            UpdatedZoneRecordsCount = ZoneRecordsCount -
-                                                        length(CurrentRRSetRecords) -
-                                                        length(RRSigsCovering),
+                            UpdatedZoneRecordsCount =
+                                ZoneRecordsCount -
+                                    length(CurrentRRSetRecords) -
+                                    length(RRSigsCovering),
                             update_zone_records_and_digest(ZoneName, UpdatedZoneRecordsCount, Digest),
                             write_rrset_sync_counter({ZoneName, RRFqdn, Type, Counter});
                         _ ->
                             ok
                     end;
                 N when CurrentCounter > N ->
-                    lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [RRFqdn, Counter])
+                    lager:debug("Not processing delete operation for RRSet (~p): counter (~p) provided is lower than system", [
+                        RRFqdn, Counter
+                    ])
             end;
         _ ->
             {error, zone_not_found}
@@ -407,14 +460,19 @@ update_zone_records_and_digest(ZoneName, RecordsCount, Digest) ->
         {ok, Zone} ->
             Zone,
             UpdatedZone =
-                Zone#zone{version = Digest,
-                          authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
-                          record_count = RecordsCount},
-            ?with_span(<<"put_zone">>, #{},
+                Zone#zone{
+                    version = Digest,
+                    authority = get_records_by_name_and_type(ZoneName, ?DNS_TYPE_SOA),
+                    record_count = RecordsCount
+                },
+            ?with_span(
+                <<"put_zone">>,
+                #{},
                 fun(_SpanCtx) ->
                     ?set_attributes([{zone, ZoneName}]),
                     put_zone(Zone#zone.name, UpdatedZone)
-                end);
+                end
+            );
         _ ->
             {error, zone_not_found}
     end.
@@ -426,8 +484,10 @@ filter_rrsig_records_with_type_covered(RRFqdn, TypeCovered) ->
     case find_zone_in_cache(erldns:normalize_name(RRFqdn)) of
         {ok, _Zone} ->
             % {RRSigsCovering, RRSigsNotCovering} =
-            lists:partition(erldns_records:match_type_covered(TypeCovered),
-                            get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER));
+            lists:partition(
+                erldns_records:match_type_covered(TypeCovered),
+                get_records_by_name_and_type(RRFqdn, ?DNS_TYPE_RRSIG_NUMBER)
+            );
         _ ->
             {[], []}
     end.
@@ -472,7 +532,11 @@ code_change(_PreviousVersion, State, _Extra) ->
 % Internal API
 is_name_in_zone(Name, Zone) ->
     ZoneName = erldns:normalize_name(Zone#zone.name),
-    case lists:flatten(erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)) of
+    case
+        lists:flatten(
+            erldns_storage:select(zone_records_typed, [{{{ZoneName, erldns:normalize_name(Name), '_'}, '$1'}, [], ['$$']}], infinite)
+        )
+    of
         [] ->
             case dns:dname_to_labels(Name) of
                 [] ->
@@ -524,23 +588,27 @@ find_zone_in_cache(Name, [_ | Labels]) ->
 
 build_zone(Qname, Version, Records, Keys) ->
     Authorities = lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), Records),
-    #zone{name = Qname,
-          version = Version,
-          record_count = length(Records),
-          authority = Authorities,
-          records = Records,
-          records_by_name = trimmed,
-          keysets = Keys}.
+    #zone{
+        name = Qname,
+        version = Version,
+        record_count = length(Records),
+        authority = Authorities,
+        records = Records,
+        records_by_name = trimmed,
+        keysets = Keys
+    }.
 
 -spec build_named_index([#dns_rr{}]) -> #{binary() => [#dns_rr{}]}.
 build_named_index(Records) ->
     NamedIndex =
-        lists:foldl(fun(R, Idx) ->
-                       Name = erldns:normalize_name(R#dns_rr.name),
-                       maps:update_with(Name, fun(RR) -> [R | RR] end, [R], Idx)
-                    end,
-                    #{},
-                    Records),
+        lists:foldl(
+            fun(R, Idx) ->
+                Name = erldns:normalize_name(R#dns_rr.name),
+                maps:update_with(Name, fun(RR) -> [R | RR] end, [R], Idx)
+            end,
+            #{},
+            Records
+        ),
     maps:map(fun(_K, V) -> lists:reverse(V) end, NamedIndex).
 
 -spec build_typed_index([#dns_rr{}]) -> #{dns:type() => [#dns_rr{}]}.
@@ -559,19 +627,28 @@ sign_zone(Zone) ->
     lager:debug("Zone verified: ~p", [Verify]),
     % TODO: remove wildcard signatures as they will not be used but are taking up space
     ZoneRRSigRecords =
-        lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Zone#zone.name,
-                                                                lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end, Zone#zone.records)),
-                                Zone#zone.keysets)),
+        lists:flatten(
+            lists:map(
+                erldns_dnssec:zone_rrset_signer(
+                    Zone#zone.name,
+                    lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end, Zone#zone.records)
+                ),
+                Zone#zone.keysets
+            )
+        ),
     Records =
         Zone#zone.records ++
-            KeyRRSigRecords ++ rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
-    #zone{name = Zone#zone.name,
-          version = Zone#zone.version,
-          record_count = length(Records),
-          authority = Zone#zone.authority,
-          records = Records,
-          records_by_name = build_named_index(Records),
-          keysets = Zone#zone.keysets}.
+            KeyRRSigRecords ++
+            rewrite_soa_rrsig_ttl(Zone#zone.records, ZoneRRSigRecords -- lists:filter(erldns_records:match_wildcard(), ZoneRRSigRecords)),
+    #zone{
+        name = Zone#zone.name,
+        version = Zone#zone.version,
+        record_count = length(Records),
+        authority = Zone#zone.authority,
+        records = Records,
+        records_by_name = build_named_index(Records),
+        keysets = Zone#zone.keysets
+    }.
 
 -spec verify_zone(erldns:zone(), [dns:rr()], [dns:rr()]) -> boolean().
 verify_zone(_Zone, DnskeyRRs, KeyRRSigRecords) ->
@@ -596,11 +673,21 @@ sign_rrset(Name, Records, DnsKeyRRs, KeySets) ->
     KeyRRSigRecords = lists:flatten(lists:map(erldns_dnssec:key_rrset_signer(Name, DnsKeyRRs), KeySets)),
     ZoneRecords = get_records_by_name_and_type(Name, ?DNS_TYPE_SOA),
     RRSigRecords =
-        rewrite_soa_rrsig_ttl(ZoneRecords,
-                              lists:flatten(lists:map(erldns_dnssec:zone_rrset_signer(Name,
-                                                                                      lists:filter(fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end,
-                                                                                                   Records)),
-                                                      KeySets))),
+        rewrite_soa_rrsig_ttl(
+            ZoneRecords,
+            lists:flatten(
+                lists:map(
+                    erldns_dnssec:zone_rrset_signer(
+                        Name,
+                        lists:filter(
+                            fun(RR) -> RR#dns_rr.type =/= ?DNS_TYPE_DNSKEY end,
+                            Records
+                        )
+                    ),
+                    KeySets
+                )
+            )
+        ),
     verify_rrset(DnsKeyRRs, KeyRRSigRecords),
     RRSigRecords.
 
@@ -627,14 +714,17 @@ verify_rrset(DnsKeyRRs, KeyRRSigRecords) ->
 % Rewrite the RRSIG TTL so it follows the same rewrite rules as the SOA TTL.
 rewrite_soa_rrsig_ttl(ZoneRecords, RRSigRecords) ->
     SoaRR = lists:last(lists:filter(erldns_records:match_type(?DNS_TYPE_SOA), ZoneRecords)),
-    lists:map(fun(RR) ->
-                 case RR#dns_rr.type of
-                     ?DNS_TYPE_RRSIG ->
-                         case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
-                             ?DNS_TYPE_SOA -> erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
-                             _ -> RR
-                         end;
-                     _ -> RR
-                 end
-              end,
-              RRSigRecords).
+    lists:map(
+        fun(RR) ->
+            case RR#dns_rr.type of
+                ?DNS_TYPE_RRSIG ->
+                    case RR#dns_rr.data#dns_rrdata_rrsig.type_covered of
+                        ?DNS_TYPE_SOA -> erldns_records:minimum_soa_ttl(RR, SoaRR#dns_rr.data);
+                        _ -> RR
+                    end;
+                _ ->
+                    RR
+            end
+        end,
+        RRSigRecords
+    ).

--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -21,18 +21,22 @@
 
 -include("erldns.hrl").
 
--export([start_link/0,
-         zone_to_erlang/1,
-         register_parsers/1,
-         register_parser/1,
-         list_parsers/0]).
+-export([
+    start_link/0,
+    zone_to_erlang/1,
+    register_parsers/1,
+    register_parser/1,
+    list_parsers/0
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -define(SERVER, ?MODULE).
 -define(PARSE_TIMEOUT, 30 * 1000).
@@ -107,25 +111,30 @@ json_to_erlang(Zone, Parsers) when is_map(Zone) ->
     JsonRecords = maps:get(<<"records">>, Zone),
     JsonKeys = maps:get(<<"keys">>, Zone, []),
     Records =
-        lists:map(fun(JsonRecord) ->
-                     Data = json_record_to_list(JsonRecord),
-                     % Filter by context
-                     case apply_context_options(Data) of
-                         pass ->
-                             case json_record_to_erlang(Data) of
-                                 {} ->
-                                     case try_custom_parsers(Data, Parsers) of
-                                         {} ->
-                                             erldns_events:notify({?MODULE, unsupported_record, Data}),
-                                             {};
-                                         ParsedRecord -> ParsedRecord
-                                     end;
-                                 ParsedRecord -> ParsedRecord
-                             end;
-                         _ -> {}
-                     end
-                  end,
-                  JsonRecords),
+        lists:map(
+            fun(JsonRecord) ->
+                Data = json_record_to_list(JsonRecord),
+                % Filter by context
+                case apply_context_options(Data) of
+                    pass ->
+                        case json_record_to_erlang(Data) of
+                            {} ->
+                                case try_custom_parsers(Data, Parsers) of
+                                    {} ->
+                                        erldns_events:notify({?MODULE, unsupported_record, Data}),
+                                        {};
+                                    ParsedRecord ->
+                                        ParsedRecord
+                                end;
+                            ParsedRecord ->
+                                ParsedRecord
+                        end;
+                    _ ->
+                        {}
+                end
+            end,
+            JsonRecords
+        ),
     FilteredRecords = lists:filter(record_filter(), Records),
     DistinctRecords = lists:usort(FilteredRecords),
     {Name, Sha, DistinctRecords, parse_json_keys_as_maps(JsonKeys)};
@@ -135,25 +144,30 @@ json_to_erlang(Zone, Parsers) ->
     JsonRecords = proplists:get_value(<<"records">>, Zone),
     JsonKeys = proplists:get_value(<<"keys">>, Zone, []),
     Records =
-        lists:map(fun(JsonRecord) ->
-                     Data = json_record_to_list(JsonRecord),
-                     % Filter by context
-                     case apply_context_options(Data) of
-                         pass ->
-                             case json_record_to_erlang(Data) of
-                                 {} ->
-                                     case try_custom_parsers(Data, Parsers) of
-                                         {} ->
-                                             erldns_events:notify({?MODULE, unsupported_record, Data}),
-                                             {};
-                                         ParsedRecord -> ParsedRecord
-                                     end;
-                                 ParsedRecord -> ParsedRecord
-                             end;
-                         _ -> {}
-                     end
-                  end,
-                  JsonRecords),
+        lists:map(
+            fun(JsonRecord) ->
+                Data = json_record_to_list(JsonRecord),
+                % Filter by context
+                case apply_context_options(Data) of
+                    pass ->
+                        case json_record_to_erlang(Data) of
+                            {} ->
+                                case try_custom_parsers(Data, Parsers) of
+                                    {} ->
+                                        erldns_events:notify({?MODULE, unsupported_record, Data}),
+                                        {};
+                                    ParsedRecord ->
+                                        ParsedRecord
+                                end;
+                            ParsedRecord ->
+                                ParsedRecord
+                        end;
+                    _ ->
+                        {}
+                end
+            end,
+            JsonRecords
+        ),
     FilteredRecords = lists:filter(record_filter(), Records),
     DistinctRecords = lists:usort(FilteredRecords),
     {Name, Sha, DistinctRecords, parse_json_keys(JsonKeys)}.
@@ -167,14 +181,16 @@ parse_json_keys_as_maps([], Keys) ->
     Keys;
 parse_json_keys_as_maps([Key | Rest], Keys) ->
     KeySet =
-        #keyset{key_signing_key = to_crypto_key(maps:get(<<"ksk">>, Key)),
-                key_signing_key_tag = maps:get(<<"ksk_keytag">>, Key),
-                key_signing_alg = maps:get(<<"ksk_alg">>, Key),
-                zone_signing_key = to_crypto_key(maps:get(<<"zsk">>, Key)),
-                zone_signing_key_tag = maps:get(<<"zsk_keytag">>, Key),
-                zone_signing_alg = maps:get(<<"zsk_alg">>, Key),
-                inception = iso8601:parse(maps:get(<<"inception">>, Key)),
-                valid_until = iso8601:parse(maps:get(<<"until">>, Key))},
+        #keyset{
+            key_signing_key = to_crypto_key(maps:get(<<"ksk">>, Key)),
+            key_signing_key_tag = maps:get(<<"ksk_keytag">>, Key),
+            key_signing_alg = maps:get(<<"ksk_alg">>, Key),
+            zone_signing_key = to_crypto_key(maps:get(<<"zsk">>, Key)),
+            zone_signing_key_tag = maps:get(<<"zsk_keytag">>, Key),
+            zone_signing_alg = maps:get(<<"zsk_alg">>, Key),
+            inception = iso8601:parse(maps:get(<<"inception">>, Key)),
+            valid_until = iso8601:parse(maps:get(<<"until">>, Key))
+        },
     parse_json_keys_as_maps(Rest, [KeySet | Keys]).
 
 parse_json_keys([]) ->
@@ -187,26 +203,34 @@ parse_json_keys(JsonKeys) ->
 %% that the pattern-match can succeed (or fail) in a single pass.
 parse_json_keys([], Keys) ->
     Keys;
-parse_json_keys([[%% pre-sorting the proplist allows us to pattern-match
-                  {<<"inception">>, Inception},
-                  {<<"ksk">>, KskBin},
-                  {<<"ksk_alg">>, KskAlg},
-                  {<<"ksk_keytag">>, KskKeytag},
-                  {<<"until">>, ValidUntil},
-                  {<<"zsk">>, ZskBin},
-                  {<<"zsk_alg">>, ZskAlg},
-                  {<<"zsk_keytag">>, ZskKeytag}]
-                 | Rest],
-                Keys) ->
+%% pre-sorting the proplist allows us to pattern-match
+parse_json_keys(
+    [
+        [
+            {<<"inception">>, Inception},
+            {<<"ksk">>, KskBin},
+            {<<"ksk_alg">>, KskAlg},
+            {<<"ksk_keytag">>, KskKeytag},
+            {<<"until">>, ValidUntil},
+            {<<"zsk">>, ZskBin},
+            {<<"zsk_alg">>, ZskAlg},
+            {<<"zsk_keytag">>, ZskKeytag}
+        ]
+        | Rest
+    ],
+    Keys
+) ->
     KeySet =
-        #keyset{key_signing_key = to_crypto_key(KskBin),
-                key_signing_key_tag = KskKeytag,
-                key_signing_alg = KskAlg,
-                zone_signing_key = to_crypto_key(ZskBin),
-                zone_signing_key_tag = ZskKeytag,
-                zone_signing_alg = ZskAlg,
-                inception = iso8601:parse(Inception),
-                valid_until = iso8601:parse(ValidUntil)},
+        #keyset{
+            key_signing_key = to_crypto_key(KskBin),
+            key_signing_key_tag = KskKeytag,
+            key_signing_alg = KskAlg,
+            zone_signing_key = to_crypto_key(ZskBin),
+            zone_signing_key_tag = ZskKeytag,
+            zone_signing_alg = ZskAlg,
+            inception = iso8601:parse(Inception),
+            valid_until = iso8601:parse(ValidUntil)
+        },
     parse_json_keys(Rest, [KeySet | Keys]);
 %% pre-sort the proplist, to be consumed in previous pattern match
 parse_json_keys([Proplist], Acc) ->
@@ -219,10 +243,10 @@ to_crypto_key(RsaKeyBin) ->
 
 record_filter() ->
     fun(R) ->
-       case R of
-           {} -> false;
-           _ -> true
-       end
+        case R of
+            {} -> false;
+            _ -> true
+        end
     end.
 
 -spec apply_context_list_check(sets:set(), sets:set()) -> [fail] | [pass].
@@ -254,8 +278,10 @@ apply_context_options([_, _, _, _, Context]) ->
         {ok, ContextOptions} ->
             ContextSet = sets:from_list(Context),
             Result =
-                lists:append([apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
-                              apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)]),
+                lists:append([
+                    apply_context_match_empty_check(erldns_config:keyget(match_empty, ContextOptions), Context),
+                    apply_context_list_check(sets:from_list(erldns_config:keyget(allow, ContextOptions)), ContextSet)
+                ]),
             case lists:any(fun(I) -> I =:= pass end, Result) of
                 true ->
                     pass;
@@ -267,17 +293,21 @@ apply_context_options([_, _, _, _, Context]) ->
     end.
 
 json_record_to_list(JsonRecord) when is_map(JsonRecord) ->
-    [maps:get(<<"name">>, JsonRecord),
-     maps:get(<<"type">>, JsonRecord),
-     maps:get(<<"ttl">>, JsonRecord),
-     maps:get(<<"data">>, JsonRecord),
-     maps:get(<<"context">>, JsonRecord)];
+    [
+        maps:get(<<"name">>, JsonRecord),
+        maps:get(<<"type">>, JsonRecord),
+        maps:get(<<"ttl">>, JsonRecord),
+        maps:get(<<"data">>, JsonRecord),
+        maps:get(<<"context">>, JsonRecord)
+    ];
 json_record_to_list(JsonRecord) ->
-    [erldns_config:keyget(<<"name">>, JsonRecord),
-     erldns_config:keyget(<<"type">>, JsonRecord),
-     erldns_config:keyget(<<"ttl">>, JsonRecord),
-     erldns_config:keyget(<<"data">>, JsonRecord),
-     erldns_config:keyget(<<"context">>, JsonRecord)].
+    [
+        erldns_config:keyget(<<"name">>, JsonRecord),
+        erldns_config:keyget(<<"type">>, JsonRecord),
+        erldns_config:keyget(<<"ttl">>, JsonRecord),
+        erldns_config:keyget(<<"data">>, JsonRecord),
+        erldns_config:keyget(<<"context">>, JsonRecord)
+    ].
 
 try_custom_parsers([_Name, _Type, _Ttl, _Rdata, _Context], []) ->
     {};
@@ -294,46 +324,60 @@ json_record_to_erlang([Name, Type, _Ttl, Data = null, _]) ->
     erldns_events:notify({?MODULE, error, {Name, Type, Data, null_data}}),
     {};
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SOA,
-            data =
-                #dns_rrdata_soa{mname = maps:get(<<"mname">>, Data),
-                                rname = maps:get(<<"rname">>, Data),
-                                serial = maps:get(<<"serial">>, Data),
-                                refresh = maps:get(<<"refresh">>, Data),
-                                retry = maps:get(<<"retry">>, Data),
-                                expire = maps:get(<<"expire">>, Data),
-                                minimum = maps:get(<<"minimum">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SOA,
+        data =
+            #dns_rrdata_soa{
+                mname = maps:get(<<"mname">>, Data),
+                rname = maps:get(<<"rname">>, Data),
+                serial = maps:get(<<"serial">>, Data),
+                refresh = maps:get(<<"refresh">>, Data),
+                retry = maps:get(<<"retry">>, Data),
+                expire = maps:get(<<"expire">>, Data),
+                minimum = maps:get(<<"minimum">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"SOA">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SOA,
-            data =
-                #dns_rrdata_soa{mname = erldns_config:keyget(<<"mname">>, Data),
-                                rname = erldns_config:keyget(<<"rname">>, Data),
-                                serial = erldns_config:keyget(<<"serial">>, Data),
-                                refresh = erldns_config:keyget(<<"refresh">>, Data),
-                                retry = erldns_config:keyget(<<"retry">>, Data),
-                                expire = erldns_config:keyget(<<"expire">>, Data),
-                                minimum = erldns_config:keyget(<<"minimum">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SOA,
+        data =
+            #dns_rrdata_soa{
+                mname = erldns_config:keyget(<<"mname">>, Data),
+                rname = erldns_config:keyget(<<"rname">>, Data),
+                serial = erldns_config:keyget(<<"serial">>, Data),
+                refresh = erldns_config:keyget(<<"refresh">>, Data),
+                retry = erldns_config:keyget(<<"retry">>, Data),
+                expire = erldns_config:keyget(<<"expire">>, Data),
+                minimum = erldns_config:keyget(<<"minimum">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"NS">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NS,
-            data = #dns_rrdata_ns{dname = maps:get(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_NS,
+        data = #dns_rrdata_ns{dname = maps:get(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"NS">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NS,
-            data = #dns_rrdata_ns{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_NS,
+        data = #dns_rrdata_ns{dname = erldns_config:keyget(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) when is_map(Data) ->
     case inet_parse:address(binary_to_list(maps:get(<<"ip">>, Data))) of
         {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_A,
-                    data = #dns_rrdata_a{ip = Address},
-                    ttl = Ttl};
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_A,
+                data = #dns_rrdata_a{ip = Address},
+                ttl = Ttl
+            };
         {error, Reason} ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
             {}
@@ -341,10 +385,12 @@ json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) when is_map(D
 json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) ->
     case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
         {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_A,
-                    data = #dns_rrdata_a{ip = Address},
-                    ttl = Ttl};
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_A,
+                data = #dns_rrdata_a{ip = Address},
+                ttl = Ttl
+            };
         {error, Reason} ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
             {}
@@ -352,10 +398,12 @@ json_record_to_erlang([Name, Type = <<"A">>, Ttl, Data, _Context]) ->
 json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) when is_map(Data) ->
     case inet_parse:address(binary_to_list(maps:get(<<"ip">>, Data))) of
         {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_AAAA,
-                    data = #dns_rrdata_aaaa{ip = Address},
-                    ttl = Ttl};
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_AAAA,
+                data = #dns_rrdata_aaaa{ip = Address},
+                ttl = Ttl
+            };
         {error, Reason} ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
             {}
@@ -363,78 +411,108 @@ json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) when is_ma
 json_record_to_erlang([Name, Type = <<"AAAA">>, Ttl, Data, _Context]) ->
     case inet_parse:address(binary_to_list(erldns_config:keyget(<<"ip">>, Data))) of
         {ok, Address} ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_AAAA,
-                    data = #dns_rrdata_aaaa{ip = Address},
-                    ttl = Ttl};
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_AAAA,
+                data = #dns_rrdata_aaaa{ip = Address},
+                ttl = Ttl
+            };
         {error, Reason} ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Reason}}),
             {}
     end;
 json_record_to_erlang([Name, <<"CAA">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CAA,
-            data =
-                #dns_rrdata_caa{flags = maps:get(<<"flags">>, Data),
-                                tag = maps:get(<<"tag">>, Data),
-                                value = maps:get(<<"value">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_CAA,
+        data =
+            #dns_rrdata_caa{
+                flags = maps:get(<<"flags">>, Data),
+                tag = maps:get(<<"tag">>, Data),
+                value = maps:get(<<"value">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"CAA">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CAA,
-            data =
-                #dns_rrdata_caa{flags = erldns_config:keyget(<<"flags">>, Data),
-                                tag = erldns_config:keyget(<<"tag">>, Data),
-                                value = erldns_config:keyget(<<"value">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_CAA,
+        data =
+            #dns_rrdata_caa{
+                flags = erldns_config:keyget(<<"flags">>, Data),
+                tag = erldns_config:keyget(<<"tag">>, Data),
+                value = erldns_config:keyget(<<"value">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"CNAME">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CNAME,
-            data = #dns_rrdata_cname{dname = maps:get(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_CNAME,
+        data = #dns_rrdata_cname{dname = maps:get(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"CNAME">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_CNAME,
-            data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_CNAME,
+        data = #dns_rrdata_cname{dname = erldns_config:keyget(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"MX">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_MX,
-            data = #dns_rrdata_mx{exchange = maps:get(<<"exchange">>, Data), preference = maps:get(<<"preference">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_MX,
+        data = #dns_rrdata_mx{exchange = maps:get(<<"exchange">>, Data), preference = maps:get(<<"preference">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"MX">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_MX,
-            data = #dns_rrdata_mx{exchange = erldns_config:keyget(<<"exchange">>, Data), preference = erldns_config:keyget(<<"preference">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_MX,
+        data = #dns_rrdata_mx{
+            exchange = erldns_config:keyget(<<"exchange">>, Data), preference = erldns_config:keyget(<<"preference">>, Data)
+        },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"HINFO">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_HINFO,
-            data = #dns_rrdata_hinfo{cpu = maps:get(<<"cpu">>, Data), os = maps:get(<<"os">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_HINFO,
+        data = #dns_rrdata_hinfo{cpu = maps:get(<<"cpu">>, Data), os = maps:get(<<"os">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"HINFO">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_HINFO,
-            data = #dns_rrdata_hinfo{cpu = erldns_config:keyget(<<"cpu">>, Data), os = erldns_config:keyget(<<"os">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_HINFO,
+        data = #dns_rrdata_hinfo{cpu = erldns_config:keyget(<<"cpu">>, Data), os = erldns_config:keyget(<<"os">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"RP">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_RP,
-            data = #dns_rrdata_rp{mbox = maps:get(<<"mbox">>, Data), txt = maps:get(<<"txt">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_RP,
+        data = #dns_rrdata_rp{mbox = maps:get(<<"mbox">>, Data), txt = maps:get(<<"txt">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"RP">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_RP,
-            data = #dns_rrdata_rp{mbox = erldns_config:keyget(<<"mbox">>, Data), txt = erldns_config:keyget(<<"txt">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_RP,
+        data = #dns_rrdata_rp{mbox = erldns_config:keyget(<<"mbox">>, Data), txt = erldns_config:keyget(<<"txt">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, Type = <<"TXT">>, Ttl, Data, _Context]) when is_map(Data) ->
     %% This function call may crash. Handle it as a bad record.
     try erldns_txt:parse(maps:get(<<"txt">>, Data)) of
         ParsedText ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_TXT,
-                    data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_TXT,
+                data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -444,46 +522,60 @@ json_record_to_erlang([Name, Type = <<"TXT">>, Ttl, Data, _Context]) ->
     %% This function call may crash. Handle it as a bad record.
     try erldns_txt:parse(erldns_config:keyget(<<"txt">>, Data)) of
         ParsedText ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_TXT,
-                    data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_TXT,
+                data = #dns_rrdata_txt{txt = lists:flatten(ParsedText)},
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
             {}
     end;
 json_record_to_erlang([Name, <<"SPF">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SPF,
-            data = #dns_rrdata_spf{spf = [maps:get(<<"spf">>, Data)]},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SPF,
+        data = #dns_rrdata_spf{spf = [maps:get(<<"spf">>, Data)]},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"SPF">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SPF,
-            data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SPF,
+        data = #dns_rrdata_spf{spf = [erldns_config:keyget(<<"spf">>, Data)]},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"PTR">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_PTR,
-            data = #dns_rrdata_ptr{dname = maps:get(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_PTR,
+        data = #dns_rrdata_ptr{dname = maps:get(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"PTR">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_PTR,
-            data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_PTR,
+        data = #dns_rrdata_ptr{dname = erldns_config:keyget(<<"dname">>, Data)},
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, Type = <<"SSHFP">>, Ttl, Data, _Context]) when is_map(Data) ->
     %% This function call may crash. Handle it as a bad record.
     try hex_to_bin(maps:get(<<"fp">>, Data)) of
         Fp ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_SSHFP,
-                    data =
-                        #dns_rrdata_sshfp{alg = maps:get(<<"alg">>, Data),
-                                          fp_type = maps:get(<<"fptype">>, Data),
-                                          fp = Fp},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_SSHFP,
+                data =
+                    #dns_rrdata_sshfp{
+                        alg = maps:get(<<"alg">>, Data),
+                        fp_type = maps:get(<<"fptype">>, Data),
+                        fp = Fp
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -493,69 +585,93 @@ json_record_to_erlang([Name, Type = <<"SSHFP">>, Ttl, Data, _Context]) ->
     %% This function call may crash. Handle it as a bad record.
     try hex_to_bin(erldns_config:keyget(<<"fp">>, Data)) of
         Fp ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_SSHFP,
-                    data =
-                        #dns_rrdata_sshfp{alg = erldns_config:keyget(<<"alg">>, Data),
-                                          fp_type = erldns_config:keyget(<<"fptype">>, Data),
-                                          fp = Fp},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_SSHFP,
+                data =
+                    #dns_rrdata_sshfp{
+                        alg = erldns_config:keyget(<<"alg">>, Data),
+                        fp_type = erldns_config:keyget(<<"fptype">>, Data),
+                        fp = Fp
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
             {}
     end;
 json_record_to_erlang([Name, <<"SRV">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SRV,
-            data =
-                #dns_rrdata_srv{priority = maps:get(<<"priority">>, Data),
-                                weight = maps:get(<<"weight">>, Data),
-                                port = maps:get(<<"port">>, Data),
-                                target = maps:get(<<"target">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SRV,
+        data =
+            #dns_rrdata_srv{
+                priority = maps:get(<<"priority">>, Data),
+                weight = maps:get(<<"weight">>, Data),
+                port = maps:get(<<"port">>, Data),
+                target = maps:get(<<"target">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"SRV">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SRV,
-            data =
-                #dns_rrdata_srv{priority = erldns_config:keyget(<<"priority">>, Data),
-                                weight = erldns_config:keyget(<<"weight">>, Data),
-                                port = erldns_config:keyget(<<"port">>, Data),
-                                target = erldns_config:keyget(<<"target">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SRV,
+        data =
+            #dns_rrdata_srv{
+                priority = erldns_config:keyget(<<"priority">>, Data),
+                weight = erldns_config:keyget(<<"weight">>, Data),
+                port = erldns_config:keyget(<<"port">>, Data),
+                target = erldns_config:keyget(<<"target">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"NAPTR">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NAPTR,
-            data =
-                #dns_rrdata_naptr{order = maps:get(<<"order">>, Data),
-                                  preference = maps:get(<<"preference">>, Data),
-                                  flags = maps:get(<<"flags">>, Data),
-                                  services = maps:get(<<"services">>, Data),
-                                  regexp = maps:get(<<"regexp">>, Data),
-                                  replacement = maps:get(<<"replacement">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_NAPTR,
+        data =
+            #dns_rrdata_naptr{
+                order = maps:get(<<"order">>, Data),
+                preference = maps:get(<<"preference">>, Data),
+                flags = maps:get(<<"flags">>, Data),
+                services = maps:get(<<"services">>, Data),
+                regexp = maps:get(<<"regexp">>, Data),
+                replacement = maps:get(<<"replacement">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"NAPTR">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_NAPTR,
-            data =
-                #dns_rrdata_naptr{order = erldns_config:keyget(<<"order">>, Data),
-                                  preference = erldns_config:keyget(<<"preference">>, Data),
-                                  flags = erldns_config:keyget(<<"flags">>, Data),
-                                  services = erldns_config:keyget(<<"services">>, Data),
-                                  regexp = erldns_config:keyget(<<"regexp">>, Data),
-                                  replacement = erldns_config:keyget(<<"replacement">>, Data)},
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_NAPTR,
+        data =
+            #dns_rrdata_naptr{
+                order = erldns_config:keyget(<<"order">>, Data),
+                preference = erldns_config:keyget(<<"preference">>, Data),
+                flags = erldns_config:keyget(<<"flags">>, Data),
+                services = erldns_config:keyget(<<"services">>, Data),
+                regexp = erldns_config:keyget(<<"regexp">>, Data),
+                replacement = erldns_config:keyget(<<"replacement">>, Data)
+            },
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) when is_map(Data) ->
     try hex_to_bin(maps:get(<<"digest">>, Data)) of
         Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_DS,
-                    data =
-                        #dns_rrdata_ds{keytag = maps:get(<<"keytag">>, Data),
-                                       alg = maps:get(<<"alg">>, Data),
-                                       digest_type = maps:get(<<"digest_type">>, Data),
-                                       digest = Digest},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_DS,
+                data =
+                    #dns_rrdata_ds{
+                        keytag = maps:get(<<"keytag">>, Data),
+                        alg = maps:get(<<"alg">>, Data),
+                        digest_type = maps:get(<<"digest_type">>, Data),
+                        digest = Digest
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -564,14 +680,18 @@ json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) when is_map(
 json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) ->
     try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
         Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_DS,
-                    data =
-                        #dns_rrdata_ds{keytag = erldns_config:keyget(<<"keytag">>, Data),
-                                       alg = erldns_config:keyget(<<"alg">>, Data),
-                                       digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                                       digest = Digest},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_DS,
+                data =
+                    #dns_rrdata_ds{
+                        keytag = erldns_config:keyget(<<"keytag">>, Data),
+                        alg = erldns_config:keyget(<<"alg">>, Data),
+                        digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                        digest = Digest
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -580,14 +700,18 @@ json_record_to_erlang([Name, Type = <<"DS">>, Ttl, Data, _Context]) ->
 json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) when is_map(Data) ->
     try hex_to_bin(maps:get(<<"digest">>, Data)) of
         Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_CDS,
-                    data =
-                        #dns_rrdata_cds{keytag = maps:get(<<"keytag">>, Data),
-                                        alg = maps:get(<<"alg">>, Data),
-                                        digest_type = maps:get(<<"digest_type">>, Data),
-                                        digest = Digest},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_CDS,
+                data =
+                    #dns_rrdata_cds{
+                        keytag = maps:get(<<"keytag">>, Data),
+                        alg = maps:get(<<"alg">>, Data),
+                        digest_type = maps:get(<<"digest_type">>, Data),
+                        digest = Digest
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -596,14 +720,18 @@ json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) when is_map
 json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) ->
     try hex_to_bin(erldns_config:keyget(<<"digest">>, Data)) of
         Digest ->
-            #dns_rr{name = Name,
-                    type = ?DNS_TYPE_CDS,
-                    data =
-                        #dns_rrdata_cds{keytag = erldns_config:keyget(<<"keytag">>, Data),
-                                        alg = erldns_config:keyget(<<"alg">>, Data),
-                                        digest_type = erldns_config:keyget(<<"digest_type">>, Data),
-                                        digest = Digest},
-                    ttl = Ttl}
+            #dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_CDS,
+                data =
+                    #dns_rrdata_cds{
+                        keytag = erldns_config:keyget(<<"keytag">>, Data),
+                        alg = erldns_config:keyget(<<"alg">>, Data),
+                        digest_type = erldns_config:keyget(<<"digest_type">>, Data),
+                        digest = Digest
+                    },
+                ttl = Ttl
+            }
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -612,14 +740,18 @@ json_record_to_erlang([Name, Type = <<"CDS">>, Ttl, Data, _Context]) ->
 json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) when is_map(Data) ->
     try base64_to_bin(maps:get(<<"public_key">>, Data)) of
         PublicKey ->
-            dnssec:add_keytag_to_dnskey(#dns_rr{name = Name,
-                                                type = ?DNS_TYPE_DNSKEY,
-                                                data =
-                                                    #dns_rrdata_dnskey{flags = maps:get(<<"flags">>, Data),
-                                                                       protocol = maps:get(<<"protocol">>, Data),
-                                                                       alg = maps:get(<<"alg">>, Data),
-                                                                       public_key = PublicKey},
-                                                ttl = Ttl})
+            dnssec:add_keytag_to_dnskey(#dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_DNSKEY,
+                data =
+                    #dns_rrdata_dnskey{
+                        flags = maps:get(<<"flags">>, Data),
+                        protocol = maps:get(<<"protocol">>, Data),
+                        alg = maps:get(<<"alg">>, Data),
+                        public_key = PublicKey
+                    },
+                ttl = Ttl
+            })
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -628,14 +760,18 @@ json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) when is_
 json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) ->
     try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
         PublicKey ->
-            dnssec:add_keytag_to_dnskey(#dns_rr{name = Name,
-                                                type = ?DNS_TYPE_DNSKEY,
-                                                data =
-                                                    #dns_rrdata_dnskey{flags = erldns_config:keyget(<<"flags">>, Data),
-                                                                       protocol = erldns_config:keyget(<<"protocol">>, Data),
-                                                                       alg = erldns_config:keyget(<<"alg">>, Data),
-                                                                       public_key = PublicKey},
-                                                ttl = Ttl})
+            dnssec:add_keytag_to_dnskey(#dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_DNSKEY,
+                data =
+                    #dns_rrdata_dnskey{
+                        flags = erldns_config:keyget(<<"flags">>, Data),
+                        protocol = erldns_config:keyget(<<"protocol">>, Data),
+                        alg = erldns_config:keyget(<<"alg">>, Data),
+                        public_key = PublicKey
+                    },
+                ttl = Ttl
+            })
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -644,14 +780,18 @@ json_record_to_erlang([Name, Type = <<"DNSKEY">>, Ttl, Data, _Context]) ->
 json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) when is_map(Data) ->
     try base64_to_bin(maps:get(<<"public_key">>, Data)) of
         PublicKey ->
-            dnssec:add_keytag_to_cdnskey(#dns_rr{name = Name,
-                                                 type = ?DNS_TYPE_CDNSKEY,
-                                                 data =
-                                                     #dns_rrdata_cdnskey{flags = maps:get(<<"flags">>, Data),
-                                                                         protocol = maps:get(<<"protocol">>, Data),
-                                                                         alg = maps:get(<<"alg">>, Data),
-                                                                         public_key = PublicKey},
-                                                 ttl = Ttl})
+            dnssec:add_keytag_to_cdnskey(#dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_CDNSKEY,
+                data =
+                    #dns_rrdata_cdnskey{
+                        flags = maps:get(<<"flags">>, Data),
+                        protocol = maps:get(<<"protocol">>, Data),
+                        alg = maps:get(<<"alg">>, Data),
+                        public_key = PublicKey
+                    },
+                ttl = Ttl
+            })
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -660,14 +800,18 @@ json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) when is
 json_record_to_erlang([Name, Type = <<"CDNSKEY">>, Ttl, Data, _Context]) ->
     try base64_to_bin(erldns_config:keyget(<<"public_key">>, Data)) of
         PublicKey ->
-            dnssec:add_keytag_to_cdnskey(#dns_rr{name = Name,
-                                                 type = ?DNS_TYPE_CDNSKEY,
-                                                 data =
-                                                     #dns_rrdata_cdnskey{flags = erldns_config:keyget(<<"flags">>, Data),
-                                                                         protocol = erldns_config:keyget(<<"protocol">>, Data),
-                                                                         alg = erldns_config:keyget(<<"alg">>, Data),
-                                                                         public_key = PublicKey},
-                                                 ttl = Ttl})
+            dnssec:add_keytag_to_cdnskey(#dns_rr{
+                name = Name,
+                type = ?DNS_TYPE_CDNSKEY,
+                data =
+                    #dns_rrdata_cdnskey{
+                        flags = erldns_config:keyget(<<"flags">>, Data),
+                        protocol = erldns_config:keyget(<<"protocol">>, Data),
+                        alg = erldns_config:keyget(<<"alg">>, Data),
+                        public_key = PublicKey
+                    },
+                ttl = Ttl
+            })
     catch
         Exception:Reason ->
             erldns_events:notify({?MODULE, error, {Name, Type, Data, Exception, Reason}}),
@@ -678,12 +822,12 @@ json_record_to_erlang(_Data) ->
 
 hex_to_bin(Bin) when is_binary(Bin) ->
     Fun = fun(A, B) ->
-             case io_lib:fread("~16u", [A, B]) of
-                 {ok, [V], []} -> V;
-                 _ -> error(badarg)
-             end
-          end,
-    << <<(Fun(A, B))>> || <<A, B>> <= Bin >>.
+        case io_lib:fread("~16u", [A, B]) of
+            {ok, [V], []} -> V;
+            _ -> error(badarg)
+        end
+    end,
+    <<<<(Fun(A, B))>> || <<A, B>> <= Bin>>.
 
 base64_to_bin(Bin) when is_binary(Bin) ->
     base64:decode(Bin).
@@ -691,92 +835,96 @@ base64_to_bin(Bin) when is_binary(Bin) ->
 -ifdef(TEST).
 
 json_to_erlang_test() ->
-    json_to_erlang(jsx:decode(<<"{\"name\":\"example.com\",\"sha\":\"10ea56ad7be9d3e6e75be3a15ef0dfabe9facafba486d74914e7baf8fb36638e\",\"rec"
-                                "ords\":[{\"name\":\"example.com\",\"type\":\"SOA\",\"data\":{\"mname\":\"ns1.dnsimple.com\",\"rname\":\"admi"
-                                "n.dnsimple.com\",\"serial\":1597990915,\"refresh\":86400,\"retry\":7200,\"expire\":604800,\"minimum\":300},\""
-                                "ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"NS\",\"data\":{\"dname\":\"ns1.dn"
-                                "simple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"NS\",\"data\":{\""
-                                "dname\":\"ns2.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"N"
-                                "S\",\"data\":{\"dname\":\"ns3.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.co"
-                                "m\",\"type\":\"NS\",\"data\":{\"dname\":\"ns4.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"nam"
-                                "e\":\"*.qa.example.com\",\"type\":\"A\",\"data\":{\"ip\":\"5.4.3.2\"},\"ttl\":3600,\"context\":[]},{\"name\""
-                                ":\"example.com\",\"type\":\"A\",\"data\":{\"ip\":\"1.2.3.4\"},\"ttl\":3600,\"context\":[]},{\"name\":\"examp"
-                                "le.com\",\"type\":\"AAAA\",\"data\":{\"ip\":\"2001:db8:0:0:0:0:2:1\"},\"ttl\":3600,\"context\":[]},{\"name\""
-                                ":\"www.example.com\",\"type\":\"CNAME\",\"data\":{\"dname\":\"example.com\"},\"ttl\":3600,\"context\":[]},{\""
-                                "name\":\"example.com\",\"type\":\"CAA\",\"data\":{\"flags\":0,\"tag\":\"issue\",\"value\":\"comodoca.com\"},\""
-                                "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"MX\",\"data\":{\"preference\":10,\"exchange\""
-                                ":\"mailserver.foo.com\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"TXT\",\"data\":{\""
-                                "txt\":\"this is a test\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"SPF\",\"data\":{\""
-                                "spf\":\"v=spf1 a mx ~all\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"TXT\",\"data\""
-                                ":{\"txt\":\"v=spf1 a mx ~all\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"SSHFP\",\""
-                                "data\":{\"alg\":3,\"fptype\":2,\"fp\":\"ABC123\"},\"ttl\":3600,\"context\":[]},{\"name\":\"_foo._bar.example"
-                                ".com\",\"type\":\"SRV\",\"data\":{\"priority\":20,\"weight\":10,\"port\":3333,\"target\":\"example.net\"},\""
-                                "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"NAPTR\",\"data\":{\"order\":5,\"preference\""
-                                ":10,\"flags\":\"u\",\"services\":\"foo\",\"regexp\":\"https:\/\/example\\\\.net\",\"replacement\":\"example."
-                                "org\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"A\",\"data\":{\"ip\":\"5.5.5.5\"},\""
-                                "ttl\":3600,\"context\":[\"SV1\"]},{\"name\":\"example.com\",\"type\":\"HINFO\",\"data\":{\"cpu\":\"cpu\",\"o"
-                                "s\":\"os\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":2"
-                                "57,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAcFwY\/oPw5JPGTT2qf2opNMpNAopxC6xWvGO2QAKA7ERAzKYsiXt7j1\/t"
-                                "tJjgnLS2Qj30bbnRyazj7Lg9oZcmiJ4\/cfBHLBczzaxtqwZrxX1rcQz1OpU\/hnq4W5Rsk2i1hxdpRjLnVfddVFD3GDDgIEjvaiKtaJcA61"
-                                "WtDDA08Ba90S7czkUh2Nfv7cTYEFhjnx0bdtapwRQEirHjzyAJqs=\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\""
-                                ":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":256,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAA"
-                                "ddpSYg8TvfhxHRTG1zrCPXWuG\/gN0\/q2dzQtM3um6zVl0sIFQKWfcdcowpim13K4euSqzltBB+XwDjv9fbWb6xi0mTF0c0NgOQ\/Ctf5sQ"
-                                "OBtGBkopbQgxDuXDTC1jJaUTVlzjN9m8KYoVacTbhMFBAtwn6LC1sEYfwiCsADk3cV\",\"key_tag\":0},\"ttl\":3600,\"context\""
-                                ":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":257,\"protocol\":3,\"alg\":8,\"public"
-                                "_key\":\"AwEAAbPhmoznnzWMbx0h+RcyI+Bi2tzlOnd\/AbZK7iXgGY62lZo442+6TpZNlkeFEqk+YKxUce70RWkG\/LHuJeywfmPySSra2"
-                                "rYG3P3ntAgbcrbwMDa9cmYVEnS2+ObEFeqowcoe4kjzy5249skMn9Hl8D5pWXp0EbzOSuKSRDFEaGfNycvc8\/VfcEi8LwUffTkq8ZFE9P6Q"
-                                "EqyeDM4yO2XmoSs=\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\""
-                                ",\"data\":{\"flags\":256,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAdAKvoBtIj2GzLpawDNm\/ztuuxIbU2lticK5"
-                                "lMwisLN8HY1QXjdFk+pOCHp1XsS2Odd6rQyy\/IJvBEFFeeZDoyUeoa2i93STTETMZZ\/dX1YtJPQnw8MJ0buxfeCxZGRVmbpu4p+YeZ2AFN"
-                                "1ZSziKD7HununBWFXQc7vHRK0QSBTH\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"typ"
-                                "e\":\"CDNSKEY\",\"data\":{\"flags\":257,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAbPhmoznnzWMbx0h+RcyI+"
-                                "Bi2tzlOnd\/AbZK7iXgGY62lZo442+6TpZNlkeFEqk+YKxUce70RWkG\/LHuJeywfmPySSra2rYG3P3ntAgbcrbwMDa9cmYVEnS2+ObEFeqo"
-                                "wcoe4kjzy5249skMn9Hl8D5pWXp0EbzOSuKSRDFEaGfNycvc8\/VfcEi8LwUffTkq8ZFE9P6QEqyeDM4yO2XmoSs=\",\"key_tag\":0},\""
-                                "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"CDS\",\"data\":{\"flags\":61079,\"alg\":8,\""
-                                "digest_type\":2,\"digest\":\"933FE542B3351226B7D0460EBFCB3D48909106B052E803E04063ACC179D3664B\",\"keytag\":0"
-                                "},\"ttl\":3600,\"context\":[]}],\"keys\":[{\"ksk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIIC7AIBAAKBoQDBcGP6D"
-                                "8OSTxk09qn9qKTTKTQKKcQusVrxjtkACgOxEQMymLIl\\n7e49f7bSY4Jy0tkI99G250cms4+y4PaGXJoieP3HwRywXM82sbasGa8V9a3EM9"
-                                "Tq\\nVP4Z6uFuUbJNotYcXaUYy51X3XVRQ9xgw4CBI72oirWiXAOtVrQwwNPAWvdEu3M5\\nFIdjX7+3E2BBYY58dG3bWqcEUBIqx488gCar"
-                                "AgMBAAECgaBZk\/9oVJZ\/kYudwEB2\\nS\/uQIbuMnUzRRqZTyI\/q+bg97h\/p9VZCRE2YQyVZhmVpYQTKp2CBb9a+MFbyQkVH\\ncWibY"
-                                "CY9s8riTQhUTrXGOtqesumWkTDdacbyuMjobme4WPX8L3xlX5spttpkZQfc\\neC0hpwX8bKRUuQifHPAhjuYxcVWIOZk5OaprHxwoXtM0oS"
-                                "NPaGiPCM0fq4GmnF1n\\n3Eg5AlEA4aB6F0pG5ajnycvWETz\/WZpv\/wkcO0UlbgSFlx2OD545CKYcZlbx22bl\\nWvYHvkio1AAg03oFQf"
-                                "XNtcl6274s2WFEJw5v0UBk0VHGq2zeTDUCUQDbeqkepngF\\njyuRSzfViuA3jpO\/8zmFm6Fpr5eCNgqEf+uC7zF+dg9bnnfEA88+x8Ijui"
-                                "oRvbx7\\nkSMjiIijQUgo103vXadpPhBXFx7EadBDXwJQV0wtEQfXKJLSo\/xvJhpQvk2H2cif\\nmLsnQUsUmSSBS7+vV45V3K71QyurwCc"
-                                "DVfdtAyHNkaVblWrSneyH0a\/iUHVW1jm6\\nv97HY0ndsYQc+qUCUQC3Al24wAh+YjZq7bR97FIwIUQUH4TMYsxCKveDzPoSJ\/RC\\ndp7"
-                                "nmxwNQmMNYDvUVo8MaXQg3PwocQpC29tLfejknTtQJ+CrgePwKsgt8SmGswJQ\\nVt10NCsGdK7ACTz1Asfcb4JQUYM\/d14ofhJRHptROLE"
-                                "93gHx9He+JGq4ET74YQvd\\nD8V0L923eLixsHh5I5t\/1QEVwbpeGcDhb+j8LeVvV8w=\\n-----END RSA PRIVATE KEY-----\\n\",\""
-                                "ksk_keytag\":57949,\"ksk_alg\":8,\"zsk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIICXQIBAAKBgQDXaUmIPE734cR0Uxt"
-                                "c6wj11rhv4DdP6tnc0LTN7pus1ZdLCBUC\\nln3HXKMKYptdyuHrkqs5bQQfl8A47\/X21m+sYtJkxdHNDYDkPwrX+bEDgbRgZKKW\\n0IMQ"
-                                "7lw0wtYyWlE1Zc4zfZvCmKFWnE24TBQQLcJ+iwtbBGH8IgrAA5N3FQIDAQAB\\nAoGBAIozFGgBOTCzedSflQiSChefAIlWMmZlaAzRIY6VL"
-                                "O8\/wWbz8nbMkjmbZ0a8\\naK1OAo+ec5fOJz0VoM9mtEj+3nlvQoJBw1ubBy4o3yr6X8dOwyEqtH8Riciv9XlE\\nDg6uQH8u52CErzYd7i"
-                                "o9NVn+vQZEFdw1kwy9bHl6Zb+SwwWpAkEA69Dw7b2VC4aP\\na\/wr0\/xME2hXb7qf2YsH3GreJHTH1D7fdQozKdw4o8tUFjKvOTy827N2X"
-                                "7PSp+cW\\nXYzk7Pp7nwJBAOnZPx2KK58IqBdmRpSfdQmstbC9k9SWby1NxH7xerepdRr+Fvnr\\nSVZo4JcIyWk1FVUHd9ZNIagIJZhE2tR"
-                                "WkMsCQDPX05\/wtfu6sX1ECz6nkPITVmWx\\n2cKx1iCXPg81vVjkGaxZebYSPEGGSg43Rl6HA94pLjUMC5vuKfSXLR0MVHECQEWu\\n6ADc"
-                                "cH02bihy4KtfDNgyL\/4Xr9qUbVK5rskJGkFqbKv7dUtJ0pO+Mtau1p3UJKQu\\n0oX4fAP\/UXybX\/4QQZsCQQCcym4PAXhtW5U1FmV\/d"
-                                "GCMb8rufZt7bmHHPulrAIVv\\n5Zse+HIV\/u0c36RRHSRuW4MPICrHE7Uf5B7\/7TcWp3nZ\\n-----END RSA PRIVATE KEY-----\\n\""
-                                ",\"zsk_keytag\":15271,\"zsk_alg\":8,\"inception\":\"2020-12-02T08:38:09.631363Z\",\"until\":\"2021-03-02T08:"
-                                "38:09.630312Z\"},{\"ksk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIIC7QIBAAKBoQCz4ZqM5581jG8dIfkXMiPgYtrc5Tp3fw"
-                                "G2Su4l4BmOtpWaOONv\\nuk6WTZZHhRKpPmCsVHHu9EVpBvyx7iXssH5j8kkq2tq2Btz957QIG3K28DA2vXJm\\nFRJ0tvjmxBXqqMHKHuJI"
-                                "88uduPbJDJ\/R5fA+aVl6dBG8zkrikkQxRGhnzcnL3PP1\\nX3BIvC8FH305KvGRRPT+kBKsngzOMjtl5qErAgMBAAECgaEAmKofJfkqaSMP"
-                                "5pS\/\\nuA0I39ZmU9WEgohbJqB\/b8u7RSD25RXlCR0At5WPtpFdHiBfocJlk9ziz9lrO4OX\\n0kKUcjTeHi3yM0yt4Bv28m6BNHpFvrdo"
-                                "31jOpSkvYzcip2LdYENMTxAi4NSsDDQg\\nLjuxbKJskvHgwz73XXj9g6X0uiotTzuUnT0gWJvIDykeXnoru2U2YfYjsN4uSHJF\\nPWYlwQ"
-                                "JRAOgxqQv1pe7VSQ4sLAnwW3NsGPMHCmAbmcbsjxnPj8Wjf4L0ervHxebt\\nnZOCaUlUxZm9X8GiONZAGMG2xPz6tuKYz9wE\/6j+9jtFe2"
-                                "5alaCLAlEAxlLnapw5\\ne3oYElrw1MR1aNOwiSXJuhQ8wlM6EifuV9HA\/Aq3AApOoKmwL3n9EqfxuZbFmuRA\\nu4FB78tFckIyhqhxHNz"
-                                "9KNZR5ZkwUdWvdeECUBLk\/6GWgsM1nfVGSOsiIP76e+lC\\n2GhLtq7GTzrFdiiaDmVEqbwgHI2XJmx7fz\/VYyMIkwM5xTBCFQGmcs83Q6"
-                                "yazMdV\\nrMw+uyDFna60NlrTAlBnPVkCgnjZ8mD9jSG5YNvNygUoH+e3WjmW30RnlynXxXU0\\nv08sUjFEKZFx5Yr8XzjSZ85OJ2wbL9pn"
-                                "PeXU6OjseFsJr3CKBad0Yh5pO1evgQJR\\nAMFyXCvulXFDKMqV3ePut7pMGGTUl53qoEOYGPsokl+C2Ho7sOgR2wzNLpchYZNr\\nS4eCZD"
-                                "PgcC+1JAVOUoDK8IyPbnQaZ0K3kGWxPpzC29xj\\n-----END RSA PRIVATE KEY-----\\n\",\"ksk_keytag\":61079,\"ksk_alg\""
-                                ":8,\"zsk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIICXQIBAAKBgQDQCr6AbSI9hsy6WsAzZv87brsSG1NpbYnCuZTMIrCzfB2NU"
-                                "F43\\nRZPqTgh6dV7EtjnXeq0MsvyCbwRBRXnmQ6MlHqGtovd0k0xEzGWf3V9WLST0J8PD\\nCdG7sX3gsWRkVZm6buKfmHmdgBTdWUs4ig+"
-                                "x7p7pwVhV0HO7x0StEEgUxwIDAQAB\\nAoGANs891TPrW25SLZ6PGHvALnZDzsdoOFRlgOnHq+hPyVmfp4VO7RzllUstrKWT\\nbBveLUjio"
-                                "n\/dSrfY1SFqtiGHr1w7tzTW39kTEdca4lvUtSmt7\/\/wrEV0GLsgHwnZ\\nVVyCuH0PpRcSmYYVYrSsCEH9\/mXxs8Fq0tsn+wMls7O1WW"
-                                "ECQQDruuKG\/X\/tYmps\\nm239lLH8VyDRqQmX3mdtz+uKI8J37a+emd7lOWmkqa6b2ep+sZPDEk8xR7ktSiDb\\nAhyf85jvAkEA4e5dBt"
-                                "UG05ieO+XtzvZOdMiU4zdWSAtgIyqegXunnvulwddEFbw0\\njwRzW5MYo0eTRfgaS0obMw8uZ0hN7zPRqQJBAOH1+ZCWTNta\/FLxRqTNtT"
-                                "MCvcXb\\nuANowFIl\/U0kbBQTtcVdD6lAuICL2oEwiTQ6uj5CPcEqVFoSdZ4ZzyCQG+cCQDBv\\ni54FWXtPgszQlFUEVPmQburvWB4F4kx"
-                                "nvKeBvQPGa1jNL5mBSbtHdvuw411N4PLl\\nJ63wazhdDtOxmpOnhlECQQCfdp\/ZOAKUalTUuqZLgIGwobDAmcOzXN\/85WWlWLIx\\nDf1"
-                                "j0nabGCBLJt6VB0oVHd9a7rC7oTcl3TjO3kP9Zhts\\n-----END RSA PRIVATE KEY-----\\n\",\"zsk_keytag\":49225,\"zsk_al"
-                                "g\":8,\"inception\":\"2020-12-02T10:45:48.279746Z\",\"until\":\"2021-03-02T10:45:48.279414Z\"}]}">>),
-                   []).
+    json_to_erlang(
+        jsx:decode(<<
+            "{\"name\":\"example.com\",\"sha\":\"10ea56ad7be9d3e6e75be3a15ef0dfabe9facafba486d74914e7baf8fb36638e\",\"rec"
+            "ords\":[{\"name\":\"example.com\",\"type\":\"SOA\",\"data\":{\"mname\":\"ns1.dnsimple.com\",\"rname\":\"admi"
+            "n.dnsimple.com\",\"serial\":1597990915,\"refresh\":86400,\"retry\":7200,\"expire\":604800,\"minimum\":300},\""
+            "ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"NS\",\"data\":{\"dname\":\"ns1.dn"
+            "simple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"NS\",\"data\":{\""
+            "dname\":\"ns2.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.com\",\"type\":\"N"
+            "S\",\"data\":{\"dname\":\"ns3.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"name\":\"example.co"
+            "m\",\"type\":\"NS\",\"data\":{\"dname\":\"ns4.dnsimple.com\"},\"ttl\":3600,\"context\":[\"anycast\"]},{\"nam"
+            "e\":\"*.qa.example.com\",\"type\":\"A\",\"data\":{\"ip\":\"5.4.3.2\"},\"ttl\":3600,\"context\":[]},{\"name\""
+            ":\"example.com\",\"type\":\"A\",\"data\":{\"ip\":\"1.2.3.4\"},\"ttl\":3600,\"context\":[]},{\"name\":\"examp"
+            "le.com\",\"type\":\"AAAA\",\"data\":{\"ip\":\"2001:db8:0:0:0:0:2:1\"},\"ttl\":3600,\"context\":[]},{\"name\""
+            ":\"www.example.com\",\"type\":\"CNAME\",\"data\":{\"dname\":\"example.com\"},\"ttl\":3600,\"context\":[]},{\""
+            "name\":\"example.com\",\"type\":\"CAA\",\"data\":{\"flags\":0,\"tag\":\"issue\",\"value\":\"comodoca.com\"},\""
+            "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"MX\",\"data\":{\"preference\":10,\"exchange\""
+            ":\"mailserver.foo.com\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"TXT\",\"data\":{\""
+            "txt\":\"this is a test\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"SPF\",\"data\":{\""
+            "spf\":\"v=spf1 a mx ~all\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"TXT\",\"data\""
+            ":{\"txt\":\"v=spf1 a mx ~all\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"SSHFP\",\""
+            "data\":{\"alg\":3,\"fptype\":2,\"fp\":\"ABC123\"},\"ttl\":3600,\"context\":[]},{\"name\":\"_foo._bar.example"
+            ".com\",\"type\":\"SRV\",\"data\":{\"priority\":20,\"weight\":10,\"port\":3333,\"target\":\"example.net\"},\""
+            "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"NAPTR\",\"data\":{\"order\":5,\"preference\""
+            ":10,\"flags\":\"u\",\"services\":\"foo\",\"regexp\":\"https:\/\/example\\\\.net\",\"replacement\":\"example."
+            "org\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"A\",\"data\":{\"ip\":\"5.5.5.5\"},\""
+            "ttl\":3600,\"context\":[\"SV1\"]},{\"name\":\"example.com\",\"type\":\"HINFO\",\"data\":{\"cpu\":\"cpu\",\"o"
+            "s\":\"os\"},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":2"
+            "57,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAcFwY\/oPw5JPGTT2qf2opNMpNAopxC6xWvGO2QAKA7ERAzKYsiXt7j1\/t"
+            "tJjgnLS2Qj30bbnRyazj7Lg9oZcmiJ4\/cfBHLBczzaxtqwZrxX1rcQz1OpU\/hnq4W5Rsk2i1hxdpRjLnVfddVFD3GDDgIEjvaiKtaJcA61"
+            "WtDDA08Ba90S7czkUh2Nfv7cTYEFhjnx0bdtapwRQEirHjzyAJqs=\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\""
+            ":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":256,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAA"
+            "ddpSYg8TvfhxHRTG1zrCPXWuG\/gN0\/q2dzQtM3um6zVl0sIFQKWfcdcowpim13K4euSqzltBB+XwDjv9fbWb6xi0mTF0c0NgOQ\/Ctf5sQ"
+            "OBtGBkopbQgxDuXDTC1jJaUTVlzjN9m8KYoVacTbhMFBAtwn6LC1sEYfwiCsADk3cV\",\"key_tag\":0},\"ttl\":3600,\"context\""
+            ":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\",\"data\":{\"flags\":257,\"protocol\":3,\"alg\":8,\"public"
+            "_key\":\"AwEAAbPhmoznnzWMbx0h+RcyI+Bi2tzlOnd\/AbZK7iXgGY62lZo442+6TpZNlkeFEqk+YKxUce70RWkG\/LHuJeywfmPySSra2"
+            "rYG3P3ntAgbcrbwMDa9cmYVEnS2+ObEFeqowcoe4kjzy5249skMn9Hl8D5pWXp0EbzOSuKSRDFEaGfNycvc8\/VfcEi8LwUffTkq8ZFE9P6Q"
+            "EqyeDM4yO2XmoSs=\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"DNSKEY\""
+            ",\"data\":{\"flags\":256,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAdAKvoBtIj2GzLpawDNm\/ztuuxIbU2lticK5"
+            "lMwisLN8HY1QXjdFk+pOCHp1XsS2Odd6rQyy\/IJvBEFFeeZDoyUeoa2i93STTETMZZ\/dX1YtJPQnw8MJ0buxfeCxZGRVmbpu4p+YeZ2AFN"
+            "1ZSziKD7HununBWFXQc7vHRK0QSBTH\",\"key_tag\":0},\"ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"typ"
+            "e\":\"CDNSKEY\",\"data\":{\"flags\":257,\"protocol\":3,\"alg\":8,\"public_key\":\"AwEAAbPhmoznnzWMbx0h+RcyI+"
+            "Bi2tzlOnd\/AbZK7iXgGY62lZo442+6TpZNlkeFEqk+YKxUce70RWkG\/LHuJeywfmPySSra2rYG3P3ntAgbcrbwMDa9cmYVEnS2+ObEFeqo"
+            "wcoe4kjzy5249skMn9Hl8D5pWXp0EbzOSuKSRDFEaGfNycvc8\/VfcEi8LwUffTkq8ZFE9P6QEqyeDM4yO2XmoSs=\",\"key_tag\":0},\""
+            "ttl\":3600,\"context\":[]},{\"name\":\"example.com\",\"type\":\"CDS\",\"data\":{\"flags\":61079,\"alg\":8,\""
+            "digest_type\":2,\"digest\":\"933FE542B3351226B7D0460EBFCB3D48909106B052E803E04063ACC179D3664B\",\"keytag\":0"
+            "},\"ttl\":3600,\"context\":[]}],\"keys\":[{\"ksk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIIC7AIBAAKBoQDBcGP6D"
+            "8OSTxk09qn9qKTTKTQKKcQusVrxjtkACgOxEQMymLIl\\n7e49f7bSY4Jy0tkI99G250cms4+y4PaGXJoieP3HwRywXM82sbasGa8V9a3EM9"
+            "Tq\\nVP4Z6uFuUbJNotYcXaUYy51X3XVRQ9xgw4CBI72oirWiXAOtVrQwwNPAWvdEu3M5\\nFIdjX7+3E2BBYY58dG3bWqcEUBIqx488gCar"
+            "AgMBAAECgaBZk\/9oVJZ\/kYudwEB2\\nS\/uQIbuMnUzRRqZTyI\/q+bg97h\/p9VZCRE2YQyVZhmVpYQTKp2CBb9a+MFbyQkVH\\ncWibY"
+            "CY9s8riTQhUTrXGOtqesumWkTDdacbyuMjobme4WPX8L3xlX5spttpkZQfc\\neC0hpwX8bKRUuQifHPAhjuYxcVWIOZk5OaprHxwoXtM0oS"
+            "NPaGiPCM0fq4GmnF1n\\n3Eg5AlEA4aB6F0pG5ajnycvWETz\/WZpv\/wkcO0UlbgSFlx2OD545CKYcZlbx22bl\\nWvYHvkio1AAg03oFQf"
+            "XNtcl6274s2WFEJw5v0UBk0VHGq2zeTDUCUQDbeqkepngF\\njyuRSzfViuA3jpO\/8zmFm6Fpr5eCNgqEf+uC7zF+dg9bnnfEA88+x8Ijui"
+            "oRvbx7\\nkSMjiIijQUgo103vXadpPhBXFx7EadBDXwJQV0wtEQfXKJLSo\/xvJhpQvk2H2cif\\nmLsnQUsUmSSBS7+vV45V3K71QyurwCc"
+            "DVfdtAyHNkaVblWrSneyH0a\/iUHVW1jm6\\nv97HY0ndsYQc+qUCUQC3Al24wAh+YjZq7bR97FIwIUQUH4TMYsxCKveDzPoSJ\/RC\\ndp7"
+            "nmxwNQmMNYDvUVo8MaXQg3PwocQpC29tLfejknTtQJ+CrgePwKsgt8SmGswJQ\\nVt10NCsGdK7ACTz1Asfcb4JQUYM\/d14ofhJRHptROLE"
+            "93gHx9He+JGq4ET74YQvd\\nD8V0L923eLixsHh5I5t\/1QEVwbpeGcDhb+j8LeVvV8w=\\n-----END RSA PRIVATE KEY-----\\n\",\""
+            "ksk_keytag\":57949,\"ksk_alg\":8,\"zsk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIICXQIBAAKBgQDXaUmIPE734cR0Uxt"
+            "c6wj11rhv4DdP6tnc0LTN7pus1ZdLCBUC\\nln3HXKMKYptdyuHrkqs5bQQfl8A47\/X21m+sYtJkxdHNDYDkPwrX+bEDgbRgZKKW\\n0IMQ"
+            "7lw0wtYyWlE1Zc4zfZvCmKFWnE24TBQQLcJ+iwtbBGH8IgrAA5N3FQIDAQAB\\nAoGBAIozFGgBOTCzedSflQiSChefAIlWMmZlaAzRIY6VL"
+            "O8\/wWbz8nbMkjmbZ0a8\\naK1OAo+ec5fOJz0VoM9mtEj+3nlvQoJBw1ubBy4o3yr6X8dOwyEqtH8Riciv9XlE\\nDg6uQH8u52CErzYd7i"
+            "o9NVn+vQZEFdw1kwy9bHl6Zb+SwwWpAkEA69Dw7b2VC4aP\\na\/wr0\/xME2hXb7qf2YsH3GreJHTH1D7fdQozKdw4o8tUFjKvOTy827N2X"
+            "7PSp+cW\\nXYzk7Pp7nwJBAOnZPx2KK58IqBdmRpSfdQmstbC9k9SWby1NxH7xerepdRr+Fvnr\\nSVZo4JcIyWk1FVUHd9ZNIagIJZhE2tR"
+            "WkMsCQDPX05\/wtfu6sX1ECz6nkPITVmWx\\n2cKx1iCXPg81vVjkGaxZebYSPEGGSg43Rl6HA94pLjUMC5vuKfSXLR0MVHECQEWu\\n6ADc"
+            "cH02bihy4KtfDNgyL\/4Xr9qUbVK5rskJGkFqbKv7dUtJ0pO+Mtau1p3UJKQu\\n0oX4fAP\/UXybX\/4QQZsCQQCcym4PAXhtW5U1FmV\/d"
+            "GCMb8rufZt7bmHHPulrAIVv\\n5Zse+HIV\/u0c36RRHSRuW4MPICrHE7Uf5B7\/7TcWp3nZ\\n-----END RSA PRIVATE KEY-----\\n\""
+            ",\"zsk_keytag\":15271,\"zsk_alg\":8,\"inception\":\"2020-12-02T08:38:09.631363Z\",\"until\":\"2021-03-02T08:"
+            "38:09.630312Z\"},{\"ksk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIIC7QIBAAKBoQCz4ZqM5581jG8dIfkXMiPgYtrc5Tp3fw"
+            "G2Su4l4BmOtpWaOONv\\nuk6WTZZHhRKpPmCsVHHu9EVpBvyx7iXssH5j8kkq2tq2Btz957QIG3K28DA2vXJm\\nFRJ0tvjmxBXqqMHKHuJI"
+            "88uduPbJDJ\/R5fA+aVl6dBG8zkrikkQxRGhnzcnL3PP1\\nX3BIvC8FH305KvGRRPT+kBKsngzOMjtl5qErAgMBAAECgaEAmKofJfkqaSMP"
+            "5pS\/\\nuA0I39ZmU9WEgohbJqB\/b8u7RSD25RXlCR0At5WPtpFdHiBfocJlk9ziz9lrO4OX\\n0kKUcjTeHi3yM0yt4Bv28m6BNHpFvrdo"
+            "31jOpSkvYzcip2LdYENMTxAi4NSsDDQg\\nLjuxbKJskvHgwz73XXj9g6X0uiotTzuUnT0gWJvIDykeXnoru2U2YfYjsN4uSHJF\\nPWYlwQ"
+            "JRAOgxqQv1pe7VSQ4sLAnwW3NsGPMHCmAbmcbsjxnPj8Wjf4L0ervHxebt\\nnZOCaUlUxZm9X8GiONZAGMG2xPz6tuKYz9wE\/6j+9jtFe2"
+            "5alaCLAlEAxlLnapw5\\ne3oYElrw1MR1aNOwiSXJuhQ8wlM6EifuV9HA\/Aq3AApOoKmwL3n9EqfxuZbFmuRA\\nu4FB78tFckIyhqhxHNz"
+            "9KNZR5ZkwUdWvdeECUBLk\/6GWgsM1nfVGSOsiIP76e+lC\\n2GhLtq7GTzrFdiiaDmVEqbwgHI2XJmx7fz\/VYyMIkwM5xTBCFQGmcs83Q6"
+            "yazMdV\\nrMw+uyDFna60NlrTAlBnPVkCgnjZ8mD9jSG5YNvNygUoH+e3WjmW30RnlynXxXU0\\nv08sUjFEKZFx5Yr8XzjSZ85OJ2wbL9pn"
+            "PeXU6OjseFsJr3CKBad0Yh5pO1evgQJR\\nAMFyXCvulXFDKMqV3ePut7pMGGTUl53qoEOYGPsokl+C2Ho7sOgR2wzNLpchYZNr\\nS4eCZD"
+            "PgcC+1JAVOUoDK8IyPbnQaZ0K3kGWxPpzC29xj\\n-----END RSA PRIVATE KEY-----\\n\",\"ksk_keytag\":61079,\"ksk_alg\""
+            ":8,\"zsk\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIICXQIBAAKBgQDQCr6AbSI9hsy6WsAzZv87brsSG1NpbYnCuZTMIrCzfB2NU"
+            "F43\\nRZPqTgh6dV7EtjnXeq0MsvyCbwRBRXnmQ6MlHqGtovd0k0xEzGWf3V9WLST0J8PD\\nCdG7sX3gsWRkVZm6buKfmHmdgBTdWUs4ig+"
+            "x7p7pwVhV0HO7x0StEEgUxwIDAQAB\\nAoGANs891TPrW25SLZ6PGHvALnZDzsdoOFRlgOnHq+hPyVmfp4VO7RzllUstrKWT\\nbBveLUjio"
+            "n\/dSrfY1SFqtiGHr1w7tzTW39kTEdca4lvUtSmt7\/\/wrEV0GLsgHwnZ\\nVVyCuH0PpRcSmYYVYrSsCEH9\/mXxs8Fq0tsn+wMls7O1WW"
+            "ECQQDruuKG\/X\/tYmps\\nm239lLH8VyDRqQmX3mdtz+uKI8J37a+emd7lOWmkqa6b2ep+sZPDEk8xR7ktSiDb\\nAhyf85jvAkEA4e5dBt"
+            "UG05ieO+XtzvZOdMiU4zdWSAtgIyqegXunnvulwddEFbw0\\njwRzW5MYo0eTRfgaS0obMw8uZ0hN7zPRqQJBAOH1+ZCWTNta\/FLxRqTNtT"
+            "MCvcXb\\nuANowFIl\/U0kbBQTtcVdD6lAuICL2oEwiTQ6uj5CPcEqVFoSdZ4ZzyCQG+cCQDBv\\ni54FWXtPgszQlFUEVPmQburvWB4F4kx"
+            "nvKeBvQPGa1jNL5mBSbtHdvuw411N4PLl\\nJ63wazhdDtOxmpOnhlECQQCfdp\/ZOAKUalTUuqZLgIGwobDAmcOzXN\/85WWlWLIx\\nDf1"
+            "j0nabGCBLJt6VB0oVHd9a7rC7oTcl3TjO3kP9Zhts\\n-----END RSA PRIVATE KEY-----\\n\",\"zsk_keytag\":49225,\"zsk_al"
+            "g\":8,\"inception\":\"2020-12-02T10:45:48.279746Z\",\"until\":\"2021-03-02T10:45:48.279414Z\"}]}"
+        >>),
+        []
+    ).
 
 json_to_erlang_ensure_sorting_and_defaults_test() ->
     ?assertEqual({"foo.org", [], [], []}, json_to_erlang([{<<"name">>, "foo.org"}, {<<"records">>, []}], [])).
@@ -789,108 +937,150 @@ json_record_to_erlang_test() ->
 
 json_record_soa_to_erlang_test() ->
     Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_SOA,
-                         data =
-                             #dns_rrdata_soa{mname = <<"ns1.example.com">>,
-                                             rname = <<"admin.example.com">>,
-                                             serial = 12345,
-                                             refresh = 555,
-                                             retry = 666,
-                                             expire = 777,
-                                             minimum = 888},
-                         ttl = 3600},
-                 json_record_to_erlang([Name,
-                                        <<"SOA">>,
-                                        3600,
-                                        [{<<"mname">>, <<"ns1.example.com">>},
-                                         {<<"rname">>, <<"admin.example.com">>},
-                                         {<<"serial">>, 12345},
-                                         {<<"refresh">>, 555},
-                                         {<<"retry">>, 666},
-                                         {<<"expire">>, 777},
-                                         {<<"minimum">>, 888}],
-                                        undefined])).
+    ?assertEqual(
+        #dns_rr{
+            name = Name,
+            type = ?DNS_TYPE_SOA,
+            data =
+                #dns_rrdata_soa{
+                    mname = <<"ns1.example.com">>,
+                    rname = <<"admin.example.com">>,
+                    serial = 12345,
+                    refresh = 555,
+                    retry = 666,
+                    expire = 777,
+                    minimum = 888
+                },
+            ttl = 3600
+        },
+        json_record_to_erlang([
+            Name,
+            <<"SOA">>,
+            3600,
+            [
+                {<<"mname">>, <<"ns1.example.com">>},
+                {<<"rname">>, <<"admin.example.com">>},
+                {<<"serial">>, 12345},
+                {<<"refresh">>, 555},
+                {<<"retry">>, 666},
+                {<<"expire">>, 777},
+                {<<"minimum">>, 888}
+            ],
+            undefined
+        ])
+    ).
 
 json_record_ns_to_erlang_test() ->
     Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_NS,
-                         data = #dns_rrdata_ns{dname = <<"ns1.example.com">>},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"NS">>, 3600, [{<<"dname">>, <<"ns1.example.com">>}], undefined])).
+    ?assertEqual(
+        #dns_rr{
+            name = Name,
+            type = ?DNS_TYPE_NS,
+            data = #dns_rrdata_ns{dname = <<"ns1.example.com">>},
+            ttl = 3600
+        },
+        json_record_to_erlang([Name, <<"NS">>, 3600, [{<<"dname">>, <<"ns1.example.com">>}], undefined])
+    ).
 
 json_record_a_to_erlang_test() ->
     Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_A,
-                         data = #dns_rrdata_a{ip = {1, 2, 3, 4}},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"A">>, 3600, [{<<"ip">>, <<"1.2.3.4">>}], undefined])).
+    ?assertEqual(
+        #dns_rr{
+            name = Name,
+            type = ?DNS_TYPE_A,
+            data = #dns_rrdata_a{ip = {1, 2, 3, 4}},
+            ttl = 3600
+        },
+        json_record_to_erlang([Name, <<"A">>, 3600, [{<<"ip">>, <<"1.2.3.4">>}], undefined])
+    ).
 
 json_record_aaaa_to_erlang_test() ->
     Name = <<"example.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_AAAA,
-                         data = #dns_rrdata_aaaa{ip = {0, 0, 0, 0, 0, 0, 0, 1}},
-                         ttl = 3600},
-                 json_record_to_erlang([Name, <<"AAAA">>, 3600, [{<<"ip">>, <<"::1">>}], undefined])).
+    ?assertEqual(
+        #dns_rr{
+            name = Name,
+            type = ?DNS_TYPE_AAAA,
+            data = #dns_rrdata_aaaa{ip = {0, 0, 0, 0, 0, 0, 0, 1}},
+            ttl = 3600
+        },
+        json_record_to_erlang([Name, <<"AAAA">>, 3600, [{<<"ip">>, <<"::1">>}], undefined])
+    ).
 
 json_record_cds_to_erlang_test() ->
     Name = <<"example-dnssec.com">>,
-    ?assertEqual(#dns_rr{name = Name,
-                         type = ?DNS_TYPE_CDS,
-                         data =
-                             #dns_rrdata_cds{keytag = 0,
-                                             digest_type = 2,
-                                             alg = 8,
-                                             digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)},
-                         ttl = 3600},
-                 json_record_to_erlang([Name,
-                                        <<"CDS">>,
-                                        3600,
-                                        [{<<"keytag">>, 0},
-                                         {<<"digest_type">>, 2},
-                                         {<<"alg">>, 8},
-                                         {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}],
-                                        undefined])).
+    ?assertEqual(
+        #dns_rr{
+            name = Name,
+            type = ?DNS_TYPE_CDS,
+            data =
+                #dns_rrdata_cds{
+                    keytag = 0,
+                    digest_type = 2,
+                    alg = 8,
+                    digest = hex_to_bin(<<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>)
+                },
+            ttl = 3600
+        },
+        json_record_to_erlang([
+            Name,
+            <<"CDS">>,
+            3600,
+            [
+                {<<"keytag">>, 0},
+                {<<"digest_type">>, 2},
+                {<<"alg">>, 8},
+                {<<"digest">>, <<"4315A7AD09AE0BEBA6CC3104BBCD88000ED796887F1C4D520A3A608D715B72CA">>}
+            ],
+            undefined
+        ])
+    ).
 
 parse_json_keys_unsorted_proplists_test() ->
-    ?assertEqual([{keyset,
-                   [1025,
+    ?assertEqual(
+        [
+            {keyset,
+                [
+                    1025,
                     117942195211355436516708579275854541924575773884167758398377054474457061084450782563901956510831117716183526402173215071572529228555976594387632086643427143744605045813923857147839015187463121492324352653506190767692034127161982651669657643423469824721891177589201529187860925827553628207715191151413138514807,
-                    105745246243156727959858716443424706369448913365414799968886354206854672328400262610952095642393948469436742208387497220268443279066285356333886719634448317208189715942402022382731037836531762881862458283240610274107136766709456566004076449761688996028612988763775001691587086168632010166111722279727494037097],
-                   37440,
-                   8,
-                   [513,
+                    105745246243156727959858716443424706369448913365414799968886354206854672328400262610952095642393948469436742208387497220268443279066285356333886719634448317208189715942402022382731037836531762881862458283240610274107136766709456566004076449761688996028612988763775001691587086168632010166111722279727494037097
+                ],
+                37440, 8,
+                [
+                    513,
                     9170529505818457214552347052832728824507861128011245996056627438339703762731346681703094163316286362641501571794424157931806097889892946273849538579240359,
-                    5130491166023191463112131781994138738077497356216817935415696052248528225933414267440640871636073852185344964288812312263453467652493907737029964715172561],
-                   49016,
-                   8,
-                   {{2016, 11, 14}, {11, 36, 59}},
-                   {{2017, 2, 12}, {11, 36, 59}}}],
-                 parse_json_keys([[{<<"ksk">>,
-                                    <<"-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USCh\nEW0fLYT/Q"
-                                      "kAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+C\nfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHS"
-                                      "U8htjdwICBAEC\ngYEAlpYTHWYrcd0HQXO3F9lPqwwfHUt7VBaSEUYrk3N3ZYCWvmV1qyKbB/kb1SBs\n4GfW1vP966HXCffnX92LDXYxi7I"
-                                      "t3TJaKmo8aF/leN7w8WLNJXUayEoQKUfKLprj\nN14Jx/tgMu7I/BOoHId8b7e57pBKtDiSF6WWn3K7tNPbfmkCQQDST41m62mC4MAa\nDsU"
-                                      "dyM0Vg/tjduGqnygryCDEXDabdg95a3wMk0SQCQzZFHGNYnsXcffTqGs/y+5w\nQWxyOGSNAkEAzHFkDJla30NiiKvhu7dY+0+dGrfMA7pNU"
-                                      "h+LGdXe5QFdjwwxqPbF\n7NMGXKMdB8agSCxGZC3bxdvYNF9LULzhEwJABpDYNSoQx+UMvaEN5XTpLmCHuS1r\nsmhfKZPcDx8Z7mAYda3wZ"
-                                      "EuHQq+cf6i5XhOO9P5QKpKeslHLAMHa7NaNgQJBAI03\nGGacYLwui32fbzb8BYRg82Kga/OW6btY+O6hNs6iSR2gBlQ9j3Tgrzo+N4R/NQS"
-                                      "l\nc05wGO2RnBUwlu0XUckCQHfHsWHVrrADTpalbv+FTDyWd0ouHXBmDecVZh3e7/ue\ncdMoblzeasvgp8CjFa9U+uDozY+aL6TNIpG++nn"
-                                      "4lNw=\n-----END RSA PRIVATE KEY-----\n">>},
-                                   {<<"ksk_alg">>, 8},
-                                   {<<"ksk_keytag">>, 37440},
-                                   {<<"zsk">>,
-                                    <<"-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jT\nCaEwnpE74"
-                                      "YHCLegKAAn+efeZrT/EBBrzlacCAgIBAkBh9VGFW2SJk1I9SBQaDIA9\nchdrrx+PHibSyozwT4eAPmd6OFoLausc7ls6v9evPeb+Yj3g0JX"
-                                      "vTGp6BgNhFqLR\nAiEA1+ievAEBVM6IlOmpiTwlaWe/HV6MokBBq1G/tvJS0M8CIQDPm/DUsoTEv/Jj\n6O3U9hNcPLbvKMMGld2wbf7nrQm"
-                                      "zqQIhAJrhwTaFdjnXhmfUB9a33vRIbSaIsLxA\nDyuM+03XP+YhAiEAmJIJz7WX9uPkCIy8wO655Hh4dt4UkBFRE98OqkHIwGkCIFFv\nN8r"
-                                      "JojI+oEiJyNjEjWZD4qoUMUp3+YBl0htAJUE2\n-----END RSA PRIVATE KEY-----\n">>},
-                                   {<<"zsk_alg">>, 8},
-                                   {<<"zsk_keytag">>, 49016},
-                                   {<<"inception">>, <<"2016-11-14T11:36:58.851612Z">>},
-                                   {<<"until">>, <<"2017-02-12T11:36:58.849384Z">>}]])).
+                    5130491166023191463112131781994138738077497356216817935415696052248528225933414267440640871636073852185344964288812312263453467652493907737029964715172561
+                ],
+                49016, 8, {{2016, 11, 14}, {11, 36, 59}}, {{2017, 2, 12}, {11, 36, 59}}}
+        ],
+        parse_json_keys([
+            [
+                {<<"ksk">>, <<
+                    "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USCh\nEW0fLYT/Q"
+                    "kAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+C\nfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHS"
+                    "U8htjdwICBAEC\ngYEAlpYTHWYrcd0HQXO3F9lPqwwfHUt7VBaSEUYrk3N3ZYCWvmV1qyKbB/kb1SBs\n4GfW1vP966HXCffnX92LDXYxi7I"
+                    "t3TJaKmo8aF/leN7w8WLNJXUayEoQKUfKLprj\nN14Jx/tgMu7I/BOoHId8b7e57pBKtDiSF6WWn3K7tNPbfmkCQQDST41m62mC4MAa\nDsU"
+                    "dyM0Vg/tjduGqnygryCDEXDabdg95a3wMk0SQCQzZFHGNYnsXcffTqGs/y+5w\nQWxyOGSNAkEAzHFkDJla30NiiKvhu7dY+0+dGrfMA7pNU"
+                    "h+LGdXe5QFdjwwxqPbF\n7NMGXKMdB8agSCxGZC3bxdvYNF9LULzhEwJABpDYNSoQx+UMvaEN5XTpLmCHuS1r\nsmhfKZPcDx8Z7mAYda3wZ"
+                    "EuHQq+cf6i5XhOO9P5QKpKeslHLAMHa7NaNgQJBAI03\nGGacYLwui32fbzb8BYRg82Kga/OW6btY+O6hNs6iSR2gBlQ9j3Tgrzo+N4R/NQS"
+                    "l\nc05wGO2RnBUwlu0XUckCQHfHsWHVrrADTpalbv+FTDyWd0ouHXBmDecVZh3e7/ue\ncdMoblzeasvgp8CjFa9U+uDozY+aL6TNIpG++nn"
+                    "4lNw=\n-----END RSA PRIVATE KEY-----\n"
+                >>},
+                {<<"ksk_alg">>, 8},
+                {<<"ksk_keytag">>, 37440},
+                {<<"zsk">>, <<
+                    "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jT\nCaEwnpE74"
+                    "YHCLegKAAn+efeZrT/EBBrzlacCAgIBAkBh9VGFW2SJk1I9SBQaDIA9\nchdrrx+PHibSyozwT4eAPmd6OFoLausc7ls6v9evPeb+Yj3g0JX"
+                    "vTGp6BgNhFqLR\nAiEA1+ievAEBVM6IlOmpiTwlaWe/HV6MokBBq1G/tvJS0M8CIQDPm/DUsoTEv/Jj\n6O3U9hNcPLbvKMMGld2wbf7nrQm"
+                    "zqQIhAJrhwTaFdjnXhmfUB9a33vRIbSaIsLxA\nDyuM+03XP+YhAiEAmJIJz7WX9uPkCIy8wO655Hh4dt4UkBFRE98OqkHIwGkCIFFv\nN8r"
+                    "JojI+oEiJyNjEjWZD4qoUMUp3+YBl0htAJUE2\n-----END RSA PRIVATE KEY-----\n"
+                >>},
+                {<<"zsk_alg">>, 8},
+                {<<"zsk_keytag">>, 49016},
+                {<<"inception">>, <<"2016-11-14T11:36:58.851612Z">>},
+                {<<"until">>, <<"2017-02-12T11:36:58.849384Z">>}
+            ]
+        ])
+    ).
 
 hex_to_bin_test() ->
     ?assertEqual(<<"">>, hex_to_bin(<<"">>)),
@@ -898,12 +1088,16 @@ hex_to_bin_test() ->
 
 base64_to_bin_test() ->
     ?assertEqual(<<"">>, base64_to_bin(<<"">>)),
-    ?assertEqual(<<3, 1, 0, 1, 191, 165, 76, 56, 217, 9, 250, 187, 15, 147, 125, 112, 215, 117, 186, 13, 244, 192, 186, 219, 9, 112, 125, 153, 82, 73, 64,
-                   105, 80, 64, 122, 98, 28, 121, 76, 104, 177, 134, 177, 93, 191, 143, 159, 158, 162, 49, 233, 249, 100, 20, 204, 218, 78, 206, 181, 11, 23,
-                   169, 172, 108, 75, 212, 185, 93, 160, 72, 73, 233, 110, 231, 145, 87, 139, 112, 59, 201, 174, 24, 79, 177, 121, 75, 172, 121, 42, 7, 135,
-                   246, 147, 164, 15, 25, 245, 35, 238, 109, 189, 53, 153, 219, 170, 169, 165, 4, 55, 146, 110, 207, 100, 56, 132, 93, 29, 73, 68, 137, 98, 82,
-                   79, 42, 26, 122, 54, 179, 160, 161, 236, 163>>,
-                 base64_to_bin(<<"AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8mu"
-                                 "GE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj">>)).
+    ?assertEqual(
+        <<3, 1, 0, 1, 191, 165, 76, 56, 217, 9, 250, 187, 15, 147, 125, 112, 215, 117, 186, 13, 244, 192, 186, 219, 9, 112, 125, 153, 82,
+            73, 64, 105, 80, 64, 122, 98, 28, 121, 76, 104, 177, 134, 177, 93, 191, 143, 159, 158, 162, 49, 233, 249, 100, 20, 204, 218, 78,
+            206, 181, 11, 23, 169, 172, 108, 75, 212, 185, 93, 160, 72, 73, 233, 110, 231, 145, 87, 139, 112, 59, 201, 174, 24, 79, 177,
+            121, 75, 172, 121, 42, 7, 135, 246, 147, 164, 15, 25, 245, 35, 238, 109, 189, 53, 153, 219, 170, 169, 165, 4, 55, 146, 110, 207,
+            100, 56, 132, 93, 29, 73, 68, 137, 98, 82, 79, 42, 26, 122, 54, 179, 160, 161, 236, 163>>,
+        base64_to_bin(<<
+            "AwEAAb+lTDjZCfq7D5N9cNd1ug30wLrbCXB9mVJJQGlQQHpiHHlMaLGGsV2/j5+eojHp+WQUzNpOzrULF6msbEvUuV2gSEnpbueRV4twO8mu"
+            "GE+xeUuseSoHh/aTpA8Z9SPubb01mduqqaUEN5Juz2Q4hF0dSUSJYlJPKhp6NrOgoeyj"
+        >>)
+    ).
 
 -endif.

--- a/src/gen_nb_server.erl
+++ b/src/gen_nb_server.erl
@@ -27,12 +27,14 @@
 %% API
 -export([start_link/4]).
 %% gen_server callbacks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -define(SERVER, ?MODULE).
 
@@ -42,20 +44,20 @@
 
 -callback init(term()) -> {ok, State :: state()}.
 -callback handle_call(Request :: term(), From :: {pid(), Tag :: term()}, State :: state()) ->
-                         {reply, Reply :: term(), NewState :: state()} |
-                         {reply, Reply :: term(), NewState :: state(), timeout() | hibernate} |
-                         {noreply, NewState :: state()} |
-                         {noreply, NewState :: state(), timeout() | hibernate} |
-                         {stop, Reason :: term(), Reply :: term(), NewState :: state()} |
-                         {stop, Reason :: term(), NewState :: state()}.
+    {reply, Reply :: term(), NewState :: state()}
+    | {reply, Reply :: term(), NewState :: state(), timeout() | hibernate}
+    | {noreply, NewState :: state()}
+    | {noreply, NewState :: state(), timeout() | hibernate}
+    | {stop, Reason :: term(), Reply :: term(), NewState :: state()}
+    | {stop, Reason :: term(), NewState :: state()}.
 -callback handle_cast(Request :: term(), State :: state()) ->
-                         {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: term()}.
+    {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: term()}.
 -callback handle_info(Info :: timeout | term(), State :: state()) ->
-                         {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: state()}.
+    {noreply, NewState :: state()} | {noreply, NewState :: state(), timeout() | hibernate} | {stop, Reason :: term(), NewState :: state()}.
 -callback terminate(Reason :: normal | shutdown | {shutdown, term()} | term(), State :: state()) -> term().
 -callback sock_opts() -> [gen_tcp:listen_option()].
 -callback new_connection(Socket :: gen_tcp:socket(), State :: state()) ->
-                            {ok, NewServerState :: state()} | {stop, Reason :: term(), NewServerState :: state()}.
+    {ok, NewServerState :: state()} | {stop, Reason :: term(), NewServerState :: state()}.
 
 -export_type([state/0]).
 
@@ -76,10 +78,11 @@ init([CallbackModule, IpAddr, Port, InitParams]) ->
             case listen_on(CallbackModule, IpAddr, Port) of
                 {ok, Sock} ->
                     process_flag(trap_exit, true),
-                    {ok,
-                     #state{cb = CallbackModule,
-                            sock = Sock,
-                            server_state = ServerState}};
+                    {ok, #state{
+                        cb = CallbackModule,
+                        sock = Sock,
+                        server_state = ServerState
+                    }};
                 Error ->
                     CallbackModule:terminate(Error, ServerState),
                     Error
@@ -137,10 +140,14 @@ handle_info(Info, #state{cb = Callback, server_state = ServerState} = State) ->
     end.
 
 %% @hidden
-terminate(Reason,
-          #state{cb = Callback,
-                 sock = Sock,
-                 server_state = ServerState}) ->
+terminate(
+    Reason,
+    #state{
+        cb = Callback,
+        sock = Sock,
+        server_state = ServerState
+    }
+) ->
     gen_tcp:close(Sock),
     Callback:terminate(Reason, ServerState),
     ok.

--- a/src/sample_custom_handler.erl
+++ b/src/sample_custom_handler.erl
@@ -21,17 +21,21 @@
 
 -behavior(gen_server).
 
--export([start_link/0,
-         handle/4,
-         filter/1,
-         nsec_rr_type_mapper/1]).
+-export([
+    start_link/0,
+    handle/4,
+    filter/1,
+    nsec_rr_type_mapper/1
+]).
 % Gen server hooks
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -define(DNS_TYPE_SAMPLE, 20001).
 
@@ -64,13 +68,17 @@ handle_call({filter, Records}, _From, State) ->
     TypeMatchFunction = type_match(),
     ConvertFunction = convert(),
     NewRecords =
-        lists:flatten(lists:map(fun(R) ->
-                                   case TypeMatchFunction(R) of
-                                       true -> ConvertFunction(R);
-                                       false -> R
-                                   end
-                                end,
-                                Records)),
+        lists:flatten(
+            lists:map(
+                fun(R) ->
+                    case TypeMatchFunction(R) of
+                        true -> ConvertFunction(R);
+                        false -> R
+                    end
+                end,
+                Records
+            )
+        ),
     {reply, NewRecords, State}.
 
 handle_cast(_Message, State) ->
@@ -92,6 +100,6 @@ type_match() ->
 
 convert() ->
     fun(Record) ->
-       {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
-       Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}}
+        {ok, Address} = inet_parse:address(binary_to_list(Record#dns_rr.data)),
+        Record#dns_rr{type = ?DNS_TYPE_A, data = #dns_rrdata_a{ip = Address}}
     end.

--- a/src/sample_custom_zone_encoder.erl
+++ b/src/sample_custom_zone_encoder.erl
@@ -25,10 +25,12 @@
 
 encode_record({dns_rr, Name, _, ?DNS_TYPE_SAMPLE, Ttl, Data}) ->
     lager:debug("Encoding SAMPLE record"),
-    [{<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-     {<<"type">>, <<"SAMPLE">>},
-     {<<"ttl">>, Ttl},
-     {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}];
+    [
+        {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
+        {<<"type">>, <<"SAMPLE">>},
+        {<<"ttl">>, Ttl},
+        {<<"content">>, erlang:iolist_to_binary(io_lib:format("~s", [Data]))}
+    ];
 encode_record(_) ->
     lager:debug("Could not encode record"),
     [].

--- a/src/sample_custom_zone_parser.erl
+++ b/src/sample_custom_zone_parser.erl
@@ -28,32 +28,36 @@
 -define(DNS_TYPE_SAMPLE, 40000).
 
 json_record_to_erlang([Name, <<"SAMPLE">>, Ttl, Data, _Context]) when is_map(Data) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SAMPLE,
-            data = maps:get(<<"dname">>, Data),
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SAMPLE,
+        data = maps:get(<<"dname">>, Data),
+        ttl = Ttl
+    };
 json_record_to_erlang([Name, <<"SAMPLE">>, Ttl, Data, _Context]) ->
-    #dns_rr{name = Name,
-            type = ?DNS_TYPE_SAMPLE,
-            data = erldns_config:keyget(<<"dname">>, Data),
-            ttl = Ttl};
+    #dns_rr{
+        name = Name,
+        type = ?DNS_TYPE_SAMPLE,
+        data = erldns_config:keyget(<<"dname">>, Data),
+        ttl = Ttl
+    };
 json_record_to_erlang(_) ->
     {}.
 
 -ifdef(TEST).
 
 json_record_to_erlang_with_map_test() ->
-  Record = json_record_to_erlang([<<"example.com">>, <<"SAMPLE">>, 60, #{<<"dname">> => <<"example.net">>}, undefined]),
-  ?assertEqual(<<"example.com">>, Record#dns_rr.name),
-  ?assertEqual(40000, Record#dns_rr.type),
-  ?assertEqual(60, Record#dns_rr.ttl),
-  ?assertEqual(<<"example.net">>, Record#dns_rr.data).
+    Record = json_record_to_erlang([<<"example.com">>, <<"SAMPLE">>, 60, #{<<"dname">> => <<"example.net">>}, undefined]),
+    ?assertEqual(<<"example.com">>, Record#dns_rr.name),
+    ?assertEqual(40000, Record#dns_rr.type),
+    ?assertEqual(60, Record#dns_rr.ttl),
+    ?assertEqual(<<"example.net">>, Record#dns_rr.data).
 
 json_record_to_erlang_with_proplist_test() ->
-  Record = json_record_to_erlang([<<"example.com">>, <<"SAMPLE">>, 60, [{<<"dname">>, <<"example.net">>}], undefined]),
-  ?assertEqual(<<"example.com">>, Record#dns_rr.name),
-  ?assertEqual(40000, Record#dns_rr.type),
-  ?assertEqual(60, Record#dns_rr.ttl),
-  ?assertEqual(<<"example.net">>, Record#dns_rr.data).
+    Record = json_record_to_erlang([<<"example.com">>, <<"SAMPLE">>, 60, [{<<"dname">>, <<"example.net">>}], undefined]),
+    ?assertEqual(<<"example.com">>, Record#dns_rr.name),
+    ?assertEqual(40000, Record#dns_rr.type),
+    ?assertEqual(60, Record#dns_rr.ttl),
+    ?assertEqual(<<"example.net">>, Record#dns_rr.data).
 
 -endif.

--- a/test/erldns_zone_cache_test.erl
+++ b/test/erldns_zone_cache_test.erl
@@ -44,11 +44,21 @@ put_zone_rrset_records_count_with_existing_rrset_test() ->
     load_standard_zone(),
     ZoneName = <<"example.com">>,
     ZoneBase = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
-    erldns_zone_cache:put_zone_rrset({ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    [#dns_rr{data = #dns_rrdata_cname{dname = <<"google.com">>},
-                                            name  = <<"cname.example.com">>, ttl = 5, type = 5}], []},
-                                            <<"cname.example.com">>, 5, 1),
+    erldns_zone_cache:put_zone_rrset(
+        {ZoneName, <<"irrelevantDigest">>,
+            [
+                #dns_rr{
+                    data = #dns_rrdata_cname{dname = <<"google.com">>},
+                    name = <<"cname.example.com">>,
+                    ttl = 5,
+                    type = 5
+                }
+            ],
+            []},
+        <<"cname.example.com">>,
+        5,
+        1
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % There should be no change in record count
     ?assertEqual(ZoneBase#zone.record_count, ZoneModified#zone.record_count),
@@ -59,11 +69,21 @@ put_zone_rrset_records_count_with_new_rrset_test() ->
     load_standard_zone(),
     ZoneName = <<"example.com">>,
     ZoneBase = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
-    erldns_zone_cache:put_zone_rrset({ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    [#dns_rr{data = #dns_rrdata_a{ip = <<"5,5,5,5">>},
-                                            name  = <<"a2.example.com">>, ttl = 5, type = 1}], []},
-                                            <<"a2.example.com">>, 5, 1),
+    erldns_zone_cache:put_zone_rrset(
+        {ZoneName, <<"irrelevantDigest">>,
+            [
+                #dns_rr{
+                    data = #dns_rrdata_a{ip = <<"5,5,5,5">>},
+                    name = <<"a2.example.com">>,
+                    ttl = 5,
+                    type = 1
+                }
+            ],
+            []},
+        <<"a2.example.com">>,
+        5,
+        1
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % New RRSet is being added with one record we should see an increase by 1
     ?assertEqual(ZoneBase#zone.record_count + 1, ZoneModified#zone.record_count),
@@ -73,11 +93,21 @@ put_zone_rrset_records_count_matches_cache_test() ->
     Pid = setup_cache(),
     load_standard_zone(),
     ZoneName = <<"example.com">>,
-    erldns_zone_cache:put_zone_rrset({ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    [#dns_rr{data = #dns_rrdata_a{ip = <<"5,5,5,5">>},
-                                            name  = <<"a2.example.com">>, ttl = 5, type = 1}], []},
-                                            <<"a2.example.com">>, 5, 1),
+    erldns_zone_cache:put_zone_rrset(
+        {ZoneName, <<"irrelevantDigest">>,
+            [
+                #dns_rr{
+                    data = #dns_rrdata_a{ip = <<"5,5,5,5">>},
+                    name = <<"a2.example.com">>,
+                    ttl = 5,
+                    type = 1
+                }
+            ],
+            []},
+        <<"a2.example.com">>,
+        5,
+        1
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % New RRSet is being added with one record we should see an increase by 1
     ?assertEqual(length(erldns_zone_cache:get_zone_records(ZoneName)), ZoneModified#zone.record_count),
@@ -88,11 +118,21 @@ put_zone_rrset_records_count_with_dnssec_zone_and_new_rrset_test() ->
     load_dnssec_zone(),
     ZoneName = <<"example-dnssec.com">>,
     Zone = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
-    erldns_zone_cache:put_zone_rrset({ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    [#dns_rr{data = #dns_rrdata_cname{dname = <<"google.com">>},
-                                            name  = <<"cname.example-dnssec.com">>, ttl = 60, type = 5}], []},
-                                            <<"cname.example-dnssec.com">>, 5, 1),
+    erldns_zone_cache:put_zone_rrset(
+        {ZoneName, <<"irrelevantDigest">>,
+            [
+                #dns_rr{
+                    data = #dns_rrdata_cname{dname = <<"google.com">>},
+                    name = <<"cname.example-dnssec.com">>,
+                    ttl = 60,
+                    type = 5
+                }
+            ],
+            []},
+        <<"cname.example-dnssec.com">>,
+        5,
+        1
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % New RRSet entry for the CNAME + 1 RRSig record
     ?assertEqual(Zone#zone.record_count + 2, ZoneModified#zone.record_count),
@@ -103,9 +143,13 @@ delete_zone_rrset_records_count_width_existing_rrset_test() ->
     load_standard_zone(),
     ZoneName = <<"example.com">>,
     ZoneBase = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
-    erldns_zone_cache:delete_zone_rrset(ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    erldns:normalize_name(<<"cname.example.com">>), 5, 1),
+    erldns_zone_cache:delete_zone_rrset(
+        ZoneName,
+        <<"irrelevantDigest">>,
+        erldns:normalize_name(<<"cname.example.com">>),
+        5,
+        1
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % Deletes a CNAME RRSet with one record
     ?assertEqual(ZoneBase#zone.record_count - 1, ZoneModified#zone.record_count),
@@ -116,9 +160,13 @@ delete_zone_rrset_records_count_width_dnssec_zone_and_existing_rrset_test() ->
     load_dnssec_zone(),
     ZoneName = <<"example-dnssec.com">>,
     ZoneBase = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
-    erldns_zone_cache:delete_zone_rrset(ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    erldns:normalize_name(<<"cname2.example-dnssec.com">>), 5, 2),
+    erldns_zone_cache:delete_zone_rrset(
+        ZoneName,
+        <<"irrelevantDigest">>,
+        erldns:normalize_name(<<"cname2.example-dnssec.com">>),
+        5,
+        2
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % Deletes a CNAME RRSet with one record + RRSig
     ?assertEqual(ZoneBase#zone.record_count - 2, ZoneModified#zone.record_count),
@@ -128,9 +176,13 @@ delete_zone_rrset_records_count_matches_cache_test() ->
     Pid = setup_cache(),
     load_dnssec_zone(),
     ZoneName = <<"example-dnssec.com">>,
-    erldns_zone_cache:delete_zone_rrset(ZoneName,
-                                    <<"irrelevantDigest">>,
-                                    erldns:normalize_name(<<"cname2.example-dnssec.com">>), 5, 2),
+    erldns_zone_cache:delete_zone_rrset(
+        ZoneName,
+        <<"irrelevantDigest">>,
+        erldns:normalize_name(<<"cname2.example-dnssec.com">>),
+        5,
+        2
+    ),
     ZoneModified = erldns_zone_cache:find_zone(erldns:normalize_name(ZoneName)),
     % Deletes a CNAME RRSet with one record + RRSig
     ?assertEqual(length(erldns_zone_cache:get_zone_records(ZoneName)), ZoneModified#zone.record_count),


### PR DESCRIPTION
This is an attempt to define some consistent formatting rules for our Erlang code.

I made some research and I tested various options, so far the one that I prefer is [erlfmt](https://github.com/WhatsApp/erlfmt) from WhatsApp. Like most non-builtin formatters, this is opinionated. But the choices they made are well thought, and seem to be a good starting point.


You have both the option to reformat the code inline:

```
rebar3 fmt
```

or check the formatting:

```
rebar3 fmt --check
```

This last command is especially useful for CI integration.
