### PR TITLE
CI: Update Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,5 @@ jobs:
       - name: Publish to hex.pm
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: rebar3 compile
         run: rebar3 hex publish -r hexpm --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           otp-version: '27'
           rebar3-version: '3.24'
-      - run: rebar3 compile
       - name: Publish to hex.pm
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,16 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
-      - name: Publish to Hex.pm
-        uses: erlangpack/github-action@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          rebar3-version: '3.24'
+      - run: rebar3 compile
+      - name: Publish to hex.pm
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: rebar3 hex publish -r hexpm --yes


### PR DESCRIPTION
The current workflow doesn't work for OTP > 24. This change aligns with the other open source repo.