### PR TITLE
Create question pipeline filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- Add `erldns_questions` questions filter to the packet pipeline.
 - Update dns_erlang v4.2 and remove `erldns_records:name_type/1`.
 
 ## v7.0.0

--- a/erldns.example.config
+++ b/erldns.example.config
@@ -4,6 +4,7 @@
             #{name => inet_1, port => 8053}
         ]},
         {packet_pipeline, [
+            erldns_questions,
             erldns_query_throttle,
             erldns_packet_cache,
             erldns_resolver,

--- a/src/listeners/erldns_proto_tcp.erl
+++ b/src/listeners/erldns_proto_tcp.erl
@@ -104,7 +104,8 @@ handle_decoded(_, _, _, #dns_message{qr = true}, _) ->
     {error, not_a_question};
 handle_decoded(Socket, TimerPid, TS0, DecodedMessage, IpAddr) ->
     forward_dp_to_timer(DecodedMessage, TimerPid),
-    Response = erldns_pipeline:call(DecodedMessage, #{transport => tcp, host => IpAddr}),
+    InitOpts = #{monotonic_time => TS0, transport => tcp, host => IpAddr},
+    Response = erldns_pipeline:call(DecodedMessage, InitOpts),
     EncodedResponse = erldns_encoder:encode_message(Response),
     exit(TimerPid, kill),
     ok = gen_tcp:send(Socket, [<<(byte_size(EncodedResponse)):16>>, EncodedResponse]),

--- a/src/listeners/erldns_proto_udp.erl
+++ b/src/listeners/erldns_proto_udp.erl
@@ -102,7 +102,8 @@ handle_decoded(_, _, _, #dns_message{qr = true}, _) ->
     {error, not_a_question};
 handle_decoded(Socket, IpAddr, Port, DecodedMessage0, TS0) ->
     DecodedMessage = normalize_edns_max_payload_size(DecodedMessage0),
-    Response = erldns_pipeline:call(DecodedMessage, #{transport => udp, host => IpAddr}),
+    InitOpts = #{monotonic_time => TS0, transport => udp, host => IpAddr},
+    Response = erldns_pipeline:call(DecodedMessage, InitOpts),
     Result = erldns_encoder:encode_message(Response, #{}),
     EncodedResponse =
         case Result of

--- a/src/pipes/erldns_pipeline.erl
+++ b/src/pipes/erldns_pipeline.erl
@@ -15,6 +15,7 @@ be injected as a new pipe handler in the right order.
 
 The following are enabled by default, see their documentation for details:
 
+- `m:erldns_questions`
 - `m:erldns_query_throttle`
 - `m:erldns_packet_cache`
 - `m:erldns_resolver`
@@ -49,6 +50,7 @@ The API expected by a module pipe is defined as a behaviour by this module.
 ```erlang
 {erldns, [
     {packet_pipeline, [
+        erldns_questions,
         erldns_query_throttle,
         erldns_packet_cache,
         erldns_resolver,
@@ -93,6 +95,9 @@ call(Msg, _Opts) ->
 -type transport() :: tcp | udp.
 -doc "Options that can be passed and accumulated to the pipeline.".
 -type opts() :: #{
+    query_labels := dns:labels(),
+    query_type := dns:type(),
+    monotonic_time := integer(),
     resolved := boolean(),
     transport := transport(),
     host := host(),
@@ -139,6 +144,7 @@ This callback can return
 -endif.
 
 -define(DEFAULT_PACKET_PIPELINE, [
+    erldns_questions,
     erldns_query_throttle,
     erldns_packet_cache,
     erldns_resolver,
@@ -265,4 +271,11 @@ prepare_pipe(Fun, _) when is_function(Fun) ->
     erlang:error({badpipe, {function_pipe_has_wrong_arity, Fun}}).
 
 def_opts() ->
-    #{resolved => false, transport => udp, host => undefined}.
+    #{
+        query_labels => [],
+        query_type => ?DNS_TYPE_A,
+        monotonic_time => 0,
+        resolved => false,
+        transport => udp,
+        host => undefined
+    }.

--- a/src/pipes/erldns_questions.erl
+++ b/src/pipes/erldns_questions.erl
@@ -1,0 +1,32 @@
+-module(erldns_questions).
+-moduledoc """
+Remove all redundant questions from a DNS message,
+and parses the first question into a list of labels.
+
+## Telemetry events
+
+- `[erldns, pipeline, questions]` with `#{count => non_neg_integer()}`
+where `count` is the number of questions removed.
+""".
+
+-include_lib("dns_erlang/include/dns.hrl").
+
+-behaviour(erldns_pipeline).
+
+-export([call/2]).
+
+-doc "`c:erldns_pipeline:call/2` callback.".
+-spec call(dns:message(), erldns_pipeline:opts()) -> erldns_pipeline:return().
+call(#dns_message{questions = []} = Msg, _) ->
+    {stop, Msg#dns_message{qr = true}};
+call(#dns_message{questions = [#dns_query{} = Q1]} = Msg, Opts) ->
+    Labels = dns:dname_to_lower_labels(Q1#dns_query.name),
+    {Msg, Opts#{query_labels := Labels, query_type := Q1#dns_query.type}};
+call(#dns_message{questions = [#dns_query{} = Q1, Q2 | Rest]} = Msg, #{host := Host} = Opts) ->
+    Labels = dns:dname_to_lower_labels(Q1#dns_query.name),
+    Measurements = #{count => 1 + length(Rest)},
+    Metadata = #{host => Host, questions => [Q1, Q2 | Rest]},
+    telemetry:execute([erldns, pipeline, questions], Measurements, Metadata),
+    Msg1 = Msg#dns_message{qc = 1, questions = [Q1]},
+    Opts1 = Opts#{query_labels := Labels, query_type := Q1#dns_query.type},
+    {Msg1, Opts1}.


### PR DESCRIPTION
This will ensure that there's only one question at a given time. If a message has no question, it will return immediately; if it has more than one, it will discard all the tail questions and raise and event as a warning.