### PR TITLE
Implement a new TCP server engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,15 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          parallel: true
           file: _build/test/covertool/erldns.covertool.xml
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v1
+        with:
+          parallel-finished: true

--- a/erldns.example.config
+++ b/erldns.example.config
@@ -1,21 +1,24 @@
 [
-  {erldns,[
-      {servers, [
-        [{name, inet_localhost_1}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}, {processes, 2}],
-        [{name, inet6_localhost_1}, {address, "::1"}, {port, 8053}, {family, inet6}]
-      ]},
+    {erldns, [
+        {servers, [
+            [{name, inet_localhost_1}, {address, "127.0.0.1"}, {port, 8053}, {with_tcp, false}, {family, inet}, {processes, 2}],
+            [{name, inet6_localhost_1}, {address, "::1"}, {port, 8053}, {with_tcp, false}, {family, inet6}]
+        ]},
+        {listeners, #{
+            test_tcp => #{protocol => tcp, port => 8053}
+        }},
 
-      {dnssec, [
-        {enabled, true}
-      ]},
+        {dnssec, [
+            {enabled, true}
+        ]},
 
-      {use_root_hints, false},
-      {catch_exceptions, false},
-      {zones, "priv/zones-example.json"},
-      {pools, [
-          {tcp_worker_pool, erldns_worker, [
-              {size, 10},
-              {max_overflow, 20}
+        {use_root_hints, false},
+        {catch_exceptions, false},
+        {zones, "priv/zones-example.json"},
+        {pools, [
+            {tcp_worker_pool, erldns_worker, [
+                {size, 10},
+                {max_overflow, 20}
             ]}
         ]}
     ]},

--- a/rebar.config
+++ b/rebar.config
@@ -40,6 +40,11 @@
     {nodefinder, "2.0.7"}
 ]}.
 
+{dist_node, [
+    {setcookie, 'erldns-cookie'},
+    {sname, erldns}
+]}.
+
 {overrides, [
     {override, cowboy, [{deps, [{cowlib, "~> 2.0"}]}]}
 ]}.
@@ -49,7 +54,7 @@
         {deps, [
             {proper, "1.5.0"},
             {meck, "1.0.0"},
-            {dnstest, ".*", {git, "https://github.com/dnsimple/dnstest", {ref, "25333aeb7abb4d1a0752d59654677e42d8ae59ca"}}}
+            {dnstest, ".*", {git, "https://github.com/dnsimple/dnstest", {ref, "13bb31a91be0c9b7ba1f64a046572d84815e8e24"}}}
         ]},
         {erl_opts, [nowarn_export_all, nowarn_missing_spec, nowarn_missing_doc]},
         {eunit_opts, [verbose]},
@@ -108,7 +113,8 @@
     {print_width, 140},
     {files, [
         "{src,test,include}/**/*.{hrl,erl,app.src}",
-        "rebar.config"
+        "rebar.config",
+        "erldns.example.config"
     ]}
 ]}.
 

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -83,7 +83,8 @@ get_servers() ->
                         {address, parse_address(keyget(address, Server))},
                         {port, keyget(port, Server)},
                         {family, keyget(family, Server)},
-                        {processes, keyget(processes, Server, 1)}
+                        {processes, keyget(processes, Server, 1)},
+                        {with_tcp, keyget(with_tcp, Server, true)}
                     ]
                 end,
                 Servers

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -64,8 +64,11 @@ init(_Args) ->
             ?CHILD(erldns_packet_cache, worker, []),
             ?CHILD(erldns_query_throttle, worker, []),
             ?CHILD(erldns_handler, worker, []),
-            ?CHILD(sample_custom_handler, worker, [])
-            | erldns_listeners:child_specs()
+            ?CHILD(sample_custom_handler, worker, []),
+            #{
+                id => erldns_listeners,
+                start => {erldns_listeners, start_link, []},
+                type => supervisor
+            }
         ],
