### PR TITLE
Do not put empty RRSIG record values in the cache

### DIFF
--- a/src/zones/erldns_zone_cache.erl
+++ b/src/zones/erldns_zone_cache.erl
@@ -462,9 +462,18 @@ delete_zone_rrset(ZoneName, Digest, RRFqdn, Type, Counter) ->
                             erldns_records:match_type_covered(Type),
                             get_records_by_name_and_type(Zone, RecordLabels, ?DNS_TYPE_RRSIG)
                         ),
-                    do_put_zone_records_typed_entry(
-                        ZoneLabels, ReducedLabels, ?DNS_TYPE_RRSIG, RRSigsNotCovering
-                    ),
+                    % Don't put an empty RRSIG in the cache
+                    case RRSigsNotCovering of
+                        [] ->
+                            % nothing left - delete the RRSIG record
+                            pattern_zone_dname_type_delete(
+                                ZoneLabels, ReducedLabels, ?DNS_TYPE_RRSIG
+                            );
+                        _ ->
+                            do_put_zone_records_typed_entry(
+                                ZoneLabels, ReducedLabels, ?DNS_TYPE_RRSIG, RRSigsNotCovering
+                            )
+                    end,
                     % only write counter if called explicitly with Counter value i.e.
                     % different than 0. this will not write the counter if called by
                     % put_zone_rrset/3 as it will prevent subsequent delete ops


### PR DESCRIPTION
When deleting records, an empty list could be a value for an RRSIG record that would be put in the cache. This could happen even if the zone had no DNSSEC enabled. The current implementation would create and insert an empty RRSIG record even if there wasn't one before. I believe the correct implementation just discards the RRSIG record instead of inserting a new one with an empty value.

Because of how the "getters" from ETS worked (for example [pattern_zone_dname/2](https://github.com/dnsimple/erldns/blob/899b0fdbcc0be5edef14c037a227cfa706e6f2b2/src/zones/erldns_zone_cache.erl#L753-L755)) by appending the resulting record list, this empty RRSIG record would not appear usually. However, it would get counted as an existing record, which could lead to bugs. Specifically for the ENT rework to be RFC compliant we sometimes would like to check if any records exist at a specific place - with the `[]` as the value for RRSET it would actually get counted.