### PR TITLE
Split erldns_resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main
 
 - Rework `erldns_handler`: behaviour is now improved and clearly defined.
+- Split `erldns_resolver` pipe into more granular steps, adding `erldns_resolver_recursive`,
+`erldns_dnssec`, `erldns_sorter`, and `erldns_section_counter`.
 - Add `erldns_questions` questions filter to the packet pipeline.
 - Update dns_erlang v4.2 and remove `erldns_records:name_type/1`.
 

--- a/erldns.example.config
+++ b/erldns.example.config
@@ -7,7 +7,11 @@
             erldns_questions,
             erldns_query_throttle,
             erldns_packet_cache,
+            erldns_resolver_recursive,
             erldns_resolver,
+            erldns_dnssec,
+            erldns_sorter,
+            erldns_section_counter,
             erldns_packet_cache,
             erldns_empty_verification
         ]},

--- a/rebar.config
+++ b/rebar.config
@@ -103,10 +103,13 @@
     {groups_for_modules, [
         {<<"Packet pipeline">>, [
             erldns_pipeline,
+            erldns_questions,
             erldns_query_throttle,
             erldns_packet_cache,
+            erldns_resolver_recursive,
             erldns_resolver,
-            erldns_packet_cache,
+            erldns_sorter,
+            erldns_section_counter,
             erldns_axfr,
             erldns_empty_verification
         ]},

--- a/src/pipes/erldns_dnssec.erl
+++ b/src/pipes/erldns_dnssec.erl
@@ -5,20 +5,35 @@ DNSSEC implementation.
 
 -include_lib("dns_erlang/include/dns.hrl").
 -include_lib("kernel/include/logger.hrl").
--include("erldns.hrl").
+-include_lib("erldns/include/erldns.hrl").
 
--export([handle/4]).
--export([
-    get_signed_records/1,
-    get_signed_zone_records/1
-]).
+-behaviour(erldns_pipeline).
+
+-export([prepare/1, call/2]).
+-export([get_signed_records/1, get_signed_zone_records/1]).
 -export([maybe_sign_rrset/3, rrsig_for_zone_rrset/2]).
 
 -ifdef(TEST).
--export([requires_key_signing_key/1, choose_signer_for_rrset/2]).
+-export([handle/4, requires_key_signing_key/1, choose_signer_for_rrset/2]).
 -endif.
 
 -define(NEXT_DNAME_PART, <<"\000">>).
+
+-doc "`c:erldns_pipeline:prepare/1` callback.".
+-spec prepare(erldns_pipeline:opts()) -> erldns_pipeline:opts().
+prepare(Opts) ->
+    Opts#{dnssec => false}.
+
+-doc "`c:erldns_pipeline:call/2` callback.".
+-spec call(dns:message(), erldns_pipeline:opts()) -> erldns_pipeline:return().
+call(
+    #dns_message{questions = [#dns_query{name = Qname, type = QType}]} = Msg,
+    #{resolved := true, auth_zone := #zone{} = Zone} = Opts
+) ->
+    RequestDnssec = proplists:get_bool(dnssec, erldns_edns:get_opts(Msg)),
+    {handle(Msg, Zone, Qname, QType), Opts#{dnssec => RequestDnssec}};
+call(Msg, _) ->
+    Msg.
 
 -doc "Get signed records from a zone".
 -spec get_signed_records(erldns:zone()) -> #{atom() => [dns:rr()]}.
@@ -106,12 +121,12 @@ This function will potentially sign the given RR set if the following conditions
 -spec maybe_sign_rrset(dns:message(), [dns:rr()], erldns:zone()) -> [dns:rr()].
 maybe_sign_rrset(Message, Records, Zone) ->
     case {proplists:get_bool(dnssec, erldns_edns:get_opts(Message)), Zone#zone.keysets} of
+        {true, [_ | _]} ->
+            % DNSSEC requested, zone signed
+            Records ++ rrsig_for_zone_rrset(Zone, Records);
         {true, []} ->
             % DNSSEC requested, zone not signed
             Records;
-        {true, _} ->
-            % DNSSEC requested, zone signed
-            Records ++ rrsig_for_zone_rrset(Zone, Records);
         {false, _} ->
             % DNSSEC not requested
             Records
@@ -221,7 +236,7 @@ sign_unsigned(Message, Zone) ->
 find_unsigned_records(Records) ->
     lists:filter(
         fun(RR) ->
-            (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) and
+            (RR#dns_rr.type =/= ?DNS_TYPE_RRSIG) andalso
                 (lists:filter(
                     erldns_records:match_name_and_type(RR#dns_rr.name, ?DNS_TYPE_RRSIG), Records
                 ) =:= [])

--- a/src/pipes/erldns_pipeline.erl
+++ b/src/pipes/erldns_pipeline.erl
@@ -18,7 +18,11 @@ The following are enabled by default, see their documentation for details:
 - `m:erldns_questions`
 - `m:erldns_query_throttle`
 - `m:erldns_packet_cache`
+- `m:erldns_resolver_recursive`
 - `m:erldns_resolver`
+- `m:erldns_dnssec`
+- `m:erldns_sorter`
+- `m:erldns_section_counter`
 - `m:erldns_empty_verification`
 
 ## Types of pipelines
@@ -53,7 +57,11 @@ The API expected by a module pipe is defined as a behaviour by this module.
         erldns_questions,
         erldns_query_throttle,
         erldns_packet_cache,
+        erldns_resolver_recursive,
         erldns_resolver,
+        erldns_dnssec,
+        erldns_sorter,
+        erldns_section_counter,
         erldns_packet_cache,
         erldns_empty_verification
     ]},
@@ -147,7 +155,11 @@ This callback can return
     erldns_questions,
     erldns_query_throttle,
     erldns_packet_cache,
+    erldns_resolver_recursive,
     erldns_resolver,
+    erldns_dnssec,
+    erldns_sorter,
+    erldns_section_counter,
     erldns_packet_cache,
     erldns_empty_verification
 ]).

--- a/src/pipes/erldns_resolver.erl
+++ b/src/pipes/erldns_resolver.erl
@@ -99,7 +99,6 @@ resolve(Message, AuthorityRecords, Host) ->
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
     resolve_qname_and_qtype(
         Message#dns_message{
-            ra = false,
             ad = false,
             cd = false
         },

--- a/src/pipes/erldns_resolver.erl
+++ b/src/pipes/erldns_resolver.erl
@@ -22,14 +22,22 @@ Emits the following telemetry events:
 
 -behaviour(erldns_pipeline).
 
--export([call/2]).
+-export([prepare/1, call/2]).
+
+-doc "`c:erldns_pipeline:prepare/1` callback.".
+-spec prepare(erldns_pipeline:opts()) -> erldns_pipeline:opts().
+prepare(Opts) ->
+    Opts#{auth_zone => zone_not_found}.
 
 -doc "`c:erldns_pipeline:call/2` callback.".
 -spec call(dns:message(), erldns_pipeline:opts()) -> erldns_pipeline:return().
-call(Msg, #{resolved := false} = Opts) ->
+call(#dns_message{questions = [#dns_query{name = Qname}]} = Msg, #{resolved := false} = Opts) ->
     case erldns_zone_cache:get_authority(Msg) of
         {ok, Authority} ->
-            complete_response(call(Msg, Opts, Authority));
+            Zone = erldns_zone_cache:find_zone(Qname, Authority),
+            Msg1 = complete_response(call(Msg, Opts, Authority)),
+            Opts1 = Opts#{resolved := true, auth_zone := Zone},
+            {Msg1, Opts1};
         {error, _} ->
             complete_response(Msg#dns_message{aa = false, rc = ?DNS_RCODE_REFUSED})
     end;
@@ -64,9 +72,6 @@ call(Msg, #{host := Host}, AuthorityRecords) ->
 
 complete_response(Message) ->
     Message#dns_message{
-        anc = length(Message#dns_message.answers),
-        auc = length(Message#dns_message.authority),
-        adc = length(Message#dns_message.additional),
         qr = true
     }.
 
@@ -92,28 +97,17 @@ resolve(Message, AuthorityRecords, Host) ->
 ) ->
     dns:message().
 resolve_question(Message, AuthorityRecords, Host, Question) when is_record(Question, dns_query) ->
-    case Question#dns_query.type of
-        ?DNS_TYPE_RRSIG ->
-            % Refuse all RRSIG requests.
-            Message#dns_message{
-                ra = false,
-                ad = false,
-                cd = false,
-                rc = ?DNS_RCODE_REFUSED
-            };
-        Qtype ->
-            resolve_qname_and_qtype(
-                Message#dns_message{
-                    ra = false,
-                    ad = false,
-                    cd = false
-                },
-                AuthorityRecords,
-                Question#dns_query.name,
-                Qtype,
-                Host
-            )
-    end.
+    resolve_qname_and_qtype(
+        Message#dns_message{
+            ra = false,
+            ad = false,
+            cd = false
+        },
+        AuthorityRecords,
+        Question#dns_query.name,
+        Question#dns_query.type,
+        Host
+    ).
 
 %% With the extracted Qname and Qtype in hand, find the nearest zone
 %% Step 2: Search the available zones for the zone which is the nearest ancestor to QNAME
@@ -132,9 +126,7 @@ resolve_qname_and_qtype(Message, AuthorityRecords, Qname, Qtype, Host) ->
             Zone = erldns_zone_cache:find_zone(Qname, AuthorityRecords),
             Message1 = resolve_authoritative(Message, Qname, Qtype, Zone, Host, []),
             Message2 = erldns_records:rewrite_soa_ttl(Message1),
-            Message3 = additional_processing(Message2, Host, Zone),
-            Message4 = erldns_dnssec:handle(Message3, Zone, Qname, Qtype),
-            sort_answers(Message4)
+            additional_processing(Message2, Host, Zone)
     end.
 
 %% An SOA was found, thus we are authoritative and have the zone.
@@ -239,10 +231,9 @@ resolve_exact_match(Message, Qname, Qtype, Host, CnameChain, MatchedRecords, Zon
             [] ->
                 % No records matched the qtype, call custom handler
                 QLabels = dns:dname_to_labels(Qname),
-                HandlerRecords = erldns_handler:call_handlers(
+                erldns_handler:call_handlers(
                     Message, QLabels, Qtype, MatchedRecords
-                ),
-                erldns_dnssec:maybe_sign_rrset(Message, HandlerRecords, Zone);
+                );
             _ ->
                 % Records match qtype, use them
                 TypeMatches
@@ -578,8 +569,7 @@ resolve_best_match_with_wildcard(
             HandlerRecords = erldns_handler:call_handlers(
                 Message, QLabels, Qtype, MatchedRecords
             ),
-            Records = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
-            NewRecords = erldns_dnssec:maybe_sign_rrset(Message, Records, Zone),
+            NewRecords = lists:map(erldns_records:replace_name(Qname), HandlerRecords),
             case NewRecords of
                 [] ->
                     % Custom handlers returned no answers, so set the authority section of the response and return NOERROR
@@ -846,27 +836,6 @@ requires_additional_processing([_ | Rest], Acc) ->
     requires_additional_processing(Rest, Acc);
 requires_additional_processing([], Acc) ->
     lists:reverse(Acc).
-
-%% Sort the answers in the given message.
--spec sort_answers(dns:message()) -> dns:message().
-sort_answers(Message) ->
-    Message#dns_message{answers = lists:usort(fun sort_fun/2, Message#dns_message.answers)}.
-
--spec sort_fun(dns:rr(), dns:rr()) -> boolean().
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}, #dns_rr{
-    type = ?DNS_TYPE_CNAME, name = Name
-}) ->
-    true;
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME, name = Name}, #dns_rr{
-    type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}
-}) ->
-    false;
-sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME}, #dns_rr{}) ->
-    true;
-sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
-    false;
-sort_fun(A, B) ->
-    A =< B.
 
 % Extract the name from the first record in the list.
 zone_authority_name([Record | _]) ->

