### PR TITLE
Apply new elvis rules to further directories

### DIFF
--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -17,7 +17,7 @@
     %% We're assuming zones were stored with names already normalised,
     %% hence removing the need to re-normalize them on every fetch
     name :: dns:dname(),
-    version :: binary(),
+    version :: erldns_zones:version(),
     authority = [] :: dns:authority(),
     record_count = 0 :: non_neg_integer(),
     records = [] :: [dns:rr()] | trimmed,

--- a/rebar.config
+++ b/rebar.config
@@ -143,16 +143,28 @@
 
 {elvis, [
     #{
-        dirs => ["src"],
+        dirs => ["src/**"],
         filter => "*.erl",
         rules => [
             %% TODO: fix
+            {elvis_text_style, line_length, #{ignore => [erldns_resolver, erldns_zone_cache]}},
+            {elvis_style, no_operation_on_same_value, #{ignore => [erldns_resolver]}},
+            {elvis_style, param_pattern_matching, #{ignore => [erldns_zone_cache]}},
+            {elvis_style, export_used_types, #{ignore => [erldns_resolver]}},
+            {elvis_style, always_shortcircuit, #{ignore => [erldns_dnssec]}},
+            {elvis_style, consistent_generic_type, #{ignore => [erldns_resolver]}},
+            {elvis_style, max_module_length, #{ignore => [erldns_resolver, erldns_zone_cache]}},
+            {elvis_style, max_function_length, disable},
+            {elvis_style, max_function_clause_length, disable},
             {elvis_style, dont_repeat_yourself, disable},
             {elvis_style, invalid_dynamic_call, disable},
             %% NOTE: keep
+            {elvis_style, no_common_caveats_call, #{ignore => [{erldns_proto_udp_sup, name, 2}]}},
+            {elvis_style, no_macros, disable},
+            {elvis_style, state_record_and_type, disable},
             {elvis_style, private_data_types, disable}
         ],
-        ruleset => erl_files,
+        ruleset => erl_files_strict,
         ignore => ['DNS-ASN1']
     },
     #{

--- a/src/admin/erldns_admin.erl
+++ b/src/admin/erldns_admin.erl
@@ -26,6 +26,7 @@ middleware modules that will be applied to all admin API requests.
 
 -ifdef(TEST).
 -export([middleware/1]).
+-export_type([env/0]).
 -endif.
 
 -doc """
@@ -47,7 +48,7 @@ Configuration parameters, see the module documentation for details.
 
 -type env() :: [{atom(), term()}].
 
--spec maybe_start() -> ok | {ok, pid()} | {error, any()}.
+-spec maybe_start() -> ok | {ok, pid()} | {error, term()}.
 maybe_start() ->
     case ensure_valid_config() of
         disabled ->
@@ -58,7 +59,7 @@ maybe_start() ->
             start(Config)
     end.
 
--spec start(config()) -> {ok, pid()} | {error, any()}.
+-spec start(config()) -> {ok, pid()} | {error, term()}.
 start(#{port := Port, username := Username, password := Password} = Config) ->
     State = #{username => Username, password => Password},
     Dispatch = cowboy_router:compile(

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -26,6 +26,6 @@ Convenience API to start erldns directly.
 -type keyset() :: #keyset{}.
 -type zone() :: #zone{}.
 
--spec start() -> any().
+-spec start() -> term().
 start() ->
     application:ensure_all_started(erldns).

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -24,6 +24,7 @@ The meat of the resolution occurs in erldns_resolver:resolve/3
 -include_lib("kernel/include/logger.hrl").
 
 -define(DEFAULT_HANDLER_VERSION, 1).
+-define(TIMEOUT, 5000).
 
 -export([
     start_link/0,
@@ -55,7 +56,7 @@ register_handler(RecordTypes, Module) ->
 -doc "Register a record handler with version".
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
-    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}, 5000).
+    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}, ?TIMEOUT).
 
 -doc "Get all registered handlers along with the DNS types they handle and associated versions".
 -spec get_versioned_handlers() -> [versioned_handler()].

--- a/src/erldns_handler.erl
+++ b/src/erldns_handler.erl
@@ -55,7 +55,7 @@ register_handler(RecordTypes, Module) ->
 -doc "Register a record handler with version".
 -spec register_handler([dns:type()], module(), integer()) -> ok.
 register_handler(RecordTypes, Module, Version) ->
-    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}).
+    gen_server:call(?MODULE, {register_handler, RecordTypes, Module, Version}, 5000).
 
 -doc "Get all registered handlers along with the DNS types they handle and associated versions".
 -spec get_versioned_handlers() -> [versioned_handler()].

--- a/src/listeners/erldns_listeners.erl
+++ b/src/listeners/erldns_listeners.erl
@@ -321,5 +321,8 @@ get_pfactor(Config) ->
     end.
 
 trigger_delayed(_Ref, _Alarm, _SupPid, _ConnPids) ->
-    ?LOG_WARNING(#{what => tcp_acceptor_delayed, transport => tcp}, #{domain => [erldns, listeners]}),
+    ?LOG_WARNING(
+        #{what => tcp_acceptor_delayed, transport => tcp},
+        #{domain => [erldns, listeners]}
+    ),
     telemetry:execute([erldns, request, delayed], #{count => 1}, #{transport => tcp}).

--- a/src/listeners/erldns_proto_tcp.erl
+++ b/src/listeners/erldns_proto_tcp.erl
@@ -38,6 +38,8 @@ loop(Socket, TimerPid, TS, IngressTimeoutMs) ->
             ?LOG_INFO(#{what => tcp_error, reason => Reason}, #{domain => [erldns, listeners]});
         {tcp_closed, Socket} ->
             ok
+    after IngressTimeoutMs ->
+        gen_tcp:close(Socket)
     end.
 
 -spec loop(inet:socket(), pid(), integer(), integer(), non_neg_integer(), binary()) -> dynamic().
@@ -52,6 +54,8 @@ loop(Socket, TimerPid, TS, IngressTimeoutMs, Len, Acc) ->
             ?LOG_INFO(#{what => tcp_error, reason => Reason}, #{domain => [erldns, listeners]});
         {tcp_closed, Socket} ->
             ok
+    after IngressTimeoutMs ->
+        gen_tcp:close(Socket)
     end.
 
 handle_if_within_time(Socket, TimerPid, TS, IngressTimeoutMs, Bin) ->
@@ -70,8 +74,8 @@ handle_if_within_time(Socket, TimerPid, TS, IngressTimeoutMs, Bin) ->
 -spec handle(inet:socket(), pid(), integer(), binary()) -> dynamic().
 handle(Socket, TimerPid, TS, Bin) ->
     Measurements = #{monotonic_time => TS, request_size => byte_size(Bin)},
-    Metadata = #{transport => tcp},
-    telemetry:execute([erldns, request, start], Measurements, Metadata),
+    InitMetadata = #{transport => tcp},
+    telemetry:execute([erldns, request, start], Measurements, InitMetadata),
     try
         {ok, {IpAddr, _Port}} = inet:peername(Socket),
         case dns:decode_message(Bin) of
@@ -89,10 +93,10 @@ handle(Socket, TimerPid, TS, Bin) ->
         end
     catch
         Class:Reason:Stacktrace ->
-            MetaData = #{
+            ExceptionMetadata = #{
                 transport => tcp, kind => Class, reason => Reason, stacktrace => Stacktrace
             },
-            telemetry:execute([erldns, request, error], #{count => 1}, MetaData)
+            telemetry:execute([erldns, request, error], #{count => 1}, ExceptionMetadata)
     end.
 
 -spec handle_decoded(inet:socket(), pid(), integer(), dns:message(), dynamic()) -> dynamic().
@@ -126,7 +130,7 @@ measure_time(Response, EncodedResponse, TS0) ->
     },
     telemetry:execute([erldns, request, stop], Measurements, Metadata).
 
--spec init_timer(integer(), pid()) -> any().
+-spec init_timer(integer(), pid()) -> term().
 init_timer(IngressTimeoutMs, Parent) ->
     Ref = erlang:monitor(process, Parent),
     receive

--- a/src/listeners/erldns_proto_udp_acceptor.erl
+++ b/src/listeners/erldns_proto_udp_acceptor.erl
@@ -13,7 +13,8 @@
     name :: atom(),
     socket :: gen_udp:socket()
 }).
--type state() :: #udp_acceptor{}.
+-opaque state() :: #udp_acceptor{}.
+-export_type([state/0]).
 
 -spec start_link(erldns_listeners:name(), [gen_udp:option()]) -> gen_server:start_ret().
 start_link(Name, SocketOpts) ->

--- a/src/listeners/erldns_sch_mon.erl
+++ b/src/listeners/erldns_sch_mon.erl
@@ -69,7 +69,7 @@ handle_info(Info, State) ->
     ?LOG_INFO(#{what => unexpected_info, info => Info}, #{domain => [erldns, listeners]}),
     {noreply, State}.
 
--spec terminate(term(), state()) -> any().
+-spec terminate(term(), state()) -> term().
 terminate(_, _) ->
     persistent_term:erase(?MODULE).
 

--- a/src/pipes/erldns_packet_cache.erl
+++ b/src/pipes/erldns_packet_cache.erl
@@ -60,7 +60,7 @@ call(Msg, _) ->
     Msg.
 
 -doc false.
--spec start_link() -> any().
+-spec start_link() -> ignore | gen_server:start_ret().
 start_link() ->
     case enabled() of
         false ->
@@ -76,7 +76,7 @@ start_link() ->
     end.
 
 -doc "Clear the cache".
--spec clear() -> any().
+-spec clear() -> true.
 clear() ->
     segmented_cache:delete_pattern(?MODULE, '_').
 

--- a/src/pipes/erldns_pipeline_worker.erl
+++ b/src/pipes/erldns_pipeline_worker.erl
@@ -26,6 +26,6 @@ handle_call(_, _, nostate) ->
 handle_cast(_, nostate) ->
     {noreply, nostate}.
 
--spec terminate(term(), nostate) -> any().
+-spec terminate(term(), nostate) -> term().
 terminate(_, nostate) ->
     persistent_term:erase(erldns_pipeline).

--- a/src/pipes/erldns_query_throttle.erl
+++ b/src/pipes/erldns_query_throttle.erl
@@ -63,7 +63,7 @@ call(Msg, _) ->
     Msg.
 
 -doc false.
--spec start_link() -> any().
+-spec start_link() -> ignore | gen_server:start_ret().
 start_link() ->
     case enabled() of
         false ->
@@ -107,7 +107,7 @@ should_throttle(Host, Limit) ->
     end.
 
 -doc "Clear the cache".
--spec clear() -> any().
+-spec clear() -> true.
 clear() ->
     segmented_cache:delete_pattern(?MODULE, '_').
 

--- a/src/zones/erldns_zone_codec.erl
+++ b/src/zones/erldns_zone_codec.erl
@@ -56,6 +56,8 @@ encode(_) ->
 -include_lib("kernel/include/logger.hrl").
 -include_lib("erldns/include/erldns.hrl").
 
+-define(TIMEOUT, 5000).
+
 -export([
     build_zone/4,
     encode/1,
@@ -123,7 +125,7 @@ register_codecs(Modules) when is_list(Modules) ->
         #{what => registering_custom_parsers, parsers => Modules},
         #{domain => [erldns, zones]}
     ),
-    gen_server:call(?MODULE, {register_codecs, Modules}, 5000).
+    gen_server:call(?MODULE, {register_codecs, Modules}, ?TIMEOUT).
 
 -doc "Get the list of registered zone parsers.".
 -spec list_codecs() -> {[encoder()], [decoder()]}.

--- a/src/zones/erldns_zone_codec.erl
+++ b/src/zones/erldns_zone_codec.erl
@@ -79,6 +79,7 @@ encode(_) ->
     decoders :: [decoder()]
 }).
 -type state() :: #state{}.
+-export_type([state/0]).
 
 -spec build_zone(dns:dname(), binary(), [dns:rr()], [erldns:keyset()]) -> erldns:zone().
 build_zone(Name, Version, Records, Keys) ->
@@ -122,7 +123,7 @@ register_codecs(Modules) when is_list(Modules) ->
         #{what => registering_custom_parsers, parsers => Modules},
         #{domain => [erldns, zones]}
     ),
-    gen_server:call(?MODULE, {register_codecs, Modules}).
+    gen_server:call(?MODULE, {register_codecs, Modules}, 5000).
 
 -doc "Get the list of registered zone parsers.".
 -spec list_codecs() -> {[encoder()], [decoder()]}.
@@ -163,7 +164,7 @@ handle_cast(Cast, State) ->
     {noreply, State}.
 
 -doc false.
--spec terminate(term(), state()) -> any().
+-spec terminate(term(), state()) -> term().
 terminate(_, _) ->
     persistent_term:erase(?MODULE).
 

--- a/src/zones/erldns_zone_encoder.erl
+++ b/src/zones/erldns_zone_encoder.erl
@@ -188,13 +188,23 @@ encode_data(#dns_rrdata_naptr{
             Order, Preference, Flags, Services, Regexp, Replacements
         ])
     );
-encode_data(#dns_rrdata_ds{keytag = KeyTag, alg = Alg, digest_type = DigType, digest = Digest}) ->
+encode_data(#dns_rrdata_ds{
+    keytag = KeyTag,
+    alg = Alg,
+    digest_type = DigestType,
+    digest = Digest
+}) ->
     escape_chars(
-        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigType, Digest])
+        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigestType, Digest])
     );
-encode_data(#dns_rrdata_cds{keytag = KeyTag, alg = Alg, digest_type = DigType, digest = Digest}) ->
+encode_data(#dns_rrdata_cds{
+    keytag = KeyTag,
+    alg = Alg,
+    digest_type = DigestType,
+    digest = Digest
+}) ->
     escape_chars(
-        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigType, Digest])
+        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigestType, Digest])
     );
 encode_data(#dns_rrdata_dnskey{
     flags = Flags, protocol = Protocol, alg = Alg, public_key = Key, keytag = KeyTag

--- a/src/zones/erldns_zone_encoder.erl
+++ b/src/zones/erldns_zone_encoder.erl
@@ -115,7 +115,10 @@ encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_CDNSKEY, ttl = Ttl, d
 encode_record(#dns_rr{name = Name, type = Type = ?DNS_TYPE_RRSIG, ttl = Ttl, data = Data}) ->
     encode_record(Name, Type, Ttl, Data);
 encode_record(Record) ->
-    ?LOG_WARNING(#{what => unable_to_encode_record, record => Record}, #{domain => [erldns, zones]}),
+    ?LOG_WARNING(
+        #{what => unable_to_encode_record, record => Record},
+        #{domain => [erldns, zones]}
+    ),
     not_implemented.
 
 encode_record(Name, Type, Ttl, Data) ->
@@ -185,13 +188,13 @@ encode_data(#dns_rrdata_naptr{
             Order, Preference, Flags, Services, Regexp, Replacements
         ])
     );
-encode_data(#dns_rrdata_ds{keytag = KeyTag, alg = Alg, digest_type = DigestType, digest = Digest}) ->
+encode_data(#dns_rrdata_ds{keytag = KeyTag, alg = Alg, digest_type = DigType, digest = Digest}) ->
     escape_chars(
-        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigestType, Digest])
+        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigType, Digest])
     );
-encode_data(#dns_rrdata_cds{keytag = KeyTag, alg = Alg, digest_type = DigestType, digest = Digest}) ->
+encode_data(#dns_rrdata_cds{keytag = KeyTag, alg = Alg, digest_type = DigType, digest = Digest}) ->
     escape_chars(
-        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigestType, Digest])
+        io_lib:format("~w ~w ~w ~s", [KeyTag, Alg, DigType, Digest])
     );
 encode_data(#dns_rrdata_dnskey{
     flags = Flags, protocol = Protocol, alg = Alg, public_key = Key, keytag = KeyTag

--- a/src/zones/erldns_zone_loader.erl
+++ b/src/zones/erldns_zone_loader.erl
@@ -17,6 +17,7 @@ See the type `t:erldns_zones:config/0` for details.
 -include_lib("kernel/include/logger.hrl").
 
 -define(WILDCARD, "**/*.json").
+-define(TIMEOUT, timer:minutes(30)).
 
 -behaviour(gen_server).
 -export([load_zones/0, load_zones/1]).
@@ -104,6 +105,8 @@ if_any_died(Ref, Pids, LoaderMons, ReaderMon, ParserMon) ->
         {'DOWN', _LoaderMon, process, _, Reason} when normal =/= Reason ->
             [exit(Pid, kill) || Pid <- Pids],
             {error, Reason}
+    after ?TIMEOUT ->
+        ok
     end.
 
 count_zones(Ref, Count) ->
@@ -132,6 +135,8 @@ zone_reader(Ref, ParentPid, ParserPid, Strict) ->
         {Ref, ParentPid, stop} ->
             ParserPid ! {Ref, ParentPid, stop},
             ok
+    after ?TIMEOUT ->
+        ok
     end.
 
 zone_parser(Ref, ParentPid, LoaderPids, Strict) ->
@@ -156,6 +161,8 @@ zone_parser(Ref, ParentPid, LoaderPids, Strict) ->
         {Ref, ParentPid, stop} ->
             [LoaderPid ! {Ref, ParentPid, stop} || LoaderPid <- LoaderPids],
             ok
+    after ?TIMEOUT ->
+        ok
     end.
 
 zone_loader(Ref, ParentPid) ->
@@ -166,6 +173,8 @@ zone_loader(Ref, ParentPid) ->
             zone_loader(Ref, ParentPid);
         {Ref, ParentPid, stop} ->
             ok
+    after ?TIMEOUT ->
+        ok
     end.
 
 load_zone(JsonZone) ->

--- a/src/zones/erldns_zone_parser.erl
+++ b/src/zones/erldns_zone_parser.erl
@@ -108,7 +108,7 @@ apply_context_list_check(ContextAllow, Context) ->
     ContextAllowSet = sets:from_list(ContextAllow, [{version, 2}]),
     0 =/= sets:size(sets:intersection(ContextAllowSet, ContextSet)).
 
--spec apply_context_match_empty_check(true | dynamic(), [any()]) -> boolean().
+-spec apply_context_match_empty_check(true | dynamic(), [dynamic()]) -> boolean().
 apply_context_match_empty_check(true, []) ->
     true;
 apply_context_match_empty_check(_, _) ->
@@ -253,7 +253,12 @@ json_record_to_erlang(#{~"name" := Name, ~"type" := ~"PTR", ~"ttl" := Ttl, ~"dat
         data = #dns_rrdata_ptr{dname = maps:get(~"dname", Data)},
         ttl = Ttl
     };
-json_record_to_erlang(#{~"name" := Name, ~"type" := Type = ~"SSHFP", ~"ttl" := Ttl, ~"data" := Data}) ->
+json_record_to_erlang(#{
+    ~"name" := Name,
+    ~"type" := Type = ~"SSHFP",
+    ~"ttl" := Ttl,
+    ~"data" := Data
+}) ->
     %% This function call may crash. Handle it as a bad record.
     try binary:decode_hex(maps:get(~"fp", Data)) of
         Fp ->
@@ -311,7 +316,12 @@ json_record_to_erlang(#{~"name" := Name, ~"type" := ~"NAPTR", ~"ttl" := Ttl, ~"d
             },
         ttl = Ttl
     };
-json_record_to_erlang(#{~"name" := Name, ~"type" := Type = ~"DS", ~"ttl" := Ttl, ~"data" := Data}) ->
+json_record_to_erlang(#{
+    ~"name" := Name,
+    ~"type" := Type = ~"DS",
+    ~"ttl" := Ttl,
+    ~"data" := Data
+}) ->
     try binary:decode_hex(maps:get(~"digest", Data)) of
         Digest ->
             #dns_rr{
@@ -341,7 +351,12 @@ json_record_to_erlang(#{~"name" := Name, ~"type" := Type = ~"DS", ~"ttl" := Ttl,
             ),
             not_implemented
     end;
-json_record_to_erlang(#{~"name" := Name, ~"type" := Type = ~"CDS", ~"ttl" := Ttl, ~"data" := Data}) ->
+json_record_to_erlang(#{
+    ~"name" := Name,
+    ~"type" := Type = ~"CDS",
+    ~"ttl" := Ttl,
+    ~"data" := Data
+}) ->
     try binary:decode_hex(maps:get(~"digest", Data)) of
         Digest ->
             #dns_rr{

--- a/src/zones/erldns_zones.erl
+++ b/src/zones/erldns_zones.erl
@@ -40,7 +40,8 @@ Codecs are a list of modules that implement the `m:erldns_zone_codec` behaviour.
     strict => boolean(),
     codecs => [module()]
 }.
--export_type([config/0]).
+-type version() :: binary().
+-export_type([config/0, version/0]).
 
 -behaviour(supervisor).
 


### PR DESCRIPTION
Note that the directory was not wildcard matching children dirs and therefore there were many modules that were not being linted.

Fixes for the ignored errors will come with later PRs.