### PR TITLE
Fix exporting an unsupported map_nsec_rr_types

### DIFF
--- a/src/erldns_dnssec.erl
+++ b/src/erldns_dnssec.erl
@@ -28,6 +28,7 @@
 -export([maybe_sign_rrset/3]).
 
 -export([map_nsec_rr_types/1]).
+-export([map_nsec_rr_types/2]).
 
 -define(NEXT_DNAME_PART, <<"\000">>).
 


### PR DESCRIPTION
The new API might be needed from dependants in their testing.