### PR TITLE
Avoid hot-code calls to a cache gen_server by using an ets table

### DIFF
--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -38,13 +38,12 @@ Emits the following telemetry events:
     start_link/0,
     register_handler/2,
     register_handler/3,
-    get_handlers/0,
     get_versioned_handlers/0,
     handle/2
 ]).
 -export([do_handle/2]).
 % Gen server hooks
--export([init/1, handle_call/3, handle_cast/2, terminate/2]).
+-export([init/1, handle_call/3, handle_cast/2]).
 % Internal API
 -export([handle_message/2]).
 
@@ -59,30 +58,22 @@ Emits the following telemetry events:
 -doc "Start the handler registry process".
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, noargs, []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, noargs, [{hibernate_after, 1000}]).
 
 -doc "Register a record handler with the default version of 1".
 -spec register_handler([dns:type()], module()) -> ok.
 register_handler(RecordTypes, Module) ->
     register_handler(RecordTypes, Module, ?DEFAULT_HANDLER_VERSION).
 
--doc "Register a record handler with version".
+-doc "Register a record handler with a version number".
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
     gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
 
--doc "Get all registered handlers of version 1 along with the DNS types they handle".
--spec get_handlers() -> [handler()].
-get_handlers() ->
-    Handlers = gen_server:call(?MODULE, get_handlers),
-    % return only Version 1 handlers
-    % strip version information for Version handlers
-    [{M, Types} || {M, Types, ?DEFAULT_HANDLER_VERSION} <- Handlers].
-
 -doc "Get all registered handlers along with the DNS types they handle and associated versions".
 -spec get_versioned_handlers() -> [versioned_handler()].
 get_versioned_handlers() ->
-    gen_server:call(?MODULE, get_handlers).
+    ets:lookup_element(?MODULE, handlers, 2, []).
 
 %% If the message has trailing garbage just throw the garbage away and continue
 %% trying to process the message.
@@ -233,27 +224,24 @@ notify_empty_response(Message) ->
 -doc false.
 -spec init(noargs) -> {ok, state()}.
 init(noargs) ->
+    ets:new(?MODULE, [named_table, protected, set, {read_concurrency, true}]),
     {ok, #handlers_state{}}.
 
 -doc false.
 -spec handle_call
     ({register_handler, [dns:type()], module(), integer()}, gen_server:from(), state()) ->
         {reply, ok, state()};
-    (get_handlers, gen_server:from(), state()) ->
-        {reply, [versioned_handler()], state()}.
+    (term(), gen_server:from(), state()) ->
+        {reply, not_implemented, state()}.
 handle_call({register_handler, RecordTypes, Module, Version}, _, State) ->
     ?LOG_INFO("Registered handler (module: ~p, types: ~p, version: ~p)", [Module, RecordTypes, Version]),
     NewHandlers = [{Module, RecordTypes, Version} | State#handlers_state.handlers],
+    ets:insert(?MODULE, {handlers, NewHandlers}),
     {reply, ok, State#handlers_state{handlers = NewHandlers}};
-handle_call(get_handlers, _, State) ->
-    {reply, State#handlers_state.handlers, State}.
+handle_call(_, _, State) ->
+    {reply, not_implemented, State}.
 
 -doc false.
 -spec handle_cast(term(), state()) -> {noreply, state()}.
 handle_cast(_, State) ->
     {noreply, State}.
-
--doc false.
--spec terminate(term(), state()) -> any().
-terminate(_, _) ->
-    erldns_storage:delete_table(handler_registry).


### PR DESCRIPTION
This gen_server is called for handlers on _every_ single request, when the handlers could be just stored on ets tables that incur next to no contention at runtime.