### PR TITLE
Create worker mailbox length telemetry event

### DIFF
--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -94,7 +94,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 report_message_queue_len() ->
     Self = self(),
-    QueueLen = erlang:process_info(Self, message_queue_len),
+    {message_queue_len, QueueLen} = erlang:process_info(Self, message_queue_len),
     telemetry:execute([erldns, worker, message_queue_len], #{count => QueueLen}, #{pid => Self}).
 
 %% @doc Handle DNS query that comes in over TCP

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -93,8 +93,9 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 report_message_queue_len() ->
-    QueueLen = erlang:process_info(self(), message_queue_len),
-    telemetry:execute([erldns, worker, message_queue_len], #{count => QueueLen}, #{}).
+    Self = self(),
+    QueueLen = erlang:process_info(Self, message_queue_len),
+    telemetry:execute([erldns, worker, message_queue_len], #{count => QueueLen}, #{pid => Self}).
 
 %% @doc Handle DNS query that comes in over TCP
 -spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()}, integer()) ->


### PR DESCRIPTION
As described [here](https://github.com/dnsimple/chef-dnsimple_erldnsimple/pull/415#issuecomment-2893335620), this creates an event with the current mailbox size of the worker processes that is triggered on every new message process, which gives an idea of the pending amount of work.