### PR TITLE
Fix spec for `erldns_zone_parser:zone_to_erlang/1`

### DIFF
--- a/src/erldns_zone_parser.erl
+++ b/src/erldns_zone_parser.erl
@@ -59,7 +59,7 @@ start_link() ->
 %% @doc Takes a JSON zone and turns it into the tuple {Name, Sha, Records}.
 %%
 %% The default timeout for parsing is currently 30 seconds.
--spec zone_to_erlang(binary()) -> {binary(), binary(), [dns:rr()], [erldns:keyset()]}.
+-spec zone_to_erlang(map() | list()) -> {binary(), binary(), [dns:rr()], [erldns:keyset()]}.
 zone_to_erlang(Zone) ->
     gen_server:call(?SERVER, {parse_zone, Zone}, ?PARSE_TIMEOUT).
 


### PR DESCRIPTION
It doesn't take a binary, it takes a map or proplist (and soon only a map when the `json` move continues).