### PR TITLE
Test admin endpoint

### DIFF
--- a/priv/zones-example.json
+++ b/priv/zones-example.json
@@ -103,5 +103,71 @@
         }
       }
     ]
+  },
+  {
+    "name": "example-dnssec0.com",
+    "records": [
+      {
+        "name": "example-dnssec0.com",
+        "type": "SOA",
+        "data": {
+          "mname": "ns1.example-dnssec0.com",
+          "rname": "ahu.example-dnssec0.com",
+          "serial": 2000081501,
+          "refresh": 28800,
+          "retry": 7200,
+          "expire": 604800,
+          "minimum": 86400
+        },
+        "ttl": 100000
+      },
+      {
+        "name": "example-dnssec0.com",
+        "type": "CDS",
+        "ttl": 120,
+        "data": {
+          "alg": 0,
+          "digest": "00",
+          "digest_type": 0,
+          "keytag": 0
+        }
+      },
+      {
+        "name": "example-dnssec0.com",
+        "type": "CDNSKEY",
+        "ttl": 120,
+        "data": {
+          "flags": 0,
+          "protocol": 3,
+          "alg": 0,
+          "public_key": "AA==",
+          "key_tag": 0
+        }
+      },
+      {
+        "name": "example-dnssec0.com",
+        "type": "DNSKEY",
+        "ttl": 120,
+        "data": {
+          "flags": 257,
+          "protocol": 3,
+          "alg": 8,
+          "public_key": "MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USChEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+CfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAE=",
+          "key_tag": 0
+        }
+      }
+    ],
+    "keys": [
+      {
+        "ksk": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCn9Iv82vkFiv8ts8K9jzUzfp3UEZx+76r+X9A4GOFfYbx3USCh\nEW0fLYT/QkAM8/SiTkEXzZPqhrV083mp5VLYNLxic2ii6DrwvyGpENVPJnDQMu+C\nfKMyb9IWcm9MkeHh8t/ovsCQAEJWIPTnzv8rlQcDU44c3qgTpHSU8htjdwICBAEC\ngYEAlpYTHWYrcd0HQXO3F9lPqwwfHUt7VBaSEUYrk3N3ZYCWvmV1qyKbB/kb1SBs\n4GfW1vP966HXCffnX92LDXYxi7It3TJaKmo8aF/leN7w8WLNJXUayEoQKUfKLprj\nN14Jx/tgMu7I/BOoHId8b7e57pBKtDiSF6WWn3K7tNPbfmkCQQDST41m62mC4MAa\nDsUdyM0Vg/tjduGqnygryCDEXDabdg95a3wMk0SQCQzZFHGNYnsXcffTqGs/y+5w\nQWxyOGSNAkEAzHFkDJla30NiiKvhu7dY+0+dGrfMA7pNUh+LGdXe5QFdjwwxqPbF\n7NMGXKMdB8agSCxGZC3bxdvYNF9LULzhEwJABpDYNSoQx+UMvaEN5XTpLmCHuS1r\nsmhfKZPcDx8Z7mAYda3wZEuHQq+cf6i5XhOO9P5QKpKeslHLAMHa7NaNgQJBAI03\nGGacYLwui32fbzb8BYRg82Kga/OW6btY+O6hNs6iSR2gBlQ9j3Tgrzo+N4R/NQSl\nc05wGO2RnBUwlu0XUckCQHfHsWHVrrADTpalbv+FTDyWd0ouHXBmDecVZh3e7/ue\ncdMoblzeasvgp8CjFa9U+uDozY+aL6TNIpG++nn4lNw=\n-----END RSA PRIVATE KEY-----\n",
+        "ksk_keytag": 37440,
+        "ksk_alg": 8,
+        "zsk": "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK8YnU+YqBxD/EDwVeHZsJillAJ80PCnLU+/rlGrlzgw+eabF8jT\nCaEwnpE74YHCLegKAAn+efeZrT/EBBrzlacCAgIBAkBh9VGFW2SJk1I9SBQaDIA9\nchdrrx+PHibSyozwT4eAPmd6OFoLausc7ls6v9evPeb+Yj3g0JXvTGp6BgNhFqLR\nAiEA1+ievAEBVM6IlOmpiTwlaWe/HV6MokBBq1G/tvJS0M8CIQDPm/DUsoTEv/Jj\n6O3U9hNcPLbvKMMGld2wbf7nrQmzqQIhAJrhwTaFdjnXhmfUB9a33vRIbSaIsLxA\nDyuM+03XP+YhAiEAmJIJz7WX9uPkCIy8wO655Hh4dt4UkBFRE98OqkHIwGkCIFFv\nN8rJojI+oEiJyNjEjWZD4qoUMUp3+YBl0htAJUE2\n-----END RSA PRIVATE KEY-----\n",
+        "zsk_keytag": 49016,
+        "zsk_alg": 8,
+        "inception": "2016-11-14T11:36:58.851612Z",
+        "until": "2017-02-12T11:36:58.849384Z"
+      }
+    ]
   }
 ]