--- a/src/pipes/erldns_resolver_recursive.erl
+++ b/src/pipes/erldns_resolver_recursive.erl
@@ -1,0 +1,19 @@
+-module(erldns_resolver_recursive).
+-moduledoc """
+DNS recursion.
+
+Stub module, as `erldns` does not implement recursion (yet),
+this module simply sets the recursion bit as false.
+""".
+
+-include_lib("dns_erlang/include/dns.hrl").
+
+-behaviour(erldns_pipeline).
+
+-export([call/2]).
+
+%% Set the RA bit to false as we do not handle recursive queries.
+-doc "`c:erldns_pipeline:call/2` callback.".
+-spec call(dns:message(), erldns_pipeline:opts()) -> erldns_pipeline:return().
+call(#dns_message{} = Msg, _) ->
+    Msg#dns_message{ra = false}.

--- a/src/pipes/erldns_section_counter.erl
+++ b/src/pipes/erldns_section_counter.erl
@@ -1,0 +1,21 @@
+-module(erldns_section_counter).
+-moduledoc """
+Counts the sections and updates the respective header fields at once.
+
+Should be ran after all resolvers are ran.
+""".
+
+-include_lib("dns_erlang/include/dns.hrl").
+
+-behaviour(erldns_pipeline).
+
+-export([call/2]).
+
+-doc "`c:erldns_pipeline:call/2` callback.".
+-spec call(dns:message(), erldns_pipeline:opts()) -> dns:message().
+call(#dns_message{} = Msg, _) ->
+    Msg#dns_message{
+        anc = length(Msg#dns_message.answers),
+        auc = length(Msg#dns_message.authority),
+        adc = length(Msg#dns_message.additional)
+    }.

--- a/src/pipes/erldns_sorter.erl
+++ b/src/pipes/erldns_sorter.erl
@@ -1,0 +1,37 @@
+-module(erldns_sorter).
+-moduledoc """
+Sorts the answers, ensuring that CNAME RRs are ordered first.
+
+Should be ran after all resolvers are ran.
+""".
+
+-include_lib("dns_erlang/include/dns.hrl").
+
+-behaviour(erldns_pipeline).
+
+-export([call/2]).
+
+-doc "`c:erldns_pipeline:call/2` callback.".
+-spec call(dns:message(), erldns_pipeline:opts()) -> dns:message().
+call(#dns_message{answers = []} = Msg, _) ->
+    Msg;
+call(#dns_message{answers = Answers} = Msg, _) ->
+    Msg#dns_message{answers = lists:usort(fun sort_fun/2, Answers)}.
+
+-spec sort_fun(dns:rr(), dns:rr()) -> boolean().
+sort_fun(
+    #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}},
+    #dns_rr{type = ?DNS_TYPE_CNAME, name = Name}
+) ->
+    true;
+sort_fun(
+    #dns_rr{type = ?DNS_TYPE_CNAME, name = Name},
+    #dns_rr{type = ?DNS_TYPE_CNAME, data = #dns_rrdata_cname{dname = Name}}
+) ->
+    false;
+sort_fun(#dns_rr{type = ?DNS_TYPE_CNAME}, #dns_rr{}) ->
+    true;
+sort_fun(#dns_rr{}, #dns_rr{type = ?DNS_TYPE_CNAME}) ->
+    false;
+sort_fun(A, B) ->
+    A =< B.

--- a/test/dnstest_SUITE.erl
+++ b/test/dnstest_SUITE.erl
@@ -90,5 +90,6 @@ assert(_Definitions, Results) ->
 failing() ->
     [
         nsec_nxname_ent,
+        direct_rrsig,
         ns_zonecut_child_cname
     ].


### PR DESCRIPTION
Split dnssec, sorter, and recursion flags, from erldns_resolver.

Also move RRSIG records from being refused to being throttled.