### PR TITLE
Fix bug with SOA records not updating correctly

### DIFF
--- a/src/zones/erldns_zone_cache.erl
+++ b/src/zones/erldns_zone_cache.erl
@@ -505,7 +505,11 @@ delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
 update_zone_records_and_digest(ZLabels, RecordsCount, Digest) ->
     case find_zone_in_cache(ZLabels) of
         #zone{} = Zone ->
-            UpdatedZone = Zone#zone{version = Digest, record_count = RecordsCount},
+            UpdatedZone = Zone#zone{
+                version = Digest,
+                authority = get_records_by_name_and_type(Zone, ZLabels, ?DNS_TYPE_SOA),
+                record_count = RecordsCount
+            },
             true = insert_zone(UpdatedZone),
             ok;
         zone_not_found ->


### PR DESCRIPTION
Closes https://github.com/dnsimple/erldnsimple/issues/548.

Note that the SOA record is stored twice: once in the zones table (the `authority` section of the `#zone{}` record), and another one as a standalone RRSet in the typed records table. And then the resolution algorithm would use the RRSet in the typed records table as the answer for an explicit query to SOA records but the cached ones on the zone record for any other query that required including SOA records. This would be an issue for DNSSEC, because for example an NSEC answer would include the RRSIG record of the _new_ SOA record, but with the _old_ SOA record, hence triggering a validation failure.

Note that this code [was available in v7](https://github.com/dnsimple/erldns/blob/0d1a717458fc6554c1a1765a5f1d2a381245f3ef/src/zones/erldns_zone_cache.erl#L440), and it was lost just very unfortunately. The PR comes with a regression test :)