--- a/src/admin/erldns_admin.erl
+++ b/src/admin/erldns_admin.erl
@@ -77,8 +77,8 @@ start(#{port := Port, username := Username, password := Password}) ->
             {'_', [
                 {"/", erldns_admin_root_handler, State},
                 {"/zones/:zone_name", erldns_admin_zone_resource_handler, State},
-                {"/zones/:zone_name/:action", erldns_admin_zone_control_handler, State},
-                {"/zones/:zone_name/records[/:record_name]", erldns_admin_zone_records_resource_handler, State}
+                {"/zones/:zone_name/records[/:record_name]", erldns_admin_zone_records_resource_handler, State},
+                {"/zones/:zone_name/:action", erldns_admin_zone_control_handler, State}
             ]}
         ]
     ),
@@ -93,8 +93,8 @@ start(#{port := Port, username := Username, password := Password}) ->
 is_authorized(Req, #{username := ValidUsername, password := ValidPassword} = State) ->
     maybe
         {basic, GivenUsername, GivenPassword} ?= cowboy_req:parse_header(<<"authorization">>, Req),
-        true ?= is_binary_of_equal_size(GivenUsername),
-        true ?= is_binary_of_equal_size(GivenPassword),
+        true ?= is_binary_of_equal_size(GivenUsername, ValidUsername),
+        true ?= is_binary_of_equal_size(GivenPassword, ValidPassword),
         true ?= crypto:hash_equals(GivenUsername, ValidUsername) andalso
             crypto:hash_equals(GivenPassword, ValidPassword),
         {true, Req, State}
@@ -103,9 +103,9 @@ is_authorized(Req, #{username := ValidUsername, password := ValidPassword} = Sta
             {{false, <<"Basic realm=\"erldns admin\"">>}, Req, State}
     end.
 
--spec is_binary_of_equal_size(term()) -> boolean().
-is_binary_of_equal_size(Bin) ->
-    is_binary(Bin) andalso byte_size(Bin) =:= byte_size(Bin).
+-spec is_binary_of_equal_size(term(), term()) -> boolean().
+is_binary_of_equal_size(Bin1, Bin2) ->
+    is_binary(Bin1) andalso is_binary(Bin2) andalso byte_size(Bin1) =:= byte_size(Bin2).
 
 -spec ensure_valid_config() -> false | disabled | config().
 ensure_valid_config() ->

--- a/src/admin/erldns_admin_zone_records_resource_handler.erl
+++ b/src/admin/erldns_admin_zone_records_resource_handler.erl
@@ -80,7 +80,7 @@ to_text(Req, State) ->
     {stop | cowboy_req:resp_body(), cowboy_req:req(), erldns_admin:handler_state()}.
 to_json(Req, State) ->
     ZoneName = cowboy_req:binding(zone_name, Req),
-    RecordName = cowboy_req:binding(record_name, Req, <<"">>),
+    RecordName = cowboy_req:binding(record_name, Req, <<>>),
     Params = cowboy_req:parse_qs(Req),
     case lists:keyfind(<<"type">>, 1, Params) of
         false ->

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -171,53 +171,53 @@ encode_record(Record, Encoders) ->
             EncodedRecord
     end.
 
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SOA, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_SOA, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NS, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_NS, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_A, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_A, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_AAAA, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_AAAA, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CNAME, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_CNAME, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_MX, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_MX, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_HINFO, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_HINFO, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_TXT, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_TXT, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SPF, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_SPF, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SSHFP, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_SSHFP, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_SRV, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_SRV, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_NAPTR, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_NAPTR, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CAA, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_CAA, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DS, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_DS, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDS, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_CDS, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_DNSKEY, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_DNSKEY, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_CDNSKEY, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_CDNSKEY, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
-encode_record({dns_rr, Name, _, Type = ?DNS_TYPE_RRSIG, Ttl, Data}) ->
+encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_RRSIG, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
 encode_record(Record) ->
     lager:warning("Unable to encode record (record: ~p)", [Record]),
     [].
 
 encode_record(Name, Type, Ttl, Data) ->
-    [
-        {<<"name">>, erlang:iolist_to_binary(io_lib:format("~s.", [Name]))},
-        {<<"type">>, dns:type_name(Type)},
-        {<<"ttl">>, Ttl},
-        {<<"content">>, encode_data(Data)}
-    ].
+    #{
+        <<"name">> => erlang:iolist_to_binary(io_lib:format("~s.", [Name])),
+        <<"type">> => dns:type_name(Type),
+        <<"ttl">> => Ttl,
+        <<"content">> => encode_data(Data)
+    }.
 
 try_custom_encoders(_Record, []) ->
     {};
@@ -262,14 +262,16 @@ encode_data({dns_rrdata_ds, Keytag, Alg, DigestType, Digest}) ->
 encode_data({dns_rrdata_cds, Keytag, Alg, DigestType, Digest}) ->
     erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~s", [Keytag, Alg, DigestType, Digest]));
 encode_data({dns_rrdata_dnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    binary:encode_hex(erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag])));
 encode_data({dns_rrdata_cdnskey, Flags, Protocol, Alg, Key, KeyTag}) ->
-    erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag]));
+    binary:encode_hex(erlang:iolist_to_binary(io_lib:format("~w ~w ~w ~w ~w", [Flags, Protocol, Alg, Key, KeyTag])));
 encode_data({dns_rrdata_rrsig, TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature}) ->