-
-    {ok, {{one_for_one, 20, 10}, SysProcs}}.
+    {ok, {#{strategy => one_for_one, intensity => 20, period => 10}, SysProcs}}.

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -65,6 +65,7 @@ init(_Args) ->
             ?CHILD(erldns_query_throttle, worker, []),
             ?CHILD(erldns_handler, worker, []),
             ?CHILD(sample_custom_handler, worker, [])
+            | erldns_listeners:child_specs()
         ],
 
     {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/listeners/erldns_listeners.erl
+++ b/src/listeners/erldns_listeners.erl
@@ -1,0 +1,76 @@
+-module(erldns_listeners).
+-moduledoc """
+DNS listeners configuration.
+
+At the moment it supports only TCP.
+
+In order to configure, add to the application environment:
+
+```erlang
+{erldns, [
+    {listeners, #{
+        Name => #{protocol => tcp, ip => IP, port => Port}
+    }}
+]}
+```
+where `Name` is any desired name,
+`IP` is `any` or a valid ip address in tuple or string format,
+and `Port` is a valid port.
+""".
+
+-define(DEFAULT_PORT, 53).
+-define(DEFAULT_IP, any).
+
+-export([child_specs/0]).
+
+-spec child_specs() -> [supervisor:child_spec()].
+child_specs() ->
+    Listeners = application:get_env(erldns, listeners, #{}),
+    [tcp_child_spec(Name, Config) || Name := #{protocol := tcp} = Config <- Listeners].
+
+tcp_child_spec(Name, Config) ->
+    IP = get_ip(Name, Config),
+    Port = get_port(Name, Config),
+    Timeout = erldns_config:ingress_tcp_request_timeout(),
+    SocketOpts = [
+        {ip, IP},
+        {port, Port},
+        {send_timeout, Timeout},
+        {keepalive, true},
+        {reuseport, true},
+        {reuseport_lb, true}
+    ],
+    Parallelism = erlang:system_info(schedulers),
+    TransOpts = #{
+        %% Potentially introduce a cap on the concurrent QPS.
+        max_connections => infinity,
+        num_acceptors => Parallelism,
+        num_conns_sups => Parallelism,
+        num_listen_sockets => Parallelism,
+        socket_opts => SocketOpts
+    },
+    ProtoOpts = [],
+    ranch:child_spec({?MODULE, Name}, ranch_tcp, TransOpts, erldns_tcp_proto, ProtoOpts).
+
+get_ip(Name, Config) ->
+    case maps:get(ip, Config, ?DEFAULT_IP) of
+        any ->
+            any;
+        IP when is_tuple(IP), tuple_size(IP) =:= 4 orelse tuple_size(IP) =:= 16 ->
+            IP;
+        IP when is_list(IP) ->
+            case inet:parse_address(IP) of
+                {ok, IpAddr} ->
+                    IpAddr;
+                {error, _} ->
+                    error({invalid_listener_ip, Name, Config})
+            end
+    end.
+
+get_port(Name, Config) ->
+    case maps:get(port, Config, ?DEFAULT_PORT) of
+        Port when is_integer(Port), 0 =< Port, Port =< 65535 ->
+            Port;
+        _ ->
+            error({invalid_listener_port, Name, Config})
+    end.

--- a/src/listeners/erldns_listeners.erl
+++ b/src/listeners/erldns_listeners.erl
@@ -71,13 +71,13 @@ get_ip(Name, Config) ->
         IP when is_tuple(IP), tuple_size(IP) =:= 4 ->
             [inet, {ip, IP}];
         IP when is_tuple(IP), tuple_size(IP) =:= 8 ->
-            [inet6, {ipv6_v6only, false}, {ip, IP}];
+            [inet6, {ip, IP}];
         IP when is_list(IP) ->
             case inet:parse_address(IP) of
                 {ok, IpAddr} when is_tuple(IpAddr), tuple_size(IpAddr) =:= 4 ->
                     [inet, {ip, IpAddr}];
                 {ok, IpAddr} when is_tuple(IpAddr), tuple_size(IpAddr) =:= 8 ->
-                    [inet6, {ipv6_v6only, false}, {ip, IpAddr}];
+                    [inet6, {ip, IpAddr}];
                 {error, _} ->
                     error({invalid_listener_ip, Name, Config})
             end

--- a/src/listeners/erldns_listeners.erl
+++ b/src/listeners/erldns_listeners.erl
@@ -62,7 +62,7 @@ tcp_child_spec(Name, Config) ->
         socket_opts => SocketOpts
     },
     ProtoOpts = [],
-    ranch:child_spec({?MODULE, Name}, ranch_tcp, TransOpts, erldns_tcp_proto, ProtoOpts).
+    ranch:child_spec({?MODULE, Name}, ranch_tcp, TransOpts, erldns_proto_tcp, ProtoOpts).
 
 get_ip(Name, Config) ->
     case maps:get(ip, Config, ?DEFAULT_IP) of

--- a/src/listeners/erldns_proto_tcp.erl
+++ b/src/listeners/erldns_proto_tcp.erl
@@ -1,4 +1,4 @@
--module(erldns_tcp_proto).
+-module(erldns_proto_tcp).
 -moduledoc false.
 
 -include_lib("kernel/include/logger.hrl").

--- a/src/listeners/erldns_tcp_proto.erl
+++ b/src/listeners/erldns_tcp_proto.erl
@@ -1,0 +1,109 @@
+-module(erldns_tcp_proto).
+-moduledoc false.
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("dns_erlang/include/dns.hrl").
+
+-behaviour(ranch_protocol).
+-export([start_link/3]).
+-export([init/1]).
+-export([init_timer/2]).
+
+-spec start_link(ranch:ref(), module(), any()) -> dynamic().
+start_link(Ref, _Transport, _Opts) ->
+    SpawnOpts = [{min_heap_size, 500}],
+    proc_lib:start_link(?MODULE, init, [Ref], 5000, SpawnOpts).
+
+-spec init(ranch:ref()) -> dynamic().
+init(Ref) ->
+    Self = self(),
+    proc_lib:init_ack({ok, Self}),
+    proc_lib:set_label(?MODULE),
+    TS = erlang:monotonic_time(),
+    Timeout = erldns_config:ingress_tcp_request_timeout(),
+    {Pid, _Ref} = erlang:spawn_monitor(?MODULE, init_timer, [Timeout, Self]),
+    {ok, Socket} = ranch:handshake(Ref),
+    loop(Socket, TS, Timeout, Pid).
+
+-spec init_timer(integer(), pid()) -> any().
+init_timer(Timeout, Parent) ->
+    receive
+    after Timeout -> exit(Parent, kill)
+    end.
+
+loop(Socket, TS, Timeout, Pid) ->
+    inet:setopts(Socket, [{active, once}]),
+    receive
+        {tcp, Socket, <<Len:16, Bin/binary>>} ->
+            loop(Socket, TS, Timeout, Pid, Len, Bin);
+        {tcp_error, Socket, Reason} ->
+            ?LOG_INFO(#{what => tcp_error, reason => Reason});
+        {tcp_closed, Socket} ->
+            ok
+    after Timeout ->
+        gen_tcp:close(Socket)
+    end.
+
+loop(Socket, TS, _, Pid, Len, Acc) when Len =:= byte_size(Acc) ->
+    handle_tcp_query(Socket, TS, Pid, Acc);
+loop(Socket, TS, Timeout, Pid, Len, Acc) ->
+    inet:setopts(Socket, [{active, once}]),
+    receive
+        {tcp, Socket, Bin} ->
+            loop(Socket, TS, Timeout, Pid, Len, <<Acc/binary, Bin/binary>>);
+        {tcp_error, Socket, Reason} ->
+            ?LOG_INFO(#{what => tcp_error, reason => Reason});
+        {tcp_closed, Socket} ->
+            ok
+    after Timeout ->
+        gen_tcp:close(Socket)
+    end.
+
+handle_tcp_query(Socket, TS, Pid, Bin) ->
+    try
+        {ok, {Address, _Port}} = inet:peername(Socket),
+        case erldns_decoder:decode_message(Bin) of
+            {trailing_garbage, DecodedMessage, TrailingGarbage} ->
+                ?LOG_INFO(#{what => trailing_garbage, trailing_garbage => TrailingGarbage}),
+                handle_decoded_tcp_message(Socket, TS, Pid, DecodedMessage, Address);
+            {Error, Message, _} ->
+                ?LOG_INFO(#{what => error_decoding, error => Error, message => Message}),
+                ok;
+            DecodedMessage ->
+                handle_decoded_tcp_message(Socket, TS, Pid, DecodedMessage, Address)
+        end
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{
+                what => handle_tcp_query_error,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            })
+    end.
+
+handle_decoded_tcp_message(Socket, TS0, Pid, DecodedMessage, Address) ->
+    case DecodedMessage#dns_message.qr of
+        false ->
+            Response = erldns_handler:do_handle(DecodedMessage, Address),
+            EncodedResponse = erldns_encoder:encode_message(Response),
+            exit(Pid, kill),
+            gen_tcp:send(Socket, [byte_size(EncodedResponse), EncodedResponse]),
+            measure_time(DecodedMessage, EncodedResponse, tcp, TS0);
+        true ->
+            {error, not_a_question}
+    end.
+
+measure_time(DecodedMessage, EncodedResponse, Protocol, TS0) ->
+    TS1 = erlang:monotonic_time(),
+    Measurements = #{
+        monotonic_time => TS1,
+        duration => TS1 - TS0,
+        response_size => byte_size(EncodedResponse)
+    },
+    DnsSec = proplists:get_bool(dnssec, erldns_edns:get_opts(DecodedMessage)),
+    Metadata = #{
+        protocol => Protocol,
+        dnssec => DnsSec
+    },
+    telemetry:execute([erldns, request, processed], Measurements, Metadata).

--- a/test/app_helper.erl
+++ b/test/app_helper.erl
@@ -1,0 +1,42 @@
+-module(app_helper).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+
+start_erldns(Config, Env) ->
+    Self = self(),
+    Ref = make_ref(),
+    {Pid, MonitorRef} = spawn_monitor(fun() ->
+        Res = ?CT_PEER(["-pa" | code:get_path()]),
+        Self ! {Ref, Res},
+        receive
+            stop ->
+                ok
+        end
+    end),
+    receive
+        {Ref, {ok, Peer, Node}} ->
+            erlang:demonitor(MonitorRef, [flush]),
+            NewConfig = [{pid, Pid}, {peer, Peer}, {node, Node} | Config],
+            do_start_erldns(NewConfig, Env);
+        {Ref, Other} ->
+            exit(Other);
+        {'DOWN', MonitorRef, _, _, _} ->
+            exit({peer, died})
+    after 10000 ->
+        exit({peer, timeout})
+    end.
+
+do_start_erldns(Config, Env) ->
+    Node = proplists:get_value(node, Config),
+    ok = erpc:call(Node, application, set_env, [Env]),
+    {ok, _} = erpc:call(Node, application, ensure_all_started, [erldns]),
+    {ok, _} = erpc:call(Node, erldns_storage, load_zones, []),
+    Config.
+
+get_node(Config) ->
+    proplists:get_value(node, Config).
+
+stop(Config) ->
+    Pid = proplists:get_value(pid, Config),
+    Pid ! stop.

--- a/test/config_test.erl
+++ b/test/config_test.erl
@@ -21,7 +21,10 @@ get_servers_empty_list_test() ->
 
 get_servers_single_server_test() ->
     application:set_env(erldns, servers, [[{name, example}, {address, "127.0.0.1"}, {port, 8053}, {family, inet}]]),
-    ?assertEqual([[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}]], erldns_config:get_servers()).
+    ?assertEqual(
+        [[{name, example}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}, {with_tcp, true}]],
+        erldns_config:get_servers()
+    ).
 
 get_servers_multiple_servers_test() ->
     application:set_env(
@@ -34,8 +37,8 @@ get_servers_multiple_servers_test() ->
     ),
     ?assertEqual(
         [
-            [{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}],
-            [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}]
+            [{name, example_inet}, {address, {127, 0, 0, 1}}, {port, 8053}, {family, inet}, {processes, 1}, {with_tcp, true}],
+            [{name, example_inet6}, {address, {0, 0, 0, 0, 0, 0, 0, 1}}, {port, 8053}, {family, inet6}, {processes, 1}, {with_tcp, true}]
         ],
         erldns_config:get_servers()
     ).


### PR DESCRIPTION
Implement a new TCP engine on top of ranch and #213. Relates to https://github.com/dnsimple/erldnsimple/issues/417.

Only question is if we want to introduce a number into the ranch configuration for the maximum number of connections. In that case ranch would throttle incoming traffic. Currently is set to infinity, that is, no throttling of new connections.