### PR TITLE
Set rebar3 in .tool-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,53 +33,20 @@ jobs:
       - name: Run YAML Lint
         uses: actionshub/yamllint@main
 
-  build:
-    name: Build
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        otp_version: ['27.1']
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: 'strict'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/rebar3
-            _build
-          key: ${{ runner.os }}-erlang-${{ matrix.otp_version }}-${{ hashFiles('**/*rebar.lock') }}
-
-      - run: make build
-
   test:
     name: Test
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        otp_version: ['27.1']
-
-    needs:
-      - build
-
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: 'strict'
-
+          version-type: strict
+          version-file: .tool-versions
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/rebar3
             _build
-          key: ${{ runner.os }}-erlang-${{ matrix.otp_version }}-${{ hashFiles('**/*rebar.lock') }}
-
+          key: ${{ runner.os }}-erlang-${{ steps.setup-beam.outputs.otp-version }}-rebar3-${{ steps.setup-beam.outputs.rebar3-version }}-hash-${{hashFiles('rebar.lock')}}
+      - run: make build
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,24 @@ jobs:
         uses: actionshub/yamllint@main
 
   test:
-    name: Test
-    runs-on: ubuntu-24.04
+    name: OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        os: ['ubuntu-24.04', 'ubuntu-22.04']
+        otp: ['27']
+        rebar3: ['3.24']
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          version-type: strict
-          version-file: .tool-versions
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{matrix.rebar3}}
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/rebar3
             _build
-          key: ${{ runner.os }}-erlang-${{ steps.setup-beam.outputs.otp-version }}-rebar3-${{ steps.setup-beam.outputs.rebar3-version }}-hash-${{hashFiles('rebar.lock')}}
+          key: ${{ runner.os }}-erlang-${{ matrix.otp }}-rebar3-${{ matrix.rebar3 }}-hash-${{hashFiles('rebar.lock')}}
       - run: make build
       - run: make test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-# Also update ci.yml
-erlang 27.2.3
-rebar 3.24.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 # Also update ci.yml
-erlang 27.1.3
+erlang 27.2.3
+rebar 3.24.0

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,28 @@
-REBAR:=$(shell which rebar3 || echo ./rebar3)
-REBAR_URL:="https://s3.amazonaws.com/rebar3/rebar3"
-
 all: clean build
 
-$(REBAR):
-	curl -o rebar3 $(REBAR_URL) && chmod +x rebar3
-
 .PHONY: build
-build: $(REBAR)
-	$(REBAR) compile
+build:
+	rebar3 compile
 
 .PHONY: release
-release: $(REBAR)
-	$(REBAR) release
+release:
+	rebar3 release
 
 .PHONY: fresh
-fresh: $(REBAR)
+fresh:
 	rm -Rf _build
-	$(REBAR) clean
+	rebar3 clean
 
 .PHONY: clean
-clean: $(REBAR)
-	$(REBAR) clean
+clean:
+	rebar3 clean
 
 .PHONY: test
-test: $(REBAR)
-	$(REBAR) eunit
-	$(REBAR) fmt --check
-	$(REBAR) dialyzer
+test:
+	rebar3 eunit
+	rebar3 fmt --check
+	rebar3 dialyzer
 
 .PHONY: format
-format: $(REBAR)
-	$(REBAR) fmt
+format:
+	rebar3 fmt

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,8 @@
     {parse_transform, lager_transform}
 ]}.
 
+{minimum_otp_vsn, "27"}.
+
 {project_plugins, [erlfmt, rebar3_depup]}.
 
 {deps, [


### PR DESCRIPTION
Also update erlang and the way it is used in CI and enforce OTP27 in rebar.config, as we were already depending on features that only OTP27 uses (json).