-    erlang:iolist_to_binary(
-        io_lib:format(
-            "~w ~w ~w ~w ~w ~w ~w ~w ~s",
-            [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]
+    binary:encode_hex(
+        erlang:iolist_to_binary(
+            io_lib:format(
+                "~w ~w ~w ~w ~w ~w ~w ~w ~s",
+                [TypeCovered, Alg, Labels, OriginalTtl, Expiration, Inception, KeyTag, SignersName, Signature]
+            )
         )
     );
 encode_data(Data) ->

--- a/src/metrics/erldns_metrics.erl
+++ b/src/metrics/erldns_metrics.erl
@@ -63,7 +63,7 @@ start(#{port := Port}) ->
             ]}
         ]
     ),
-    TransportOpts = #{socket_opts => [inet, inet6, {ip, {0, 0, 0, 0}}, {port, Port}]},
+    TransportOpts = #{socket_opts => [inet, inet6, {ip, any}, {port, Port}]},
     ProtocolOpts = #{env => #{dispatch => Dispatch}},
     cowboy:start_clear(?MODULE, TransportOpts, ProtocolOpts).
 

--- a/test/admin_endpoint_SUITE.erl
+++ b/test/admin_endpoint_SUITE.erl
@@ -1,0 +1,245 @@
+-module(admin_endpoint_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-behaviour(ct_suite).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-spec all() -> [ct_suite:ct_test_def()].
+all() ->
+    [{group, all}].
+
+-spec groups() -> [ct_suite:ct_group_def()].
+groups() ->
+    [
+        {all, [parallel], [
+            bad_auth,
+            get_zones,
+            get_not_found_resource,
+            get_zone_resources,
+            get_zone_resources_with_metaonly,
+            fake_action_zone,
+            get_zone_record_resource,
+            get_zone_record_resource_name,
+            get_zone_record_resource_name_type,
+            get_zone_record_resource_name_type_non_existing
+        ]}
+    ].
+
+-spec init_per_suite(ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_suite(Config) ->
+    Servers = [
+        [
+            {name, inet_localhost_1},
+            {address, "127.0.0.1"},
+            {port, 8053},
+            {family, inet},
+            {processes, 10}
+        ]
+    ],
+    AdminPort = 8083,
+    AppConfig = [
+        {erldns, [
+            {servers, Servers},
+            {ff_use_txts_field, true},
+            {admin, [
+                {credentials, {<<"username">>, <<"password">>}},
+                {port, AdminPort}
+            ]}
+        ]}
+    ],
+    application:set_env(AppConfig),
+    {ok, _} = application:ensure_all_started([erldns, ssl, inets]),
+    FileName = filename:join([code:priv_dir(erldns), "zones-example.json"]),
+    {ok, _} = erldns_storage:load_zones(FileName),
+    [{port, AdminPort} | Config].
+
+-spec end_per_suite(ct_suite:ct_config()) -> term().
+end_per_suite(_) ->
+    application:stop(erldns).
+
+-spec init_per_group(ct_suite:ct_groupname(), ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_group(_, Config) ->
+    Config.
+
+-spec end_per_group(ct_suite:ct_groupname(), ct_suite:ct_config()) -> term().
+end_per_group(_, _Config) ->
+    ok.
+
+-spec init_per_testcase(ct_suite:ct_testcase(), ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_testcase(_, Config) ->
+    Config.
+
+-spec end_per_testcase(ct_suite:ct_testcase(), ct_suite:ct_config()) -> term().
+end_per_testcase(_, Config) ->
+    Config.
+
+%% Tests
+bad_auth(CtConfig) ->
+    Request = {endpoint(CtConfig, ""), headers(bad_auth)},
+    case httpc:request(get, Request, [], []) of
+        {_, {{_Version, 401, "Unauthorized"}, _Headers, _Body}} ->
+            ok;
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zones(CtConfig) ->
+    Request = {endpoint(CtConfig, ""), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch(
+                #{
+                    <<"erldns">> :=
+                        #{
+                            <<"zones">> :=
+                                #{<<"count">> := 1, <<"versions">> := _}
+                        }
+                },
+                Body
+            );
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_not_found_resource(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/non_existing_zone.bad"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 404, "Not Found"}, _Headers, _Payload}} ->
+            ok;
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zone_resources(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch(
+                #{
+                    <<"erldns">> :=
+                        #{
+                            <<"zone">> :=
+                                #{
+                                    <<"name">> := <<"example.com">>,
+                                    <<"records">> := _,
+                                    <<"records_count">> := 11,
+                                    <<"version">> := <<>>
+                                }
+                        }
+                },
+                Body
+            );
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zone_resources_with_metaonly(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com?metaonly=true"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch(
+                #{
+                    <<"erldns">> :=
+                        #{
+                            <<"zone">> :=
+                                #{
+                                    <<"name">> := <<"example.com">>,
+                                    <<"records_count">> := 11,
+                                    <<"version">> := <<>>
+                                }
+                        }
+                },
+                Body
+            );
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+fake_action_zone(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com/get"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, ""}} ->
+            ok;
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+% {"/zones/:zone_name/records[/:record_name]", erldns_admin_zone_records_resource_handler, State}
+get_zone_record_resource(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com/records"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch([], Body);
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zone_record_resource_name(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com/records/www.example.com"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch(
+                [
+                    #{
+                        <<"content">> := <<"example.com.">>,
+                        <<"name">> := <<"www.example.com.">>,
+                        <<"ttl">> := 120,
+                        <<"type">> := <<"A">>
+                    }
+                ],
+                Body
+            );
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zone_record_resource_name_type(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com/records/www.example.com?type=CNAME"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch(
+                [
+                    #{
+                        <<"content">> := <<"example.com.">>,
+                        <<"name">> := <<"www.example.com.">>,
+                        <<"ttl">> := 120,
+                        <<"type">> := <<"A">>
+                    }
+                ],
+                Body
+            );
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+get_zone_record_resource_name_type_non_existing(CtConfig) ->
+    Request = {endpoint(CtConfig, "/zones/example.com/records/www.example.com?type=A"), headers(good)},
+    case httpc:request(get, Request, [], []) of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Payload}} ->
+            Body = json:decode(iolist_to_binary(Payload)),
+            ?assertMatch([], Body);
+        {_, Other} ->
+            ct:fail(Other)
+    end.
+
+endpoint(CtConfig, Path) ->
+    Port = proplists:get_value(port, CtConfig),
+    "http://localhost:" ++ integer_to_list(Port) ++ Path.
+
+headers(good) ->
+    [
+        {"accept", "application/json"},
+        {"authorization", "basic " ++ base64:encode("username:password")}
+    ];
+headers(bad_auth) ->
+    [
+        {"accept", "application/json"},
+        {"authorization", "basic " ++ base64:encode("bad_username:bad_password")}
+    ].


### PR DESCRIPTION
Relates to https://github.com/dnsimple/erldns/pull/192, adds some tests to it and fixes a couple of bugs:
- Authentication would crash if the provided token wasn't of the same length.
- DNSSEC would fail to build a json file when fetching over the admin API because the key wouldn't be a valid JSON tag and would fail to convert to JSON. I suspect this bug to be very very old.